### PR TITLE
Rename Excel into Sheets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "calamine"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Johann Tuffe <tafia973@gmail.com>"]
 repository = "https://github.com/tafia/calamine"
 documentation = "https://docs.rs/calamine"
-description = "Excel reader in pure rust"
+description = "Excel/OpenDocument Spreadsheets parser in pure rust"
 license = "MIT"
 readme = "README.md"
-keywords = ["excel", "xls", "vba", "xml", "office"]
+keywords = ["excel", "xls", "vba", "office", "ods"]
 categories = ["encoding", "parsing", "text-processing"]
 
 [badges]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.9.0"
 authors = ["Johann Tuffe <tafia973@gmail.com>"]
 repository = "https://github.com/tafia/calamine"
 documentation = "https://docs.rs/calamine"
-description = "Excel/OpenDocument Spreadsheets parser in pure rust"
+description = "An Excel/OpenDocument Spreadsheets parser in pure rust"
 license = "MIT"
 readme = "README.md"
 keywords = ["excel", "xls", "vba", "office", "ods"]
@@ -15,7 +15,7 @@ travis-ci = { repository = "tafia/calamine" }
 appveyor = { repository = "tafia/calamine" }
 
 [dependencies]
-zip = { version = "0.2.2", default-features = false }
+zip = { version = "0.2.3", default-features = false }
 quick-xml = "0.7.0"
 log = "0.3.7"
 encoding_rs = "0.5.0"

--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,7 @@
 
 ## 0.9.0
 - refactor: rename `Excel` in `Sheets` to accomodate OpenDocuments
+- feat: add Index/IndexMut for Range
 
 ## 0.8.0
 - feat: add basic support for opendocument spreadsheets

--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,9 @@
   - test: Adding missing tests
   - chore: Changes to the build process or auxiliary tools/libraries/documentation
 
+## 0.9.0
+- refactor: rename `Excel` in `Sheets` to accomodate OpenDocuments
+
 ## 0.8.0
 - feat: add basic support for opendocument spreadsheets
 - style: apply rustfmt

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # calamine
 
