### PR TITLE
Add worksheet_range_by_index function

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calamine"
-version = "0.3.3"
+version = "0.4.0"
 authors = ["Johann Tuffe <tafia973@gmail.com>"]
 repository = "https://github.com/tafia/calamine"
 documentation = "https://docs.rs/calamine"

--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,12 @@
 
 ## master
 
+## 0.4.0
+- refactor: replace `try!` with `?` operator
+- feat: adds a new `worksheet_range_by_index` function.
+- feat: adds new `ErrorKind`s
+- refactor: simplify `search_error` example by using a `run()` function
+
 ## 0.3.3
 - refactor: update dependencies (error-chain and byteorder)
 

--- a/examples/excel_to_csv.rs
+++ b/examples/excel_to_csv.rs
@@ -33,19 +33,19 @@ fn write_range<W: Write>(dest: &mut W, range: Range) -> Result<()> {
     let n = range.get_size().1 - 1;
     for r in range.rows() {
         for (i, c) in r.iter().enumerate() {
-            let _ = try!(match *c {
+            let _ = match *c {
                 DataType::Empty => Ok(()),
                 DataType::String(ref s) => write!(dest, "{}", s),
                 DataType::Float(ref f) => write!(dest, "{}", f),
                 DataType::Int(ref i) => write!(dest, "{}", i),
                 DataType::Error(ref e) => write!(dest, "{:?}", e),
                 DataType::Bool(ref b) => write!(dest, "{}", b),
-            });
+            }?;
             if i != n {
-                let _ = try!(write!(dest, ";"));
+                let _ = write!(dest, ";")?;
             }
         }
-        let _ = try!(write!(dest, "\r\n"));
+        let _ = write!(dest, "\r\n")?;
     }
     Ok(())
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -17,6 +17,26 @@ error_chain! {
         Utf8(::std::str::Utf8Error);
         FromUtf8(::std::string::FromUtf8Error);
     }
+
+    errors {
+        InvalidExtension(ext: String) {
+            description("invalid extension")
+            display("invalid extension: '{}'", ext)
+        }
+        CellOutOfRange(try_pos: (u32, u32), min_pos: (u32, u32)) {
+            description("no cell found at this position")
+            display("there is no cell at position '{:?}'. Minimum position is '{:?}'",
+                    try_pos, min_pos)
+        }
+        WorksheetName(name: String) {
+            description("invalid worksheet name")
+            display("invalid worksheet name: '{}'", name)
+        }
+        WorksheetIndex(idx: usize) {
+            description("invalid worksheet index")
+            display("invalid worksheet index: {}", idx)
+        }
+    }
 }
 
 impl From<(XmlError, usize)> for Error {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,11 +173,11 @@ impl Excel {
     /// assert!(Excel::open(path).is_ok());
     /// ```
     pub fn open<P: AsRef<Path>>(path: P) -> Result<Excel> {
-        let f = try!(File::open(&path));
+        let f = File::open(&path)?;
         let file = match path.as_ref().extension().and_then(|s| s.to_str()) {
-            Some("xls") | Some("xla") => FileType::Xls(try!(xls::Xls::new(f))),
-            Some("xlsx") | Some("xlsm") | Some("xlam") => FileType::Xlsx(try!(xlsx::Xlsx::new(f))),
-            Some("xlsb") => FileType::Xlsb(try!(xlsb::Xlsb::new(f))),
+            Some("xls") | Some("xla") => FileType::Xls(xls::Xls::new(f)?),
+            Some("xlsx") | Some("xlsm") | Some("xlam") => FileType::Xlsx(xlsx::Xlsx::new(f)?),
+            Some("xlsb") => FileType::Xlsb(xlsb::Xlsb::new(f)?),
             Some(e) => return Err(format!("unrecognized extension: {:?}", e).into()),
             None => return Err("expecting a file with an extension".into()),
         };
@@ -202,17 +202,17 @@ impl Excel {
     /// ```
     pub fn worksheet_range(&mut self, name: &str) -> Result<Range> {
         if self.strings.is_empty() {
-            let strings = try!(inner!(self, read_shared_strings()));
+            let strings = inner!(self, read_shared_strings())?;
             self.strings = strings;
         }
 
         if self.relationships.is_empty() {
-            let rels = try!(inner!(self, read_relationships()));
+            let rels = inner!(self, read_relationships())?;
             self.relationships = rels;
         }
 
         if self.sheets.is_empty() {
-            let sheets = try!(inner!(self, read_sheets_names(&self.relationships)));
+            let sheets = inner!(self, read_sheets_names(&self.relationships))?;
             self.sheets = sheets;
         }
 
@@ -258,12 +258,12 @@ impl Excel {
     pub fn sheet_names(&mut self) -> Result<Vec<String>> {
 
         if self.relationships.is_empty() {
-            let rels = try!(inner!(self, read_relationships()));
+            let rels = inner!(self, read_relationships())?;
             self.relationships = rels;
         }
 
         if self.sheets.is_empty() {
-            let sheets = try!(inner!(self, read_sheets_names(&self.relationships)));
+            let sheets = inner!(self, read_sheets_names(&self.relationships))?;
             self.sheets = sheets;
         }
 

--- a/src/xls.rs
+++ b/src/xls.rs
@@ -52,7 +52,7 @@ impl ExcelReader for Xls {
 
     /// Parses Workbook stream, no need for the relationships variable
     fn read_sheets_names(&mut self, _: &HashMap<Vec<u8>, String>) 
-        -> Result<HashMap<String, String>>
+        -> Result<Vec<(String, String)>>
     {
         let _ = try!(self.parse_workbook());
         match self.sheets {

--- a/src/xls.rs
+++ b/src/xls.rs
@@ -25,13 +25,13 @@ impl ExcelReader for Xls {
 
     fn new(r: File) -> Result<Self> {
 
-        let len = try!(r.metadata()).len() as usize;
+        let len = r.metadata()?.len() as usize;
         let mut r = BufReader::new(r);
-        let mut cfb = try!(Cfb::new(&mut r, len ));
+        let mut cfb = Cfb::new(&mut r, len )?;
 
         // Reads vba once for all (better than reading all worksheets once for all)
         let vba = if cfb.has_directory("_VBA_PROJECT_CUR") {
-            Some(try!(VbaProject::from_cfb(&mut r, &mut cfb)))
+            Some(VbaProject::from_cfb(&mut r, &mut cfb)?)
         } else {
             None
         };
@@ -54,7 +54,7 @@ impl ExcelReader for Xls {
     fn read_sheets_names(&mut self, _: &HashMap<Vec<u8>, String>) 
         -> Result<Vec<(String, String)>>
     {
-        let _ = try!(self.parse_workbook());
+        let _ = self.parse_workbook()?;
         match self.sheets {
             SheetsState::NotParsed(_, _) => unreachable!(),
             SheetsState::Parsed(ref shs) => Ok(shs.keys().map(|k| (k.to_string(), k.to_string())).collect())
@@ -70,7 +70,7 @@ impl ExcelReader for Xls {
     }
 
     fn read_worksheet_range(&mut self, name: &str, _: &[String]) -> Result<Range> {
-        let _ = try!(self.parse_workbook());
+        let _ = self.parse_workbook()?;
         match self.sheets {
             SheetsState::NotParsed(_, _) => unreachable!(),
             SheetsState::Parsed(ref shs) => shs.get(name)
@@ -86,8 +86,8 @@ impl Xls {
         // gets workbook and worksheets stream, or early exit
         let stream = match self.sheets {
             SheetsState::NotParsed(ref mut reader, ref mut cfb) => {
-                try!(cfb.get_stream("Workbook", reader)
-                     .or_else(|_| cfb.get_stream("Book", reader)))
+                cfb.get_stream("Workbook", reader)
+                     .or_else(|_| cfb.get_stream("Book", reader))?
             },
             SheetsState::Parsed(_) => return Ok(()),
         };
@@ -96,10 +96,10 @@ impl Xls {
         let mut strings = Vec::new();
         {
             let mut wb = &stream;
-            let mut encoding = try!(XlsEncoding::from_codepage(1200));
+            let mut encoding = XlsEncoding::from_codepage(1200)?;
             let records = RecordIter { stream: &mut wb };
             for record in records {
-                let mut r = try!(record);
+                let mut r = record?;
                 match r.typ {
                     0x0009 => if read_u16(&r.data[2..]) != 0x0005 {
                         return Err("Expecting Workbook BOF".into());
@@ -107,13 +107,13 @@ impl Xls {
                     0x0012 => if read_u16(r.data) != 0 {
                         return Err("Workbook is password protected".into());
                     },
-                    0x0042 => encoding = try!(XlsEncoding::from_codepage(read_u16(r.data))), // CodePage
+                    0x0042 => encoding = XlsEncoding::from_codepage(read_u16(r.data))?, // CodePage
                     0x013D => {
                         let sheet_len = r.data.len() / 2;
                         sheet_names.reserve(sheet_len);
                     }, // RRTabId
-                    0x0085 => sheet_names.push(try!(parse_sheet_name(&mut r, &mut encoding))), // BoundSheet8
-                    0x00FC => strings = try!(parse_sst(&mut r, &mut encoding)), // SST
+                    0x0085 => sheet_names.push(parse_sheet_name(&mut r, &mut encoding)?), // BoundSheet8
+                    0x00FC => strings = parse_sst(&mut r, &mut encoding)?, // SST
                     0x000A => break, // EOF,
                     _ => (),
                 }
@@ -126,17 +126,17 @@ impl Xls {
             let records = RecordIter { stream: &mut sh };
             let mut cells = Vec::new();
             for record in records {
-                let r = try!(record);
+                let r = record?;
                 match r.typ {
                     0x0009 => if read_u16(&r.data[2..]) != 0x0010 { continue 'sh; }, // BOF, worksheet
                     0x0200 => {
-                        let (start, end) = try!(parse_dimensions(&r.data));
+                        let (start, end) = parse_dimensions(&r.data)?;
                         cells.reserve(((end.0 - start.0 + 1) * (end.1 - start.1 + 1)) as usize);
                     }, // Dimensions
-                    0x0203 => cells.push(try!(parse_number(&r.data))), // Number 
-                    0x0205 => cells.push(try!(parse_bool_err(&r.data))), // BoolErr
-                    0x027E => cells.push(try!(parse_rk(&r.data))), // RK
-                    0x00FD => cells.push(try!(parse_label_sst(&r.data, &strings))), // LabelSst
+                    0x0203 => cells.push(parse_number(&r.data)?), // Number 
+                    0x0205 => cells.push(parse_bool_err(&r.data)?), // BoolErr
+                    0x027E => cells.push(parse_rk(&r.data)?), // RK
+                    0x00FD => cells.push(parse_label_sst(&r.data, &strings)?), // LabelSst
                     0x000A => break, // EOF,
                     _ => (),
                 }
@@ -154,7 +154,7 @@ impl Xls {
 fn parse_sheet_name(r: &mut Record, encoding: &mut XlsEncoding) -> Result<(usize, String)> {
     let pos = read_u32(r.data) as usize;
     r.data = &r.data[6..];
-    let sheet = try!(parse_short_string(r, encoding));
+    let sheet = parse_short_string(r, encoding)?;
     Ok((pos, sheet))
 }
 
@@ -260,7 +260,7 @@ fn parse_sst(r: &mut Record, encoding: &mut XlsEncoding) -> Result<Vec<String>> 
     let mut sst = Vec::with_capacity(len);
     r.data = &r.data[8..];
     for _ in 0..len {
-        sst.push(try!(read_rich_extended_string(r, encoding)));
+        sst.push(read_rich_extended_string(r, encoding)?);
     }
     Ok(sst)
 }
@@ -292,7 +292,7 @@ fn read_rich_extended_string(r: &mut Record, encoding: &mut XlsEncoding) -> Resu
         r.data = &r.data[4..];
     };
 
-    let s = try!(read_dbcs(encoding, str_len, r));
+    let s = read_dbcs(encoding, str_len, r)?;
 
     while unused_len > 0 {
         if r.data.is_empty() && !r.continue_record() {
@@ -311,7 +311,7 @@ fn read_dbcs<'a>(encoding: &mut XlsEncoding, mut len: usize, r: &mut Record) -> 
 {
     let mut s = String::with_capacity(len);
     while len > 0 {
-        let (l, at) = try!(encoding.decode_to(r.data, len, &mut s));
+        let (l, at) = encoding.decode_to(r.data, len, &mut s)?;
         r.data = &r.data[at..];
         len -= l;
         if len > 0 {

--- a/src/xlsb.rs
+++ b/src/xlsb.rs
@@ -103,7 +103,7 @@ impl ExcelReader for Xlsb {
 
     /// MS-XLSB 2.1.7.61
     fn read_sheets_names(&mut self, relationships: &HashMap<Vec<u8>, String>) 
-        -> Result<HashMap<String, String>>
+        -> Result<Vec<(String, String)>>
     {
         let mut iter = try!(self.iter("xl/workbook.bin"));
         let mut buf = vec![0; 1024];
@@ -118,7 +118,7 @@ impl ExcelReader for Xlsb {
                                           (0x02A5, Some(0x0216)), // Book protection(iso)
                                           (0x0087, Some(0x0088)), // BOOKVIEWS
                                           ], &mut buf)); 
-        let mut sheets = HashMap::new();
+        let mut sheets = Vec::new();
         loop {
             match try!(iter.read_type()) {
                 0x0090 => return Ok(sheets), // BrtEndBundleShs
@@ -134,7 +134,7 @@ impl ExcelReader for Xlsb {
                 let relid = try!(UTF_16LE.decode(relid, DecoderTrap::Ignore).map_err(|e| e.to_string()));
                 let path = format!("xl/{}", relationships[relid.as_bytes()]);
                 let name = try!(wide_str(&buf[12 + rel_len..len]));
-                sheets.insert(name, path);
+                sheets.push((name, path));
             }
         }
     }

--- a/src/xlsx.rs
+++ b/src/xlsx.rs
@@ -83,13 +83,13 @@ impl ExcelReader for Xlsx {
     }
 
     fn read_sheets_names(&mut self, relationships: &HashMap<Vec<u8>, String>) 
-        -> Result<HashMap<String, String>>
+        -> Result<Vec<(String, String)>>
     {
         let xml = match self.xml_reader("xl/workbook.xml") {
-            None => return Ok(HashMap::new()),
+            None => return Ok(Vec::new()),
             Some(x) => try!(x),
         };
-        let mut sheets = HashMap::new();
+        let mut sheets = Vec::new();
         for res_event in xml {
             match res_event {
                 Ok(Event::Start(ref e)) if e.name() == b"sheet" => {
@@ -102,7 +102,7 @@ impl ExcelReader for Xlsx {
                             _ => (),
                         }
                     }
-                    sheets.insert(name, path);
+                    sheets.push((name, path));
                 }
                 Err(e) => return Err(e.into()),
                 _ => (),

--- a/src/xlsx.rs
+++ b/src/xlsx.rs
@@ -33,7 +33,7 @@ impl Xlsx {
 impl ExcelReader for Xlsx {
 
     fn new(f: File) -> Result<Self> {
-        Ok(Xlsx { zip: try!(ZipArchive::new(f)) })
+        Ok(Xlsx { zip: ZipArchive::new(f)? })
     }
 
     fn has_vba(&mut self) -> bool {
@@ -41,7 +41,7 @@ impl ExcelReader for Xlsx {
     }
 
     fn vba_project(&mut self) -> Result<Cow<VbaProject>> {
-        let mut f = try!(self.zip.by_name("xl/vbaProject.bin"));
+        let mut f = self.zip.by_name("xl/vbaProject.bin")?;
         let len = f.size() as usize;
         VbaProject::new(&mut f, len).map(|v| Cow::Owned(v))
     }
@@ -49,7 +49,7 @@ impl ExcelReader for Xlsx {
     fn read_shared_strings(&mut self) -> Result<Vec<String>> {
         let mut xml = match self.xml_reader("xl/sharedStrings.xml") {
             None => return Ok(Vec::new()),
-            Some(x) => try!(x),
+            Some(x) => x?,
         };
         let mut strings = Vec::new();
         let mut rich_buffer: Option<String> = None;
@@ -68,7 +68,7 @@ impl ExcelReader for Xlsx {
                     }
                 },
                 Ok(Event::Start(ref e)) if e.name() == b"t" => {
-                    let value = try!(xml.read_text_unescaped(b"t"));
+                    let value = xml.read_text_unescaped(b"t")?;
                     if let Some(ref mut s) = rich_buffer {
                         s.push_str(&value);
                     } else {
@@ -87,7 +87,7 @@ impl ExcelReader for Xlsx {
     {
         let xml = match self.xml_reader("xl/workbook.xml") {
             None => return Ok(Vec::new()),
-            Some(x) => try!(x),
+            Some(x) => x?,
         };
         let mut sheets = Vec::new();
         for res_event in xml {
@@ -96,8 +96,8 @@ impl ExcelReader for Xlsx {
                     let mut name = String::new();
                     let mut path = String::new();
                     for a in e.unescaped_attributes() {
-                        match try!(a) {
-                            (b"name", v) => name = try!(v.as_str()).to_string(),
+                        match a? {
+                            (b"name", v) => name = v.as_str()?.to_string(),
                             (b"r:id", v) => path = format!("xl/{}", relationships[&*v]),
                             _ => (),
                         }
@@ -114,7 +114,7 @@ impl ExcelReader for Xlsx {
     fn read_relationships(&mut self) -> Result<HashMap<Vec<u8>, String>> {
         let xml = match self.xml_reader("xl/_rels/workbook.xml.rels") {
             None => return Err("Cannot find relationships file".into()),
-            Some(x) => try!(x),
+            Some(x) => x?,
         };
         let mut relationships = HashMap::new();
         for res_event in xml {
@@ -123,9 +123,9 @@ impl ExcelReader for Xlsx {
                     let mut id = Vec::new();
                     let mut target = String::new();
                     for a in e.attributes() {
-                        match try!(a) {
+                        match a? {
                             (b"Id", v) => id.extend_from_slice(v),
-                            (b"Target", v) => target = try!(v.as_str()).to_string(),
+                            (b"Target", v) => target = v.as_str()?.to_string(),
                             _ => (),
                         }
                     }
@@ -141,7 +141,7 @@ impl ExcelReader for Xlsx {
     fn read_worksheet_range(&mut self, path: &str, strings: &[String]) -> Result<Range> {
         let mut xml = match self.xml_reader(path) {
             None => return Err(format!("Cannot find {} path", path).into()),
-            Some(x) => try!(x),
+            Some(x) => x?,
         };
         let mut cells = Vec::new();
         'xml: while let Some(res_event) = xml.next() {
@@ -151,8 +151,8 @@ impl ExcelReader for Xlsx {
                     match e.name() {
                         b"dimension" => {
                             for a in e.attributes() {
-                                if let (b"ref", rdim) = try!(a) {
-                                    let (start, end) = try!(get_dimension(rdim));
+                                if let (b"ref", rdim) = a? {
+                                    let (start, end) = get_dimension(rdim)?;
                                     cells.reserve(((end.0 - start.0 + 1) 
                                                    * (end.1 - start.1 + 1)) as usize);
                                     continue 'xml;
@@ -160,7 +160,7 @@ impl ExcelReader for Xlsx {
                             }
                             return Err(format!("Expecting dimension, got {:?}", e).into());
                         },
-                        b"sheetData" => try!(read_sheet_data(&mut xml, strings, &mut cells)),
+                        b"sheetData" => read_sheet_data(&mut xml, strings, &mut cells)?,
                         _ => (),
                     }
                 },
@@ -183,7 +183,7 @@ fn read_sheet_data(xml: &mut XmlReader<BufReader<ZipFile>>,
                     Ok((b"r", v)) => Some(get_row_column(v)),
                     _ => None,
                 }).next() {
-                    Some(v) => try!(v),
+                    Some(v) => v?,
                     None => return Err("Cell without a 'r' reference tag".into()),
                 };
                 loop {
@@ -192,13 +192,13 @@ fn read_sheet_data(xml: &mut XmlReader<BufReader<ZipFile>>,
                         Some(Ok(Event::Start(ref e))) => match e.name() {
                             b"v" => {
                                 // value
-                                let v = try!(xml.read_text_unescaped(b"v"));
+                                let v = xml.read_text_unescaped(b"v")?;
                                 let value = match c_element.attributes()
                                     .filter_map(|a| a.ok())
                                     .find(|&(k, _)| k == b"t") {
                                         Some((_, b"s")) => {
                                             // shared string
-                                            let idx: usize = try!(v.parse());
+                                            let idx: usize = v.parse()?;
                                             DataType::String(strings[idx].clone())
                                         },
                                         Some((_, b"str")) => {
@@ -211,9 +211,9 @@ fn read_sheet_data(xml: &mut XmlReader<BufReader<ZipFile>>,
                                         },
                                         Some((_, b"e")) => {
                                             // error
-                                            DataType::Error(try!(v.parse()))
+                                            DataType::Error(v.parse()?)
                                         },
-                                        _ => try!(v.parse().map(DataType::Float)),
+                                        _ => v.parse().map(DataType::Float)?,
                                     };
                                 cells.push(Cell::new(pos, value));
                                 break;
@@ -238,9 +238,9 @@ fn read_sheet_data(xml: &mut XmlReader<BufReader<ZipFile>>,
 /// - top left (row, column), 
 /// - bottom right (row, column)
 fn get_dimension(dimension: &[u8]) -> Result<((u32, u32), (u32, u32))> {
-    let parts: Vec<_> = try!(dimension.split(|c| *c == b':')
+    let parts: Vec<_> = dimension.split(|c| *c == b':')
         .map(|s| get_row_column(s))
-        .collect::<Result<Vec<_>>>());
+        .collect::<Result<Vec<_>>>()?;
 
     match parts.len() {
         0 => Err("dimension cannot be empty".into()),


### PR DESCRIPTION
Closes #64 and refactor some parts.

- adds a new `worksheet_range_by_index` function.
- replaces `try!` with `?` operator
- adds new `ErrorKind`s
- simplify `search_error` example by using a `run()` function

@dbkup, it is not perfect but it provides a index function.

Implementing `Index` is actually not very suited (IMO) because we return an owned struct (`Range`) and not a reference.