### PR TITLE
inlineStr implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ quick-xml = "0.4.2"
 log = "0.3.6"
 encoding = "0.2.33"
 byteorder = "1.0.0"
-error-chain = "0.7.2"
+error-chain = "0.8.1"
 
 [dev-dependencies]
 glob = "0.2.11"

--- a/examples/excel_to_csv.rs
+++ b/examples/excel_to_csv.rs
@@ -10,9 +10,13 @@ fn main() {
     // converts first argument into a csv (same name, silently overrides
     // if the file already exists
 
-    let file = env::args().skip(1).next()
+    let file = env::args()
+        .skip(1)
+        .next()
         .expect("Please provide an excel file to convert");
-    let sheet = env::args().skip(2).next()
+    let sheet = env::args()
+        .skip(2)
+        .next()
         .expect("Expecting a sheet name as second argument");
 
     let sce = PathBuf::from(file);

--- a/examples/search_errors.rs
+++ b/examples/search_errors.rs
@@ -20,30 +20,34 @@ enum FileStatus {
 }
 
 fn main() {
-    
+
     // Search recursively for all excel files matching argument pattern
     // Output statistics: nb broken references, nb broken cells etc...
     let folder = env::args().skip(1).next().unwrap_or(".".to_string());
     let pattern = format!("{}/**/*.xl*", folder);
     let mut filecount = 0;
 
-    let mut output = pattern.chars().take_while(|c| *c != '*').filter_map(|c| {
-        match c {
+    let mut output = pattern.chars()
+        .take_while(|c| *c != '*')
+        .filter_map(|c| match c {
             ':' => None,
             '/' | '\\' | ' ' => Some('_'),
             c => Some(c),
-        }
-    }).collect::<String>();
+        })
+        .collect::<String>();
     output.push_str("_errors.csv");
     let mut output = BufWriter::new(File::create(output).unwrap());
 
-    for f in glob(&pattern).expect("Failed to read excel glob, the first \
-                                    argument must correspond to a directory") {
+    for f in glob(&pattern)
+        .expect("Failed to read excel glob, the first argument must correspond to a directory") {
         filecount += 1;
         let _ = match run(f) {
-            Ok((f, missing, cell_errors)) => writeln!(output, "{:?}~{:?}~{}", f, missing, cell_errors),
-            Err(e) => writeln!(output, "{:?}", e),
-        }.unwrap_or_else(|e| println!("{:?}", e));
+                Ok((f, missing, cell_errors)) => {
+                    writeln!(output, "{:?}~{:?}~{}", f, missing, cell_errors)
+                }
+                Err(e) => writeln!(output, "{:?}", e),
+            }
+            .unwrap_or_else(|e| println!("{:?}", e));
     }
 
     println!("Found {} excel files", filecount);
@@ -65,14 +69,23 @@ fn run(f: GlobResult) -> Result<(PathBuf, Option<usize>, usize), FileStatus> {
     }
 
     // get owned sheet names
-    let sheets = xl.sheet_names().map_err(FileStatus::ExcelError)?
-        .into_iter().map(|s| s.to_string()).collect::<Vec<_>>();
+    let sheets = xl.sheet_names()
+        .map_err(FileStatus::ExcelError)?
+        .into_iter()
+        .map(|s| s.to_string())
+        .collect::<Vec<_>>();
 
     for s in sheets {
         let range = xl.worksheet_range(&s).map_err(FileStatus::RangeError)?;
-        cell_errors += range.rows().flat_map(|r| r.iter().filter(|c| {
-            if let &&DataType::Error(_) = c { true } else { false }
-        })).count();
+        cell_errors += range.rows()
+            .flat_map(|r| {
+                r.iter().filter(|c| if let &&DataType::Error(_) = c {
+                    true
+                } else {
+                    false
+                })
+            })
+            .count();
     }
 
     Ok((f, missing, cell_errors))

--- a/src/xlsx.rs
+++ b/src/xlsx.rs
@@ -104,14 +104,13 @@ impl ExcelReader for Xlsx {
                                 let r = &relationships[&*v][..];
                                 // target may have pre-prended "/xl/" or "xl/" path;
                                 // strip if present
-                                let r = if r.starts_with("/xl/") {
-                                    &r[4..]
+                                path = if r.starts_with("/xl/") {
+                                    r[1..].to_string()
                                 } else if r.starts_with("xl/") {
-                                    &r[3..]
+                                    r.to_string()
                                 } else {
-                                    r
+                                    format!("xl/{}", r)
                                 };
-                                path = format!("xl/{}", r);
                             }
                             _ => (),
                         }

--- a/src/xlsx.rs
+++ b/src/xlsx.rs
@@ -18,12 +18,15 @@ pub struct Xlsx {
 }
 
 impl Xlsx {
-    fn xml_reader<'a>(&'a mut self, path: &str) 
-        -> Option<Result<XmlReader<BufReader<ZipFile<'a>>>>> 
-    {
+    fn xml_reader<'a>(&'a mut self,
+                      path: &str)
+                      -> Option<Result<XmlReader<BufReader<ZipFile<'a>>>>> {
         match self.zip.by_name(path) {
-            Ok(f) => Some(Ok(XmlReader::from_reader(BufReader::new(f))
-                             .with_check(false).trim_text(false))),
+            Ok(f) => {
+                Some(Ok(XmlReader::from_reader(BufReader::new(f))
+                    .with_check(false)
+                    .trim_text(false)))
+            }
             Err(ZipError::FileNotFound) => None,
             Err(e) => return Some(Err(e.into())),
         }
@@ -31,7 +34,6 @@ impl Xlsx {
 }
 
 impl ExcelReader for Xlsx {
-
     fn new(f: File) -> Result<Self> {
         Ok(Xlsx { zip: ZipArchive::new(f)? })
     }
@@ -60,13 +62,13 @@ impl ExcelReader for Xlsx {
                         // use a buffer since richtext has multiples <r> and <t> for the same cell
                         rich_buffer = Some(String::new());
                     }
-                },
+                }
                 Ok(Event::End(ref e)) if e.name() == b"si" => {
                     if let Some(s) = rich_buffer {
                         strings.push(s);
                         rich_buffer = None;
                     }
-                },
+                }
                 Ok(Event::Start(ref e)) if e.name() == b"t" => {
                     let value = xml.read_text_unescaped(b"t")?;
                     if let Some(ref mut s) = rich_buffer {
@@ -82,9 +84,9 @@ impl ExcelReader for Xlsx {
         Ok(strings)
     }
 
-    fn read_sheets_names(&mut self, relationships: &HashMap<Vec<u8>, String>) 
-        -> Result<Vec<(String, String)>>
-    {
+    fn read_sheets_names(&mut self,
+                         relationships: &HashMap<Vec<u8>, String>)
+                         -> Result<Vec<(String, String)>> {
         let xml = match self.xml_reader("xl/workbook.xml") {
             None => return Ok(Vec::new()),
             Some(x) => x?,
@@ -153,17 +155,17 @@ impl ExcelReader for Xlsx {
                             for a in e.attributes() {
                                 if let (b"ref", rdim) = a? {
                                     let (start, end) = get_dimension(rdim)?;
-                                    cells.reserve(((end.0 - start.0 + 1) 
-                                                   * (end.1 - start.1 + 1)) as usize);
+                                    cells.reserve(((end.0 - start.0 + 1) * (end.1 - start.1 + 1)) as
+                                                 usize);
                                     continue 'xml;
                                 }
                             }
                             return Err(format!("Expecting dimension, got {:?}", e).into());
-                        },
+                        }
                         b"sheetData" => read_sheet_data(&mut xml, strings, &mut cells)?,
                         _ => (),
                     }
-                },
+                }
                 _ => (),
             }
         }