-A Excel/OpenDocument file reader, in pure Rust.
+A Excel/OpenDocument Spreadsheets file reader, in pure Rust.
 
 [![Build Status](https://travis-ci.org/tafia/calamine.svg?branch=master)](https://travis-ci.org/tafia/calamine)
 [![Build status](https://ci.appveyor.com/api/projects/status/njpnhq54h5hxsgel/branch/master?svg=true)](https://ci.appveyor.com/project/tafia/calamine/branch/master)
@@ -20,7 +20,7 @@ For anything else, please file an issue with a failing test or send a pull reque
 
 ### Simple
 ```rust
-let mut excel = Excel::open("file.xlsx").unwrap();
+let mut excel = Sheets::open("file.xlsx").unwrap();
 let r = excel.worksheet_range("Sheet1").unwrap();
 for row in r.rows() {
     println!("row={:?}, row[0]={:?}", row, row[0]);
@@ -30,11 +30,11 @@ for row in r.rows() {
 ### More complex
 
 ```rust
-use calamine::{Excel, Range, DataType};
+use calamine::{Sheets, Range, DataType};
 
 // opens a new workbook
 let path = "/path/to/my/excel/file.xlsm";
-let mut workbook = Excel::open(path).unwrap();
+let mut workbook = Sheets::open(path).unwrap();
 
 // Read whole worksheet data and provide some statistics
 if let Ok(range) = workbook.worksheet_range("Sheet1") {

--- a/examples/excel_to_csv.rs
+++ b/examples/excel_to_csv.rs
@@ -4,7 +4,7 @@ use std::env;
 use std::fs::File;
 use std::io::{BufWriter, Write};
 use std::path::PathBuf;
-use calamine::{Excel, Range, DataType, Result};
+use calamine::{Sheets, Range, DataType, Result};
 
 fn main() {
     // converts first argument into a csv (same name, silently overrides
@@ -27,7 +27,7 @@ fn main() {
 
     let dest = sce.with_extension("csv");
     let mut dest = BufWriter::new(File::create(dest).unwrap());
-    let mut xl = Excel::open(&sce).unwrap();
+    let mut xl = Sheets::open(&sce).unwrap();
     let range = xl.worksheet_range(&sheet).unwrap();
 
     write_range(&mut dest, range).unwrap();

--- a/examples/search_errors.rs
+++ b/examples/search_errors.rs
@@ -7,11 +7,11 @@ use std::fs::File;
 use std::path::PathBuf;
 
 use glob::{glob, GlobError, GlobResult};
-use calamine::{Excel, DataType, Error};
+use calamine::{Sheets, DataType, Error};
 
 #[derive(Debug)]
 enum FileStatus {
-    ExcelError(Error),
+    SheetsError(Error),
     VbaError(Error),
     RangeError(Error),
     Glob(GlobError),
@@ -57,7 +57,7 @@ fn run(f: GlobResult) -> Result<(PathBuf, Option<usize>, usize), FileStatus> {
     let f = f.map_err(FileStatus::Glob)?;
 
     println!("Analysing {:?}", f.display());
-    let mut xl = Excel::open(&f).map_err(FileStatus::ExcelError)?;
+    let mut xl = Sheets::open(&f).map_err(FileStatus::SheetsError)?;
 
     let mut missing = None;
     let mut cell_errors = 0;
@@ -72,7 +72,7 @@ fn run(f: GlobResult) -> Result<(PathBuf, Option<usize>, usize), FileStatus> {
 
     // get owned sheet names
     let sheets = xl.sheet_names()
-        .map_err(FileStatus::ExcelError)?
+        .map_err(FileStatus::SheetsError)?
         .into_iter()
         .map(|s| s.to_string())
         .collect::<Vec<_>>();

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,7 +1,7 @@
-//! `ExcelError` management module
+//! `Error` management module
 //!
 //! Provides all excel error conversion and description
-//! Also provides `Result` as a alias of `Result<_, ExcelError>
+//! Also provides `Result` as a alias of `Result<_, Error>
 
 #![allow(missing_docs)]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -438,9 +438,10 @@ impl Range {
         self.start.0 > self.end.0 || self.start.1 > self.end.1
     }
 
-    /// Set inner value
+    /// Set inner value from absolute position
     ///
     /// Will try to resize inner structure if the value is out of bounds.
+    /// For relative positions, use Index trait
     ///
     /// Try to avoid this method as much as possible and prefer initializing
     /// the `Range` with `from_sparce` constructor.
@@ -498,7 +499,9 @@ impl Range {
         Ok(())
     }
 
-    /// Get cell value
+    /// Get cell value from absolute position
+    ///
+    /// For relative positions, use Index trait
     ///
     /// Panics if indexes are out of range bounds
     pub fn get_value(&self, absolute_position: (u32, u32)) -> &DataType {

--- a/src/ods.rs
+++ b/src/ods.rs
@@ -11,17 +11,17 @@ use std::borrow::Cow;
 
 use zip::read::{ZipFile, ZipArchive};
 use zip::result::ZipError;
-use quick_xml::reader::Reader;
+use quick_xml::reader::Reader as XmlReader;
 use quick_xml::events::Event;
 use quick_xml::events::attributes::Attributes;
 
-use {DataType, ExcelReader, Range};
+use {DataType, Reader, Range};
 use vba::VbaProject;
 use errors::*;
 
 const MIMETYPE: &'static [u8] = b"application/vnd.oasis.opendocument.spreadsheet";
 
-type OdsReader<'a> = Reader<BufReader<ZipFile<'a>>>;
+type OdsReader<'a> = XmlReader<BufReader<ZipFile<'a>>>;
 
 enum Content {
     Zip(ZipArchive<File>),
@@ -38,7 +38,7 @@ pub struct Ods {
     content: Content,
 }
 
-impl ExcelReader for Ods {
+impl Reader for Ods {
     /// Creates a new instance based on the actual file
     fn new(f: File) -> Result<Self> {
         let mut zip = ZipArchive::new(f)?;
@@ -112,7 +112,7 @@ impl Ods {
         let sheets = if let Content::Zip(ref mut zip) = self.content {
             let mut reader = match zip.by_name("content.xml") {
                 Ok(f) => {
-                    let mut r = Reader::from_reader(BufReader::new(f));
+                    let mut r = XmlReader::from_reader(BufReader::new(f));
                     r.check_end_names(false)
                         .trim_text(true)
                         .check_comments(false)

--- a/src/vba.rs
+++ b/src/vba.rs
@@ -85,10 +85,10 @@ impl VbaProject {
     ///
     /// # Examples
     /// ```
-    /// use calamine::Excel;
+    /// use calamine::Sheets;
     ///
     /// # let path = format!("{}/tests/vba.xlsm", env!("CARGO_MANIFEST_DIR"));
-    /// let mut xl = Excel::open(path).expect("Cannot find excel file");
+    /// let mut xl = Sheets::open(path).expect("Cannot find excel file");
     /// let mut vba = xl.vba_project().expect("Cannot find vba project");
     /// let vba = vba.to_mut();
     /// let modules = vba.get_module_names().into_iter()

--- a/src/xls.rs
+++ b/src/xls.rs
@@ -5,7 +5,7 @@ use std::borrow::Cow;
 use std::cmp::min;
 
 use errors::*;
-use {ExcelReader, Range, Cell, DataType, CellErrorType};
+use {Reader, Range, Cell, DataType, CellErrorType};
 use vba::VbaProject;
 use cfb::{Cfb, XlsEncoding};
 use utils::{read_u16, read_u32, read_slice};
@@ -21,7 +21,7 @@ pub struct Xls {
     vba: Option<VbaProject>,
 }
 
-impl ExcelReader for Xls {
+impl Reader for Xls {
     fn new(r: File) -> Result<Self> {
 
         let len = r.metadata()?.len() as usize;

--- a/src/xlsb.rs
+++ b/src/xlsb.rs
@@ -6,12 +6,12 @@ use std::borrow::Cow;
 
 use zip::read::{ZipFile, ZipArchive};
 use zip::result::ZipError;
-use quick_xml::reader::Reader;
+use quick_xml::reader::Reader as XmlReader;
 use quick_xml::events::Event;
 use quick_xml::events::attributes::Attribute;
 use encoding_rs::UTF_16LE;
 
-use {DataType, ExcelReader, Cell, Range, CellErrorType};
+use {DataType, Reader, Cell, Range, CellErrorType};
 use vba::VbaProject;
 use utils::{read_u32, read_usize, read_slice};
 use errors::*;
@@ -35,7 +35,7 @@ impl Xlsb {
     }
 }
 
-impl ExcelReader for Xlsb {
+impl Reader for Xlsb {
     fn new(f: File) -> Result<Self> {
         Ok(Xlsb { zip: ZipArchive::new(f)? })
     }
@@ -55,7 +55,7 @@ impl ExcelReader for Xlsb {
         let mut relationships = HashMap::new();
         match self.zip.by_name("xl/_rels/workbook.bin.rels") {
             Ok(f) => {
-                let mut xml = Reader::from_reader(BufReader::new(f));
+                let mut xml = XmlReader::from_reader(BufReader::new(f));
                 xml.check_end_names(false)
                     .trim_text(false)
                     .check_comments(false)

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,6 +1,6 @@
 extern crate calamine;
 
-use calamine::Excel;
+use calamine::Sheets;
 use calamine::DataType::{String, Empty, Float, Bool, Error};
 use calamine::CellErrorType::*;
 
@@ -18,7 +18,7 @@ macro_rules! range_eq {
 #[test]
 fn issue_2() {
     let path = format!("{}/tests/issues.xlsx", env!("CARGO_MANIFEST_DIR"));
-    let mut excel = Excel::open(&path).expect("cannot open excel file");
+    let mut excel = Sheets::open(&path).expect("cannot open excel file");
 
     let range = excel.worksheet_range("issue2").unwrap();
     range_eq!(range,
@@ -31,7 +31,7 @@ fn issue_2() {
 fn issue_3() {
     // test if sheet is resolved with only one row
     let path = format!("{}/tests/issue3.xlsm", env!("CARGO_MANIFEST_DIR"));
-    let mut excel = Excel::open(&path).expect("cannot open excel file");
+    let mut excel = Sheets::open(&path).expect("cannot open excel file");
 
     let range = excel.worksheet_range("Sheet1").unwrap();
     range_eq!(range, [[Float(1.), String("a".to_string())]]);
@@ -41,7 +41,7 @@ fn issue_3() {
 fn issue_4() {
     // test if sheet is resolved with only one row
     let path = format!("{}/tests/issues.xlsx", env!("CARGO_MANIFEST_DIR"));
-    let mut excel = Excel::open(&path).expect("cannot open excel file");
+    let mut excel = Sheets::open(&path).expect("cannot open excel file");
 
     let range = excel.worksheet_range("issue5").unwrap();
     range_eq!(range, [[Float(0.5)]]);
@@ -51,7 +51,7 @@ fn issue_4() {
 fn issue_6() {
     // test if sheet is resolved with only one row
     let path = format!("{}/tests/issues.xlsx", env!("CARGO_MANIFEST_DIR"));
-    let mut excel = Excel::open(&path).expect("cannot open excel file");
+    let mut excel = Sheets::open(&path).expect("cannot open excel file");
 
     let range = excel.worksheet_range("issue6").unwrap();
     range_eq!(range,
@@ -64,7 +64,7 @@ fn issue_6() {
 #[test]
 fn error_file() {
     let path = format!("{}/tests/errors.xlsx", env!("CARGO_MANIFEST_DIR"));
-    let mut excel = Excel::open(&path).expect("cannot open excel file");
+    let mut excel = Sheets::open(&path).expect("cannot open excel file");
 
     let range = excel.worksheet_range("Feuil1").unwrap();
     range_eq!(range,
@@ -80,7 +80,7 @@ fn error_file() {
 #[test]
 fn issue_9() {
     let path = format!("{}/tests/issue9.xlsx", env!("CARGO_MANIFEST_DIR"));
-    let mut excel = Excel::open(&path).expect("cannot open excel file");
+    let mut excel = Sheets::open(&path).expect("cannot open excel file");
 
     let range = excel.worksheet_range("Feuil1").unwrap();
     range_eq!(range,
@@ -93,7 +93,7 @@ fn issue_9() {
 #[test]
 fn vba() {
     let path = format!("{}/tests/vba.xlsm", env!("CARGO_MANIFEST_DIR"));
-    let mut excel = Excel::open(&path).expect("cannot open excel file");
+    let mut excel = Sheets::open(&path).expect("cannot open excel file");
 
     let mut vba = excel.vba_project().unwrap();
     assert_eq!(vba.to_mut().get_module("testVBA").unwrap(),
@@ -104,7 +104,7 @@ fn vba() {
 #[test]
 fn xlsb() {
     let path = format!("{}/tests/issues.xlsb", env!("CARGO_MANIFEST_DIR"));
-    let mut excel = Excel::open(&path).expect("cannot open excel file");
+    let mut excel = Sheets::open(&path).expect("cannot open excel file");
 
     let range = excel.worksheet_range("issue2").unwrap();
     range_eq!(range,
@@ -116,7 +116,7 @@ fn xlsb() {
 #[test]
 fn xls() {
     let path = format!("{}/tests/issues.xls", env!("CARGO_MANIFEST_DIR"));
-    let mut excel = Excel::open(&path).expect("cannot open excel file");
+    let mut excel = Sheets::open(&path).expect("cannot open excel file");
 
     let range = excel.worksheet_range("issue2").unwrap();
     range_eq!(range,
@@ -128,7 +128,7 @@ fn xls() {
 #[test]
 fn ods() {
     let path = format!("{}/tests/issues.ods", env!("CARGO_MANIFEST_DIR"));
-    let mut excel = Excel::open(&path).expect("cannot open excel file");
+    let mut excel = Sheets::open(&path).expect("cannot open excel file");
 
     let range = excel.worksheet_range("datatypes").unwrap();
     range_eq!(range,
@@ -152,7 +152,7 @@ fn ods() {
 #[test]
 fn special_chrs_xlsx() {
     let path = format!("{}/tests/issues.xlsx", env!("CARGO_MANIFEST_DIR"));
-    let mut excel = Excel::open(&path).expect("cannot open excel file");
+    let mut excel = Sheets::open(&path).expect("cannot open excel file");
 
     let range = excel.worksheet_range("spc_chrs").unwrap();
     range_eq!(range,
@@ -169,7 +169,7 @@ fn special_chrs_xlsx() {
 #[test]
 fn special_chrs_xlsb() {
     let path = format!("{}/tests/issues.xlsb", env!("CARGO_MANIFEST_DIR"));
-    let mut excel = Excel::open(&path).expect("cannot open excel file");
+    let mut excel = Sheets::open(&path).expect("cannot open excel file");
 
     let range = excel.worksheet_range("spc_chrs").unwrap();
     range_eq!(range,
@@ -186,7 +186,7 @@ fn special_chrs_xlsb() {
 #[test]
 fn special_chrs_ods() {
     let path = format!("{}/tests/issues.ods", env!("CARGO_MANIFEST_DIR"));
-    let mut excel = Excel::open(&path).expect("cannot open excel file");
+    let mut excel = Sheets::open(&path).expect("cannot open excel file");
 
     let range = excel.worksheet_range("spc_chrs").unwrap();
     range_eq!(range,
@@ -204,7 +204,7 @@ fn special_chrs_ods() {
 fn richtext_namespaced() {
     let path = format!("{}/tests/richtext-namespaced.xlsx",
                        env!("CARGO_MANIFEST_DIR"));
-    let mut excel = Excel::open(&path).expect("cannot open excel file");
+    let mut excel = Sheets::open(&path).expect("cannot open excel file");
 
     let range = excel.worksheet_range("Sheet1").unwrap();
     range_eq!(range,


### PR DESCRIPTION
Now that ods files are supported, the main struct is now a `Sheets` instead of `Excel`.
This is a breaking change.