### PR TITLE
update error-chain to 0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ quick-xml = "0.4.2"
 log = "0.3.6"
 encoding = "0.2.33"
 byteorder = "0.5.3"
-error-chain = "0.7"
+error-chain = "0.7.2"
 
 [dev-dependencies]
 glob = "0.2.11"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ quick-xml = "0.4.2"
 log = "0.3.6"
 encoding = "0.2.33"
 byteorder = "0.5.3"
-error-chain = "0.6.2"
+error-chain = "0.7"
 
 [dev-dependencies]
 glob = "0.2.11"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,5 +1,5 @@
 //! `ExcelError` management module
-//! 
+//!
 //! Provides all excel error conversion and description
 //! Also provides `Result` as a alias of `Result<_, ExcelError>
 
@@ -8,9 +8,9 @@
 use quick_xml::error::Error as XmlError;
 
 error_chain! {
-    types {
-        Error, ErrorKind, Result;
-    }
+//    types {
+//        Error, ErrorKind, ResultExt, Result;
+//    }
 
 //     links {
 //         rustup_dist::Error, rustup_dist::ErrorKind, Dist;
@@ -18,13 +18,13 @@ error_chain! {
 //     }
 
     foreign_links {
-        ::std::io::Error, Io;
-        ::zip::result::ZipError, Zip;
-        XmlError, Xml;
-        ::std::num::ParseIntError, ParseInt;
-        ::std::num::ParseFloatError, ParseFloat;
-        ::std::str::Utf8Error, Utf8;
-        ::std::string::FromUtf8Error, FromUtf8;
+        Io(::std::io::Error);
+        Zip(::zip::result::ZipError);
+        Xml(XmlError);
+        ParseInt(::std::num::ParseIntError);
+        ParseFloat(::std::num::ParseFloatError);
+        Utf8(::std::str::Utf8Error);
+        FromUtf8(::std::string::FromUtf8Error);
     }
 
 //     errors {
@@ -36,5 +36,7 @@ error_chain! {
 }
 
 impl From<(XmlError, usize)> for Error {
-    fn from(err: (XmlError, usize)) -> Error { err.0.into() }
+    fn from(err: (XmlError, usize)) -> Error {
+        err.0.into()
+    }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -8,15 +8,6 @@
 use quick_xml::error::Error as XmlError;
 
 error_chain! {
-//    types {
-//        Error, ErrorKind, ResultExt, Result;
-//    }
-
-//     links {
-//         rustup_dist::Error, rustup_dist::ErrorKind, Dist;
-//         rustup_utils::Error, rustup_utils::ErrorKind, Utils;
-//     }
-
     foreign_links {
         Io(::std::io::Error);
         Zip(::zip::result::ZipError);
@@ -26,13 +17,6 @@ error_chain! {
         Utf8(::std::str::Utf8Error);
         FromUtf8(::std::string::FromUtf8Error);
     }
-
-//     errors {
-//         InvalidToolchainName(t: String) {
-//             description("invalid toolchain name")
-//             display("invalid toolchain name: '{}'", t)
-//         }
-//     }
 }
 
 impl From<(XmlError, usize)> for Error {


### PR DESCRIPTION
Changes the error_chain! invocation to the new style used in error-chain 0.7, and bumps the dependency version