@@ -172,61 +174,67 @@ impl ExcelReader for Xlsx {
 }
 
 /// read sheetData node
-fn read_sheet_data(xml: &mut XmlReader<BufReader<ZipFile>>, 
-                   strings: &[String], cells: &mut Vec<Cell>) -> Result<()> {
+fn read_sheet_data(xml: &mut XmlReader<BufReader<ZipFile>>,
+                   strings: &[String],
+                   cells: &mut Vec<Cell>)
+                   -> Result<()> {
     while let Some(res_event) = xml.next() {
         match res_event {
             Err(e) => return Err(e.into()),
             Ok(Event::Start(ref c_element)) if c_element.name() == b"c" => {
-                let pos = match c_element.attributes().filter_map(|a| match a {
-                    Err(e) => Some(Err(e.into())),
-                    Ok((b"r", v)) => Some(get_row_column(v)),
-                    _ => None,
-                }).next() {
+                let pos = match c_element.attributes()
+                    .filter_map(|a| match a {
+                        Err(e) => Some(Err(e.into())),
+                        Ok((b"r", v)) => Some(get_row_column(v)),
+                        _ => None,
+                    })
+                    .next() {
                     Some(v) => v?,
                     None => return Err("Cell without a 'r' reference tag".into()),
                 };
                 loop {
                     match xml.next() {
                         Some(Err(e)) => return Err(e.into()),
-                        Some(Ok(Event::Start(ref e))) => match e.name() {
-                            b"v" => {
-                                // value
-                                let v = xml.read_text_unescaped(b"v")?;
-                                let value = match c_element.attributes()
-                                    .filter_map(|a| a.ok())
-                                    .find(|&(k, _)| k == b"t") {
+                        Some(Ok(Event::Start(ref e))) => {
+                            match e.name() {
+                                b"v" => {
+                                    // value
+                                    let v = xml.read_text_unescaped(b"v")?;
+                                    let value = match c_element.attributes()
+                                        .filter_map(|a| a.ok())
+                                        .find(|&(k, _)| k == b"t") {
                                         Some((_, b"s")) => {
                                             // shared string
                                             let idx: usize = v.parse()?;
                                             DataType::String(strings[idx].clone())
-                                        },
+                                        }
                                         Some((_, b"str")) => {
                                             // regular string
                                             DataType::String(v)
-                                        },
+                                        }
                                         Some((_, b"b")) => {
                                             // boolean
                                             DataType::Bool(v != "0")
-                                        },
+                                        }
                                         Some((_, b"e")) => {
                                             // error
                                             DataType::Error(v.parse()?)
-                                        },
+                                        }
                                         _ => v.parse().map(DataType::Float)?,
                                     };
-                                cells.push(Cell::new(pos, value));
-                                break;
-                            },
-                            b"f" => (), // formula, ignore
-                            _name => return Err("not v or f node".into()),
-                        },
+                                    cells.push(Cell::new(pos, value));
+                                    break;
+                                }
+                                b"f" => (), // formula, ignore
+                                _name => return Err("not v or f node".into()),
+                            }
+                        }
                         Some(Ok(Event::End(ref e))) if e.name() == b"c" => break,
                         None => return Err("End of xml".into()),
                         _ => (),
                     }
                 }
-            },
+            }
             Ok(Event::End(ref e)) if e.name() == b"sheetData" => return Ok(()),
             _ => (),
         }
