### PR TITLE
Update to quick-xml v0.10.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,8 @@ byteorder = "1.1.0"
 encoding_rs = "0.7.0"
 error-chain = "0.11.0"
 log = "0.3.8"
-serde = "1.0.15"
-quick-xml = "0.9.1"
+serde = "1.0.21"
+quick-xml = "0.10.0"
 zip = { version = "0.2.6", default-features = false }
 
 [dev-dependencies]

--- a/src/ods.rs
+++ b/src/ods.rs
@@ -287,7 +287,7 @@ fn get_datatype(
         let a = a?;
         match a.key {
             b"office:value" if !is_value_set => {
-                let v = reader.decode(a.value);
+                let v = reader.decode(&a.value);
                 val = DataType::Float(v.parse()?);
                 is_value_set = true;
             }
@@ -298,10 +298,10 @@ fn get_datatype(
                 is_value_set = true;
             }
             b"office:boolean-value" if !is_value_set => {
-                val = DataType::Bool(a.value == b"TRUE");
+                val = DataType::Bool(&*a.value == b"TRUE");
                 is_value_set = true;
             }
-            b"office:value-type" if !is_value_set => is_string = a.value == b"string",
+            b"office:value-type" if !is_value_set => is_string = &*a.value == b"string",
             b"table:formula" => {
                 formula = a.unescape_and_decode_value(reader)?;
             }

--- a/src/xlsb.rs
+++ b/src/xlsb.rs
@@ -54,7 +54,7 @@ impl Xlsb {
                                         key: b"Target",
                                         value: v,
                                     } => {
-                                        target = Some(xml.decode(v).into_owned());
+                                        target = Some(xml.decode(&v).into_owned());
                                     }
                                     _ => (),
                                 }

--- a/src/xlsx.rs
+++ b/src/xlsx.rs
@@ -128,11 +128,11 @@ impl Xlsx {
                             Attribute {
                                 key: b"Id",
                                 value: v,
-                            } => id.extend_from_slice(v),
+                            } => id.extend_from_slice(&v),
                             Attribute {
                                 key: b"Target",
                                 value: v,
-                            } => target = xml.decode(v).into_owned(),
+                            } => target = xml.decode(&v).into_owned(),
                             _ => (),
                         }
                     }
@@ -174,7 +174,7 @@ impl Xlsx {
                                     value: rdim,
                                 } = a?
                                 {
-                                    let (start, end) = get_dimension(rdim)?;
+                                    let (start, end) = get_dimension(&rdim)?;
                                     let len = (end.0 - start.0 + 1) * (end.1 - start.1 + 1);
                                     if len < 1_000_000 {
                                         // it is unlikely to have more than that
@@ -270,10 +270,11 @@ fn xml_reader<'a>(zip: &'a mut ZipArchive<File>, path: &str) -> Option<Result<Xl
 }
 
 /// search through an Element's attributes for the named one
-fn get_attribute<'a>(atts: Attributes<'a>, n: &'a [u8]) -> Result<Option<&'a [u8]>> {
+fn get_attribute<'a>(atts: Attributes<'a>, n: &[u8]) -> Result<Option<&'a [u8]>> {
+    use std::borrow::Cow;
     for a in atts {
         match a {
-            Ok(Attribute { key: k, value: v }) if k == n => return Ok(Some(v)),
+            Ok(Attribute { key, value: Cow::Borrowed(value) }) if key == n => return Ok(Some(value)),
             Err(qe) => bail!(qe),
             _ => {} // ignore other attributes
         }


### PR DESCRIPTION
The only non trivial change is [destructuring the `Cow`](https://github.com/tafia/calamine/compare/quick10?expand=1#diff-048de67e34bbc8cc0a70e4225719f225R277)