### PR TITLE
Update encoding_rs to 0.7.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ appveyor = { repository = "tafia/calamine" }
 zip = { version = "0.2.6", default-features = false }
 quick-xml = "0.9.1"
 log = "0.3.8"
-encoding_rs = "0.6.11"
+encoding_rs = "0.7.0"
 byteorder = "1.1.0"
 error-chain = "0.10.0"
 


### PR DESCRIPTION
This is a performance improvement. The theoretically breaking changes (removal of a cargo feature and removal of `Encoding::for_name()`) don't affect calamine.