@@ -235,7 +243,7 @@ fn read_sheet_data(xml: &mut XmlReader<BufReader<ZipFile>>,
 }
 
 /// converts a text representation (e.g. "A6:G67") of a dimension into integers
-/// - top left (row, column), 
+/// - top left (row, column),
 /// - bottom right (row, column)
 fn get_dimension(dimension: &[u8]) -> Result<((u32, u32), (u32, u32))> {
     let parts: Vec<_> = dimension.split(|c| *c == b':')
@@ -263,25 +271,27 @@ fn get_row_column(range: &[u8]) -> Result<(u32, u32)> {
                     pow *= 10;
                 } else {
                     return Err(format!("Numeric character are only allowed \
-                        at the end of the range: {:x}", c).into());
+                        at the end of the range: {:x}",
+                                       c)
+                        .into());
                 }
             }
             c @ b'A'...b'Z' => {
-                if readrow { 
+                if readrow {
                     pow = 1;
                     readrow = false;
                 }
                 col += ((c - b'A') as u32 + 1) * pow;
                 pow *= 26;
-            },
+            }
             c @ b'a'...b'z' => {
-                if readrow { 
+                if readrow {
                     pow = 1;
                     readrow = false;
                 }
                 col += ((c - b'a') as u32 + 1) * pow;
                 pow *= 26;
-            },
+            }
             _ => return Err(format!("Expecting alphanumeric character, got {:x}", c).into()),
         }
     }

--- a/src/xlsx.rs
+++ b/src/xlsx.rs
@@ -301,7 +301,10 @@ fn read_sheet_data(xml: &mut XmlReader<BufReader<ZipFile>>,
                                     break;
                                 }
                                 b"f" => {} // ignore f nodes
