### PR TITLE
Treat codepage 21010 as codepage 1200

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -63,6 +63,9 @@ pub fn encoding_from_windows_code_page(cp: usize) -> Option<&'static Encoding> {
         1201 => Some(encoding_rs::UTF_16BE),
         1200 => Some(encoding_rs::UTF_16LE),
         949 => Some(encoding_rs::EUC_KR),
+        // This is actually not a valid codepage but it happens with some unknown writer
+        // Looking on internet, it looks like excel treats this as codepage 1200
+        21010 => Some(encoding_rs::UTF_16LE),
         // Not available because not in the Encoding Standard
         //28591 => Some(encoding_rs::ISO_8859_1),
         //38598 => Some(encoding_rs::whatwg::ISO_8859_8_I),


### PR DESCRIPTION
I got some weird file with codepage 21010.
This apparently is something other people had with other tools:
https://github.com/PHPOffice/PHPExcel/issues/396
https://github.com/SheetJS/js-xls/issues/44
