### PR TITLE
Update log from 0.3.8 to 0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ appveyor = { repository = "tafia/calamine" }
 byteorder = "1.1.0"
 encoding_rs = "0.7.0"
 error-chain = "0.11.0"
-log = "0.3.8"
+log = "0.4"
 serde = "1.0.21"
 quick-xml = "0.10.0"
 zip = { version = "0.2.6", default-features = false }

--- a/src/vba.rs
+++ b/src/vba.rs
@@ -8,7 +8,7 @@ use std::path::PathBuf;
 use std::collections::HashMap;
 
 use byteorder::{LittleEndian, ReadBytesExt};
-use log::LogLevel;
+use log::Level;
 
 use errors::*;
 use cfb::{Cfb, XlsEncoding};
@@ -357,7 +357,7 @@ fn read_variable_record<'a>(r: &mut &'a [u8], mult: usize) -> Result<&'a [u8]> {
 fn check_variable_record<'a>(id: u16, r: &mut &'a [u8]) -> Result<&'a [u8]> {
     check_record(id, r)?;
     let record = read_variable_record(r, 1)?;
-    if log_enabled!(LogLevel::Warn) && record.len() > 100_000 {
+    if log_enabled!(Level::Warn) && record.len() > 100_000 {
         warn!(
             "record id {} as a suspicious huge length of {} (hex: {:x})",
             id,


### PR DESCRIPTION
In the minor version bump log::LogLevel has been renamed to log::Level, so this
is changed as well.