-                                n => return Err(format!("not a v, f, or is node: {:?}", n).into()),
+                                n => {
+                                    return Err(format!("not a 'v', 'f', or 'is' node: {:?}", n)
+                                        .into())
+                                }
                             }
                         }
                         Some(Ok(Event::End(ref e))) if e.name() == b"c" => {

--- a/src/xlsx.rs
+++ b/src/xlsx.rs
@@ -193,6 +193,7 @@ fn read_sheet_data(xml: &mut XmlReader<BufReader<ZipFile>>,
     /// read the contents of an <is> cell
     fn read_inline_str(xml: &mut XmlReader<BufReader<ZipFile>>) -> Result<DataType> {
         while let Some(is_evt) = xml.next() {
+            debug!("is_evt: {:?}", is_evt);
             match is_evt {
                 Err(e) => return Err(e.into()),
                 Ok(Event::Start(ref t)) if t.name() == b"t" => {
@@ -278,6 +279,7 @@ fn read_sheet_data(xml: &mut XmlReader<BufReader<ZipFile>>,
         Ok(None)
     }
     while let Some(res_event) = xml.next() {
+        debug!("res_event: {:?}", res_event);
         match res_event {
             Err(e) => return Err(e.into()),
             Ok(Event::Start(ref c_element)) if c_element.name() == b"c" => {
@@ -289,6 +291,7 @@ fn read_sheet_data(xml: &mut XmlReader<BufReader<ZipFile>>,
                     match xml.next() {
                         Some(Err(e)) => return Err(e.into()),
                         Some(Ok(Event::Start(ref e))) => {
+                            debug!("e: {:?}", e);
                             match e.name() {
                                 b"is" => {
                                     cells.push(Cell::new(pos, read_inline_str(xml)?));
@@ -303,10 +306,11 @@ fn read_sheet_data(xml: &mut XmlReader<BufReader<ZipFile>>,
                             }
                         }
                         Some(Ok(Event::End(ref e))) if e.name() == b"c" => {
+                            debug!("</c>");
                             break;
                         }
                         None => return Err("End of xml".into()),
-                        _ => (),
+                        o => debug!("ignored Event: {:?}", o),
                     }
                 }
             }

--- a/src/xlsx.rs
+++ b/src/xlsx.rs
@@ -100,7 +100,19 @@ impl ExcelReader for Xlsx {
                     for a in e.unescaped_attributes() {
                         match a? {
                             (b"name", v) => name = v.as_str()?.to_string(),
-                            (b"r:id", v) => path = format!("xl/{}", relationships[&*v]),
+                            (b"r:id", v) => {
+                                let r = &relationships[&*v][..];
+                                // target may have pre-prended "/xl/" or "xl/" path;
+                                // strip if present
+                                let r = if r.starts_with("/xl/") {
+                                    &r[4..]
+                                } else if r.starts_with("xl/") {
+                                    &r[3..]
+                                } else {
+                                    r
+                                };
+                                path = format!("xl/{}", r);
+                            }
                             _ => (),
                         }
                     }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -21,9 +21,10 @@ fn issue_2() {
     let mut excel = Excel::open(&path).expect("cannot open excel file");
 
     let range = excel.worksheet_range("issue2").unwrap();
-    range_eq!(range, [[Float(1.), String("a".to_string())],
-                      [Float(2.), String("b".to_string())],
-                      [Float(3.), String("c".to_string())]]);
+    range_eq!(range,
+              [[Float(1.), String("a".to_string())],
+               [Float(2.), String("b".to_string())],
+               [Float(3.), String("c".to_string())]]);
 }
 
 #[test]
@@ -53,10 +54,8 @@ fn issue_6() {
     let mut excel = Excel::open(&path).expect("cannot open excel file");
 
     let range = excel.worksheet_range("issue6").unwrap();
-    range_eq!(range, [[Float(1.)], 
-                      [Float(2.)],
-                      [String("ab".to_string())], 
-                      [Bool(false)]]);
+    range_eq!(range,
+              [[Float(1.)], [Float(2.)], [String("ab".to_string())], [Bool(false)]]);
 }
 
 #[test]
@@ -65,13 +64,14 @@ fn error_file() {
     let mut excel = Excel::open(&path).expect("cannot open excel file");
 
     let range = excel.worksheet_range("Feuil1").unwrap();
-    range_eq!(range, [[Error(Div0)],
-                      [Error(Name)], 
-                      [Error(Value)], 
-                      [Error(Null)], 
-                      [Error(Ref)], 
-                      [Error(Num)], 
-                      [Error(NA)]]);
+    range_eq!(range,
+              [[Error(Div0)],
+               [Error(Name)],
+               [Error(Value)],
+               [Error(Null)],
+               [Error(Ref)],
+               [Error(Num)],
+               [Error(NA)]]);
 }
 
 #[test]
@@ -80,10 +80,11 @@ fn issue_9() {
     let mut excel = Excel::open(&path).expect("cannot open excel file");
 
     let range = excel.worksheet_range("Feuil1").unwrap();
-    range_eq!(range, [[String("test1".to_string())],
-                      [String("test2 other".to_string())],
-                      [String("test3 aaa".to_string())], 
-                      [String("test4".to_string())]]);
+    range_eq!(range,
+              [[String("test1".to_string())],
+               [String("test2 other".to_string())],
+               [String("test3 aaa".to_string())],
+               [String("test4".to_string())]]);
 }
 
 #[test]
@@ -92,11 +93,9 @@ fn vba() {
     let mut excel = Excel::open(&path).expect("cannot open excel file");
 
     let mut vba = excel.vba_project().unwrap();
-    assert_eq!(vba.to_mut().get_module("testVBA").unwrap(), "Attribute VB_Name = \"testVBA\"\
-    \r\nPublic Sub test()\
-    \r\n    MsgBox \"Hello from vba!\"\
-    \r\nEnd Sub\
-    \r\n");
+    assert_eq!(vba.to_mut().get_module("testVBA").unwrap(),
+               "Attribute VB_Name = \"testVBA\"\r\nPublic Sub test()\r\n    MsgBox \"Hello from \
+                vba!\"\r\nEnd Sub\r\n");
 }
 
 #[test]
@@ -105,9 +104,10 @@ fn xlsb() {
     let mut excel = Excel::open(&path).expect("cannot open excel file");
 
     let range = excel.worksheet_range("issue2").unwrap();
-    range_eq!(range, [[Float(1.), String("a".to_string())],
-                      [Float(2.), String("b".to_string())], 
-                      [Float(3.), String("c".to_string())]]);
+    range_eq!(range,
+              [[Float(1.), String("a".to_string())],
+               [Float(2.), String("b".to_string())],
+               [Float(3.), String("c".to_string())]]);
 }
 
 #[test]
@@ -116,9 +116,10 @@ fn xls() {
     let mut excel = Excel::open(&path).expect("cannot open excel file");
 
     let range = excel.worksheet_range("issue2").unwrap();
-    range_eq!(range, [[Float(1.), String("a".to_string())],
-                      [Float(2.), String("b".to_string())],
-                      [Float(3.), String("c".to_string())]]);
+    range_eq!(range,
+              [[Float(1.), String("a".to_string())],
+               [Float(2.), String("b".to_string())],
+               [Float(3.), String("c".to_string())]]);
 }
 
 #[test]
@@ -127,15 +128,15 @@ fn special_chrs_xlsx() {
     let mut excel = Excel::open(&path).expect("cannot open excel file");
 
     let range = excel.worksheet_range("spc_chrs").unwrap();
-    range_eq!(range, [[String("&".to_string())],
-                      [String("<".to_string())],
-                      [String(">".to_string())],
-                      [String("aaa ' aaa".to_string())],
-                      [String("\"".to_string())],
-                      [String("☺".to_string())],
-                      [String("֍".to_string())],
-                      [String("àâéêèçöïî«»".to_string())],
-                      ]);
+    range_eq!(range,
+              [[String("&".to_string())],
+               [String("<".to_string())],
+               [String(">".to_string())],
+               [String("aaa ' aaa".to_string())],
+               [String("\"".to_string())],
+               [String("☺".to_string())],
+               [String("֍".to_string())],
+               [String("àâéêèçöïî«»".to_string())]]);
 }
 
 #[test]
@@ -144,12 +145,13 @@ fn special_chrs_xlsb() {
     let mut excel = Excel::open(&path).expect("cannot open excel file");
 
     let range = excel.worksheet_range("spc_chrs").unwrap();
-    range_eq!(range, [[String("&".to_string())],
-                      [String("<".to_string())],
-                      [String(">".to_string())],
-                      [String("aaa ' aaa".to_string())],
-                      [String("\"".to_string())],
-                      [String("☺".to_string())],
-                      [String("֍".to_string())],
-                      [String("àâéêèçöïî«»".to_string())]]);
+    range_eq!(range,
+              [[String("&".to_string())],
+               [String("<".to_string())],
+               [String(">".to_string())],
+               [String("aaa ' aaa".to_string())],
+               [String("\"".to_string())],
+               [String("☺".to_string())],
+               [String("֍".to_string())],
+               [String("àâéêèçöïî«»".to_string())]]);
 }


### PR DESCRIPTION
This PR corrects behavior for xlsx parsing of inline string ("inlineStr") elements, which are encoded as ```<is>``` nodes per [this description](http://officeopenxml.com/SScontentOverview.php), instead of ```<v>``` nodes. Also, in some sheets I work with sheetname references already contain a "xl/" or "/xl/" prefix; a patch to handle this is also contained.

The PR also includes some unrelated commits:
* rustfmt formatting updates
* bump error-chain dependency to 0.8.1 (no code changes needed)
* added some debug!() statements