### PR TITLE
[RFC] let sheet_names return vector of String instead of &str

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -273,9 +273,9 @@ impl Excel {
     /// let mut workbook = Excel::open(path).unwrap();
     /// println!("Sheets: {:#?}", workbook.sheet_names());
     /// ```
-    pub fn sheet_names(&mut self) -> Result<Vec<&str>> {
+    pub fn sheet_names(&mut self) -> Result<Vec<String>> {
         self.initialize()?;
-        Ok(self.sheets.iter().map(|&(ref k, _)| &**k).collect())
+        Ok(self.sheets.iter().map(|&(ref k, _)| k.to_string()).collect())
     }
 }
 


### PR DESCRIPTION
*Note that this is a API-breaking change*

&str will have the same lifetime with &self. This will make it hard to
use in iterations like this:

```
let mut xl = Excel::open(&sce).unwrap();
for stn in xl.sheet_names().unwrap() {
	let range = xl.worksheet_range(stn).unwrap();
	write_range(&mut dest,  range).unwrap();
}
```

Making it return vector of String could fix this.

This is a attempt to fix #69 . However, I'm new to Rust so please review it hardly ;)