### PR TITLE
extend appveyor paths to use curl

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,7 @@ environment:
   - TARGET: x86_64-pc-windows-msvc
 
 install:
+  - set PATH=C:\Program Files\Git\mingw64\bin;%PATH%
   - curl -sSf -o rustup-init.exe https://win.rustup.rs/
   - rustup-init.exe -y --default-host %TARGET%
   - set PATH=%PATH%;C:\Users\appveyor\.cargo\bin


### PR DESCRIPTION
Fixes the error on appveyor where curl wasn't found.
See http://help.appveyor.com/discussions/problems/6312-curl-command-not-found
