### PR TITLE
fix singlebyte encoding for read_dbcs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calamine"
-version = "0.10.1"
+version = "0.10.2"
 authors = ["Johann Tuffe <tafia973@gmail.com>"]
 repository = "https://github.com/tafia/calamine"
 documentation = "https://docs.rs/calamine"

--- a/Changelog.md
+++ b/Changelog.md
@@ -8,8 +8,11 @@
   - test: Adding missing tests
   - chore: Changes to the build process or auxiliary tools/libraries/documentation
 
+## 0.10.2
+- fix: error while using a singlebyte encoding for xls files (read_dbcs)
+
 ## 0.10.1
-- fix: error while using a singlebyte encoding for xls files
+- fix: error while using a singlebyte encoding for xls files (short_strings)
 
 ## 0.10.0
 - feat: support defined names for named ranges

--- a/src/xls.rs
+++ b/src/xls.rs
@@ -358,8 +358,8 @@ fn read_dbcs<'a>(encoding: &mut XlsEncoding, mut len: usize, r: &mut Record) -> 
             if r.continue_record() {
                 if let Some(ref mut b) = encoding.high_byte {
                     *b = r.data[0] & 0x1 != 0;
-                    r.data = &r.data[1..];
                 }
+                r.data = &r.data[1..];
             } else {
                 return Err("Cannot decode entire dbcs stream".into());
             }


### PR DESCRIPTION
Following #81 fix, this should fix another related bug for `read_dbcs`