### PR TITLE
Migrate to Failure crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ appveyor = { repository = "tafia/calamine" }
 
 [dependencies]
 byteorder = "1.2.1"
-encoding_rs = "0.7.1"
+encoding_rs = "0.7.2"
 failure = "0.1.1"
 failure_derive = "0.1.1"
 log = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calamine"
-version = "0.12.1"
+version = "0.13.0"
 authors = ["Johann Tuffe <tafia973@gmail.com>"]
 repository = "https://github.com/tafia/calamine"
 documentation = "https://docs.rs/calamine"
@@ -17,7 +17,8 @@ appveyor = { repository = "tafia/calamine" }
 [dependencies]
 byteorder = "1.2.1"
 encoding_rs = "0.7.1"
-error-chain = "0.11.0"
+failure = "0.1.1"
+failure_derive = "0.1.1"
 log = "0.4"
 serde = "1.0.27"
 quick-xml = "0.11.0"

--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,13 @@
   - test: Adding missing tests
   - chore: Changes to the build process or auxiliary tools/libraries/documentation
 
+## 0.13.0
+- feat: migrate from error-chain to failure
+- refactor: simplify Reader trait (enable direct Xlsx read etc ...)
+- refactor: always initialize at creation
+- feat: more documentation on error
+- feat: bump dependencies (calamine and encoding_rs)
+
 ## 0.12.1
 - feat: update dependencies
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -13,7 +13,9 @@
 - refactor: simplify Reader trait (enable direct Xlsx read etc ...)
 - refactor: always initialize at creation
 - feat: more documentation on error
-- feat: bump dependencies (calamine and encoding_rs)
+- feat: bump dependencies (calamine, encoding_rs and zip)
+- feat: process any Read not only Files
+- docs: fix various typos
 
 ## 0.12.1
 - feat: update dependencies

--- a/benches/basic.rs
+++ b/benches/basic.rs
@@ -4,85 +4,44 @@ extern crate calamine;
 extern crate test;
 
 use test::Bencher;
-use calamine::Sheets;
+use calamine::{Xls, Xlsx, Xlsb, Ods, Reader, open_workbook};
+use std::io::{BufReader};
 use std::fs::File;
+
+fn count<R: Reader<RS = BufReader<File>>>(path: &str) -> usize {
+    let path = format!("{}/{}", env!("CARGO_MANIFEST_DIR"), path);
+    let mut excel: R = open_workbook(&path).expect("cannot open excel file");
+
+    let sheets = excel.sheet_names().to_owned();
+    let mut count = 0;
+    for s in sheets {
+        count += excel
+            .worksheet_range(&s)
+            .unwrap()
+            .unwrap()
+            .rows()
+            .flat_map(|r| r.iter())
+            .count();
+    }
+    count
+}
 
 #[bench]
 fn bench_xls(b: &mut Bencher) {
-    b.iter(|| {
-        let path = format!("{}/tests/issues.xls", env!("CARGO_MANIFEST_DIR"));
-        let mut excel = Sheets::<File>::open(&path).expect("cannot open excel file");
-
-        let sheets = excel.sheet_names().unwrap();
-        let mut count = 0;
-        for s in sheets {
-            count += excel
-                .worksheet_range(&s)
-                .unwrap()
-                .rows()
-                .flat_map(|r| r.iter())
-                .count();
-        }
-        count
-    })
+    b.iter(|| count::<Xls<_>>("tests/issues.xls"));
 }
 
 #[bench]
 fn bench_xlsx(b: &mut Bencher) {
-    b.iter(|| {
-        let path = format!("{}/tests/issues.xlsx", env!("CARGO_MANIFEST_DIR"));
-        let mut excel = Sheets::<File>::open(&path).expect("cannot open excel file");
-
-        let sheets = excel.sheet_names().unwrap();
-        let mut count = 0;
-        for s in sheets {
-            count += excel
-                .worksheet_range(&s)
-                .unwrap()
-                .rows()
-                .flat_map(|r| r.iter())
-                .count();
-        }
-        count
-    })
+    b.iter(|| count::<Xlsx<_>>("tests/issues.xlsx"));
 }
 
 #[bench]
 fn bench_xlsb(b: &mut Bencher) {
-    b.iter(|| {
-        let path = format!("{}/tests/issues.xlsb", env!("CARGO_MANIFEST_DIR"));
-        let mut excel = Sheets::<File>::open(&path).expect("cannot open excel file");
-
-        let sheets = excel.sheet_names().unwrap();
-        let mut count = 0;
-        for s in sheets {
-            count += excel
-                .worksheet_range(&s)
-                .unwrap()
-                .rows()
-                .flat_map(|r| r.iter())
-                .count();
-        }
-        count
-    })
+    b.iter(|| count::<Xlsb<_>>("tests/issues.xlsb"));
 }
 
 #[bench]
 fn bench_ods(b: &mut Bencher) {
-    b.iter(|| {
-        let path = format!("{}/tests/issues.ods", env!("CARGO_MANIFEST_DIR"));
-        let mut excel = Sheets::<File>::open(&path).expect("cannot open excel file");
-
-        let sheets = excel.sheet_names().unwrap();
-        let mut count = 0;
-        for s in sheets {
-            count += excel
-                .worksheet_range(&s)
-                .unwrap()
-                .rows()
-                .flat_map(|r| r.iter())
-                .count();
-        }
-        count
-    })
+    b.iter(|| count::<Ods<_>>("tests/issues.ods"));
 }

--- a/benches/basic.rs
+++ b/benches/basic.rs
@@ -22,7 +22,6 @@ fn bench_xls(b: &mut Bencher) {
                 .rows()
                 .flat_map(|r| r.iter())
                 .count();
-            //             count += excel.worksheet_formula(&s).unwrap().rows().flat_map(|r| r.iter()).count();
         }
         count
     })
@@ -43,7 +42,6 @@ fn bench_xlsx(b: &mut Bencher) {
                 .rows()
                 .flat_map(|r| r.iter())
                 .count();
-            //             count += excel.worksheet_formula(&s).unwrap().rows().flat_map(|r| r.iter()).count();
         }
         count
     })
@@ -64,7 +62,6 @@ fn bench_xlsb(b: &mut Bencher) {
                 .rows()
                 .flat_map(|r| r.iter())
                 .count();
-            //             count += excel.worksheet_formula(&s).unwrap().rows().flat_map(|r| r.iter()).count();
         }
         count
     })
@@ -85,7 +82,6 @@ fn bench_ods(b: &mut Bencher) {
                 .rows()
                 .flat_map(|r| r.iter())
                 .count();
-            //             count += excel.worksheet_formula(&s).unwrap().rows().flat_map(|r| r.iter()).count();
         }
         count
     })

--- a/benches/basic.rs
+++ b/benches/basic.rs
@@ -16,8 +16,13 @@ fn bench_xls(b: &mut Bencher) {
         let sheets = excel.sheet_names().unwrap();
         let mut count = 0;
         for s in sheets {
-            count += excel.worksheet_range(&s).unwrap().rows().flat_map(|r| r.iter()).count();
-//             count += excel.worksheet_formula(&s).unwrap().rows().flat_map(|r| r.iter()).count();
+            count += excel
+                .worksheet_range(&s)
+                .unwrap()
+                .rows()
+                .flat_map(|r| r.iter())
+                .count();
+            //             count += excel.worksheet_formula(&s).unwrap().rows().flat_map(|r| r.iter()).count();
         }
         count
     })
@@ -32,8 +37,13 @@ fn bench_xlsx(b: &mut Bencher) {
         let sheets = excel.sheet_names().unwrap();
         let mut count = 0;
         for s in sheets {
-            count += excel.worksheet_range(&s).unwrap().rows().flat_map(|r| r.iter()).count();
-//             count += excel.worksheet_formula(&s).unwrap().rows().flat_map(|r| r.iter()).count();
+            count += excel
+                .worksheet_range(&s)
+                .unwrap()
+                .rows()
+                .flat_map(|r| r.iter())
+                .count();
+            //             count += excel.worksheet_formula(&s).unwrap().rows().flat_map(|r| r.iter()).count();
         }
         count
     })
@@ -48,8 +58,13 @@ fn bench_xlsb(b: &mut Bencher) {
         let sheets = excel.sheet_names().unwrap();
         let mut count = 0;
         for s in sheets {
-            count += excel.worksheet_range(&s).unwrap().rows().flat_map(|r| r.iter()).count();
-//             count += excel.worksheet_formula(&s).unwrap().rows().flat_map(|r| r.iter()).count();
+            count += excel
+                .worksheet_range(&s)
+                .unwrap()
+                .rows()
+                .flat_map(|r| r.iter())
+                .count();
+            //             count += excel.worksheet_formula(&s).unwrap().rows().flat_map(|r| r.iter()).count();
         }
         count
     })
@@ -64,8 +79,13 @@ fn bench_ods(b: &mut Bencher) {
         let sheets = excel.sheet_names().unwrap();
         let mut count = 0;
         for s in sheets {
-            count += excel.worksheet_range(&s).unwrap().rows().flat_map(|r| r.iter()).count();
-//             count += excel.worksheet_formula(&s).unwrap().rows().flat_map(|r| r.iter()).count();
+            count += excel
+                .worksheet_range(&s)
+                .unwrap()
+                .rows()
+                .flat_map(|r| r.iter())
+                .count();
+            //             count += excel.worksheet_formula(&s).unwrap().rows().flat_map(|r| r.iter()).count();
         }
         count
     })

--- a/examples/excel_to_csv.rs
+++ b/examples/excel_to_csv.rs
@@ -4,7 +4,7 @@ use std::env;
 use std::fs::File;
 use std::io::{BufWriter, Write};
 use std::path::PathBuf;
-use calamine::{DataType, Range, Sheets};
+use calamine::{AutoReader, DataType, ExtensionReader, Range, Sheets};
 
 fn main() {
     // converts first argument into a csv (same name, silently overrides
@@ -25,8 +25,8 @@ fn main() {
 
     let dest = sce.with_extension("csv");
     let mut dest = BufWriter::new(File::create(dest).unwrap());
-    let mut xl = Sheets::<File>::open(&sce).unwrap();
-    let range = xl.worksheet_range(&sheet).unwrap();
+    let mut xl = Sheets::<AutoReader<_>>::new(ExtensionReader::open(&sce).unwrap()).unwrap();
+    let range = xl.worksheet_range(&sheet).unwrap().unwrap();
 
     write_range(&mut dest, &range).unwrap();
 }

--- a/examples/excel_to_csv.rs
+++ b/examples/excel_to_csv.rs
@@ -4,7 +4,7 @@ use std::env;
 use std::fs::File;
 use std::io::{BufWriter, Write};
 use std::path::PathBuf;
-use calamine::{AutoReader, DataType, ExtensionReader, Range, Reader};
+use calamine::{open_workbook_auto, DataType, Range, Reader};
 
 fn main() {
     // converts first argument into a csv (same name, silently overrides
@@ -25,7 +25,7 @@ fn main() {
 
     let dest = sce.with_extension("csv");
     let mut dest = BufWriter::new(File::create(dest).unwrap());
-    let mut xl = AutoReader::new(ExtensionReader::open(&sce).unwrap()).unwrap();
+    let mut xl = open_workbook_auto(&sce).unwrap();
     let range = xl.worksheet_range(&sheet).unwrap().unwrap();
 
     write_range(&mut dest, &range).unwrap();

--- a/examples/excel_to_csv.rs
+++ b/examples/excel_to_csv.rs
@@ -4,7 +4,7 @@ use std::env;
 use std::fs::File;
 use std::io::{BufWriter, Write};
 use std::path::PathBuf;
-use calamine::{AutoReader, DataType, ExtensionReader, Range, Sheets};
+use calamine::{AutoReader, DataType, ExtensionReader, Range, Reader};
 
 fn main() {
     // converts first argument into a csv (same name, silently overrides
@@ -25,7 +25,7 @@ fn main() {
 
     let dest = sce.with_extension("csv");
     let mut dest = BufWriter::new(File::create(dest).unwrap());
-    let mut xl = Sheets::<AutoReader<_>>::new(ExtensionReader::open(&sce).unwrap()).unwrap();
+    let mut xl = AutoReader::new(ExtensionReader::open(&sce).unwrap()).unwrap();
     let range = xl.worksheet_range(&sheet).unwrap().unwrap();
 
     write_range(&mut dest, &range).unwrap();

--- a/examples/excel_to_csv.rs
+++ b/examples/excel_to_csv.rs
@@ -4,7 +4,7 @@ use std::env;
 use std::fs::File;
 use std::io::{BufWriter, Write};
 use std::path::PathBuf;
-use calamine::{DataType, Range, Result, Sheets};
+use calamine::{DataType, Range, Sheets};
 
 fn main() {
     // converts first argument into a csv (same name, silently overrides
@@ -31,7 +31,7 @@ fn main() {
     write_range(&mut dest, &range).unwrap();
 }
 
-fn write_range<W: Write>(dest: &mut W, range: &Range<DataType>) -> Result<()> {
+fn write_range<W: Write>(dest: &mut W, range: &Range<DataType>) -> ::std::io::Result<()> {
     let n = range.get_size().1 - 1;
     for r in range.rows() {
         for (i, c) in r.iter().enumerate() {

--- a/examples/search_errors.rs
+++ b/examples/search_errors.rs
@@ -7,13 +7,14 @@ use std::fs::File;
 use std::path::PathBuf;
 
 use glob::{glob, GlobError, GlobResult};
-use calamine::{DataType, Error, Sheets};
+use calamine::{DataType, Sheets};
+use calamine::errors::CalError;
 
 #[derive(Debug)]
 enum FileStatus {
-    SheetsError(Error),
-    VbaError(Error),
-    RangeError(Error),
+    SheetsError(CalError),
+    VbaError(CalError),
+    RangeError(CalError),
     Glob(GlobError),
 }
 

--- a/examples/search_errors.rs
+++ b/examples/search_errors.rs
@@ -7,12 +7,12 @@ use std::fs::File;
 use std::path::PathBuf;
 
 use glob::{glob, GlobError, GlobResult};
-use calamine::{AutoError, AutoReader, DataType, ExtensionReader, Reader};
+use calamine::{open_workbook_auto, DataType, Error, Reader};
 
 #[derive(Debug)]
 enum FileStatus {
-    VbaError(AutoError),
-    RangeError(AutoError),
+    VbaError(Error),
+    RangeError(Error),
     Glob(GlobError),
 }
 
@@ -55,7 +55,7 @@ fn run(f: GlobResult) -> Result<(PathBuf, Option<usize>, usize), FileStatus> {
     let f = f.map_err(FileStatus::Glob)?;
 
     println!("Analysing {:?}", f.display());
-    let mut xl = AutoReader::new(ExtensionReader::open(&f).unwrap()).unwrap();
+    let mut xl = open_workbook_auto(&f).unwrap();
 
     let mut missing = None;
     let mut cell_errors = 0;

--- a/examples/search_errors.rs
+++ b/examples/search_errors.rs
@@ -84,10 +84,12 @@ fn run(f: GlobResult) -> Result<(PathBuf, Option<usize>, usize), FileStatus> {
         cell_errors += range
             .rows()
             .flat_map(|r| {
-                r.iter().filter(|c| if let DataType::Error(_) = **c {
-                    true
-                } else {
-                    false
+                r.iter().filter(|c| {
+                    if let DataType::Error(_) = **c {
+                        true
+                    } else {
+                        false
+                    }
                 })
             })
             .count();

--- a/examples/search_errors.rs
+++ b/examples/search_errors.rs
@@ -8,13 +8,13 @@ use std::path::PathBuf;
 
 use glob::{glob, GlobError, GlobResult};
 use calamine::{DataType, Sheets};
-use calamine::errors::CalError;
+use calamine::errors::Error;
 
 #[derive(Debug)]
 enum FileStatus {
-    SheetsError(CalError),
-    VbaError(CalError),
-    RangeError(CalError),
+    SheetsError(Error),
+    VbaError(Error),
+    RangeError(Error),
     Glob(GlobError),
 }
 

--- a/src/auto.rs
+++ b/src/auto.rs
@@ -1,0 +1,161 @@
+//! A module to convert file extension to reader
+
+use std::borrow::Cow;
+use std::fs::File;
+use std::path::Path;
+use std::io::{BufReader, Error as IoError, ErrorKind, Read, Seek, SeekFrom};
+use vba::VbaProject;
+use {DataType, Metadata, Range, Reader};
+
+/// A wrapper around path which resolves extension
+pub enum Extension {
+    /// wrapper for extension .xls
+    Xls,
+    /// wrapper for extension .xlsx and .xlsm
+    Xlsx,
+    /// wrapper for extension .xlsb
+    Xlsb,
+    /// wrapper for extension .ods
+    Ods,
+}
+
+impl Extension {
+    /// Converts a path into an Extension
+    pub fn from_path(p: &Path) -> Result<Extension, IoError> {
+        Ok(match p.extension().and_then(|e| e.to_str()) {
+            Some("xls") => Extension::Xls,
+            Some("xlsx") | Some("xlsm") => Extension::Xlsx,
+            Some("xlsb") => Extension::Xlsb,
+            Some("ods") => Extension::Ods,
+            _ => return Err(IoError::new(ErrorKind::InvalidInput, "unknown extension")),
+        })
+    }
+}
+
+/// A wrapper over a reader which hold original file extension
+pub struct ExtensionReader<R> {
+    extension: Extension,
+    inner: R,
+}
+
+impl<R> ExtensionReader<R> {
+    /// Creates a new `ExtensionReader`
+    pub fn new(extension: Extension, reader: R) -> Self {
+        ExtensionReader {
+            extension: extension,
+            inner: reader,
+        }
+    }
+}
+
+impl ExtensionReader<BufReader<File>> {
+    /// Open a path and return a ExtensionReader<BufReader<File>>
+    pub fn open<P: AsRef<Path>>(p: P) -> Result<Self, IoError> {
+        let extension = Extension::from_path(p.as_ref())?;
+        Ok(ExtensionReader::new(
+            extension,
+            BufReader::new(File::open(p)?),
+        ))
+    }
+}
+
+impl<R: Read> Read for ExtensionReader<R> {
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize, IoError> {
+        self.inner.read(buf)
+    }
+}
+
+impl<R: Seek> Seek for ExtensionReader<R> {
+    fn seek(&mut self, pos: SeekFrom) -> Result<u64, IoError> {
+        self.inner.seek(pos)
+    }
+}
+
+/// A reader wrapper based on file extension
+pub enum AutoSheets<RS>
+where
+    RS: Read + Seek,
+{
+    /// wrapper for extension .xls
+    Xls(::xls::Xls<RS>),
+    /// wrapper for extension .xlsx or .xlsm
+    Xlsx(::xlsx::Xlsx<RS>),
+    /// wrapper for extension .xlsb
+    Xlsb(::xlsb::Xlsb<RS>),
+    /// wrapper for extension .ods
+    Ods(::ods::Ods<RS>),
+}
+
+/// An error wrapper based on file extension
+pub enum AutoError {
+    /// wrapper for extension .xls
+    Xls(::xls::XlsError),
+    /// wrapper for extension .xlsx or .xlsm
+    Xlsx(::xlsx::XlsxError),
+    /// wrapper for extension .xlsb
+    Xlsb(::xlsb::XlsbError),
+    /// wrapper for extension .ods
+    Ods(::ods::OdsError),
+    /// special io error
+    Io(::std::io::Error),
+}
+
+from_err!(IoError, AutoError, Io);
+
+macro_rules! auto {
+    ($self:expr, $fn:tt $(, $arg:expr)*) => {
+        match *$self {
+            AutoSheets::Xls(ref mut e) => e.$fn($($arg,)*).map_err(AutoError::Xls),
+            AutoSheets::Xlsx(ref mut e) => e.$fn($($arg,)*).map_err(AutoError::Xlsx),
+            AutoSheets::Xlsb(ref mut e) => e.$fn($($arg,)*).map_err(AutoError::Xlsb),
+            AutoSheets::Ods(ref mut e) => e.$fn($($arg,)*).map_err(AutoError::Ods),
+        }
+    }
+}
+
+impl<RS: Read + Seek> Reader for AutoSheets<RS> {
+    type Error = AutoError;
+    type RS = ExtensionReader<RS>;
+
+    fn new(reader: Self::RS) -> Result<Self, Self::Error> {
+        Ok(match reader.extension {
+            Extension::Xls => {
+                AutoSheets::Xls(::xls::Xls::new(reader.inner).map_err(AutoError::Xls)?)
+            }
+            Extension::Xlsx => {
+                AutoSheets::Xlsx(::xlsx::Xlsx::new(reader.inner).map_err(AutoError::Xlsx)?)
+            }
+            Extension::Xlsb => {
+                AutoSheets::Xlsb(::xlsb::Xlsb::new(reader.inner).map_err(AutoError::Xlsb)?)
+            }
+            Extension::Ods => {
+                AutoSheets::Ods(::ods::Ods::new(reader.inner).map_err(AutoError::Ods)?)
+            }
+        })
+    }
+
+    fn has_vba(&mut self) -> bool {
+        match *self {
+            AutoSheets::Xls(ref mut e) => e.has_vba(),
+            AutoSheets::Xlsx(ref mut e) => e.has_vba(),
+            AutoSheets::Xlsb(ref mut e) => e.has_vba(),
+            AutoSheets::Ods(ref mut e) => e.has_vba(),
+        }
+    }
+
+    fn vba_project(&mut self) -> Result<Cow<VbaProject>, Self::Error> {
+        auto!(self, vba_project)
+    }
+
+    fn initialize(&mut self) -> Result<Metadata, Self::Error> {
+        auto!(self, initialize)
+    }
+
+    fn read_worksheet_range(&mut self, name: &str) -> Result<Option<Range<DataType>>, Self::Error> {
+        auto!(self, read_worksheet_range, name)
+    }
+
+    fn read_worksheet_formula(&mut self, name: &str) -> Result<Option<Range<String>>, Self::Error> {
+        auto!(self, read_worksheet_formula, name)
+    }
+}

--- a/src/auto.rs
+++ b/src/auto.rs
@@ -153,15 +153,20 @@ impl<RS: Read + Seek> Reader for AutoReader<RS> {
         auto!(self, vba_project)
     }
 
-    fn initialize(&mut self) -> Result<Metadata, Self::Error> {
-        auto!(self, initialize)
+    fn metadata(&self) -> &Metadata {
+        match *self {
+            AutoReader::Xls(ref e) => e.metadata(),
+            AutoReader::Xlsx(ref e) => e.metadata(),
+            AutoReader::Xlsb(ref e) => e.metadata(),
+            AutoReader::Ods(ref e) => e.metadata(),
+        }
     }
 
-    fn read_worksheet_range(&mut self, name: &str) -> Result<Option<Range<DataType>>, Self::Error> {
-        auto!(self, read_worksheet_range, name)
+    fn worksheet_range(&mut self, name: &str) -> Result<Option<Range<DataType>>, Self::Error> {
+        auto!(self, worksheet_range, name)
     }
 
-    fn read_worksheet_formula(&mut self, name: &str) -> Result<Option<Range<String>>, Self::Error> {
-        auto!(self, read_worksheet_formula, name)
+    fn worksheet_formula(&mut self, name: &str) -> Result<Option<Range<String>>, Self::Error> {
+        auto!(self, worksheet_formula, name)
     }
 }

--- a/src/auto.rs
+++ b/src/auto.rs
@@ -44,23 +44,13 @@ impl Reader for Sheets {
         Err(Error::Msg("Sheets must be created from a Path"))
     }
 
-    /// Does the workbook contain a vba project
-    fn has_vba(&mut self) -> bool {
-        match *self {
-            Sheets::Xls(ref mut e) => e.has_vba(),
-            Sheets::Xlsx(ref mut e) => e.has_vba(),
-            Sheets::Xlsb(ref mut e) => e.has_vba(),
-            Sheets::Ods(ref mut e) => e.has_vba(),
-        }
-    }
-
     /// Gets `VbaProject`
-    fn vba_project(&mut self) -> Result<Cow<VbaProject>, Self::Error> {
+    fn vba_project(&mut self) -> Option<Result<Cow<VbaProject>, Self::Error>> {
         match *self {
-            Sheets::Xls(ref mut e) => e.vba_project().map_err(Error::Xls),
-            Sheets::Xlsx(ref mut e) => e.vba_project().map_err(Error::Xlsx),
-            Sheets::Xlsb(ref mut e) => e.vba_project().map_err(Error::Xlsb),
-            Sheets::Ods(ref mut e) => e.vba_project().map_err(Error::Ods),
+            Sheets::Xls(ref mut e) => e.vba_project().map(|vba| vba.map_err(Error::Xls)),
+            Sheets::Xlsx(ref mut e) => e.vba_project().map(|vba| vba.map_err(Error::Xlsx)),
+            Sheets::Xlsb(ref mut e) => e.vba_project().map(|vba| vba.map_err(Error::Xlsb)),
+            Sheets::Ods(ref mut e) => e.vba_project().map(|vba| vba.map_err(Error::Ods)),
         }
     }
 
@@ -75,22 +65,22 @@ impl Reader for Sheets {
     }
 
     /// Read worksheet data in corresponding worksheet path
-    fn worksheet_range(&mut self, name: &str) -> Result<Option<Range<DataType>>, Self::Error> {
+    fn worksheet_range(&mut self, name: &str) -> Option<Result<Range<DataType>, Self::Error>> {
         match *self {
-            Sheets::Xls(ref mut e) => e.worksheet_range(name).map_err(Error::Xls),
-            Sheets::Xlsx(ref mut e) => e.worksheet_range(name).map_err(Error::Xlsx),
-            Sheets::Xlsb(ref mut e) => e.worksheet_range(name).map_err(Error::Xlsb),
-            Sheets::Ods(ref mut e) => e.worksheet_range(name).map_err(Error::Ods),
+            Sheets::Xls(ref mut e) => e.worksheet_range(name).map(|r| r.map_err(Error::Xls)),
+            Sheets::Xlsx(ref mut e) => e.worksheet_range(name).map(|r| r.map_err(Error::Xlsx)),
+            Sheets::Xlsb(ref mut e) => e.worksheet_range(name).map(|r| r.map_err(Error::Xlsb)),
+            Sheets::Ods(ref mut e) => e.worksheet_range(name).map(|r| r.map_err(Error::Ods)),
         }
     }
 
     /// Read worksheet formula in corresponding worksheet path
-    fn worksheet_formula(&mut self, name: &str) -> Result<Option<Range<String>>, Self::Error> {
+    fn worksheet_formula(&mut self, name: &str) -> Option<Result<Range<String>, Self::Error>> {
         match *self {
-            Sheets::Xls(ref mut e) => e.worksheet_formula(name).map_err(Error::Xls),
-            Sheets::Xlsx(ref mut e) => e.worksheet_formula(name).map_err(Error::Xlsx),
-            Sheets::Xlsb(ref mut e) => e.worksheet_formula(name).map_err(Error::Xlsb),
-            Sheets::Ods(ref mut e) => e.worksheet_formula(name).map_err(Error::Ods),
+            Sheets::Xls(ref mut e) => e.worksheet_formula(name).map(|r| r.map_err(Error::Xls)),
+            Sheets::Xlsx(ref mut e) => e.worksheet_formula(name).map(|r| r.map_err(Error::Xlsx)),
+            Sheets::Xlsb(ref mut e) => e.worksheet_formula(name).map(|r| r.map_err(Error::Xlsb)),
+            Sheets::Ods(ref mut e) => e.worksheet_formula(name).map(|r| r.map_err(Error::Ods)),
         }
     }
 }

--- a/src/auto.rs
+++ b/src/auto.rs
@@ -2,171 +2,95 @@
 
 use std::borrow::Cow;
 use std::fs::File;
+use std::io::BufReader;
 use std::path::Path;
-use std::io::{BufReader, Error as IoError, ErrorKind, Read, Seek, SeekFrom};
 use vba::VbaProject;
-use {DataType, Metadata, Range, Reader};
+use {open_workbook, DataType, Metadata, Ods, Range, Reader, Xls, Xlsb, Xlsx};
+use errors::Error;
 
-/// A wrapper around path which resolves extension
-pub enum Extension {
-    /// wrapper for extension .xls
-    Xls,
-    /// wrapper for extension .xlsx and .xlsm
-    Xlsx,
-    /// wrapper for extension .xlsb
-    Xlsb,
-    /// wrapper for extension .ods
-    Ods,
+/// A wrapper over all sheets when the file type is not known at static time
+pub enum Sheets {
+    /// Xls reader
+    Xls(Xls<BufReader<File>>),
+    /// Xlsx reader
+    Xlsx(Xlsx<BufReader<File>>),
+    /// Xlsb reader
+    Xlsb(Xlsb<BufReader<File>>),
+    /// Ods reader
+    Ods(Ods<BufReader<File>>),
 }
 
-impl Extension {
-    /// Converts a path into an Extension
-    pub fn from_path(p: &Path) -> Result<Extension, IoError> {
-        Ok(match p.extension().and_then(|e| e.to_str()) {
-            Some("xls") => Extension::Xls,
-            Some("xlsx") | Some("xlsm") => Extension::Xlsx,
-            Some("xlsb") => Extension::Xlsb,
-            Some("ods") => Extension::Ods,
-            _ => return Err(IoError::new(ErrorKind::InvalidInput, "unknown extension")),
-        })
-    }
-}
-
-/// A wrapper over a reader which hold original file extension
-pub struct ExtensionReader<R> {
-    extension: Extension,
-    inner: R,
-}
-
-impl<R> ExtensionReader<R> {
-    /// Creates a new `ExtensionReader`
-    pub fn new(extension: Extension, reader: R) -> Self {
-        ExtensionReader {
-            extension: extension,
-            inner: reader,
+/// Opens a workbook and define the file type at runtime.
+///
+/// Whenever possible use the statically known `open_workbook` function instead
+pub fn open_workbook_auto<P: AsRef<Path>>(path: P) -> Result<Sheets, Error> {
+    Ok(match path.as_ref().extension().and_then(|e| e.to_str()) {
+        Some("xls") | Some("xla") => Sheets::Xls(open_workbook(&path).map_err(Error::Xls)?),
+        Some("xlsx") | Some("xlsm") | Some("xlam") => {
+            Sheets::Xlsx(open_workbook(&path).map_err(Error::Xlsx)?)
         }
-    }
+        Some("xlsb") => Sheets::Xlsb(open_workbook(&path).map_err(Error::Xlsb)?),
+        Some("ods") => Sheets::Ods(open_workbook(&path).map_err(Error::Ods)?),
+        _ => return Err(Error::Msg("Unknown extension")),
+    })
 }
 
-impl ExtensionReader<BufReader<File>> {
-    /// Open a path and return a ExtensionReader<BufReader<File>>
-    pub fn open<P: AsRef<Path>>(p: P) -> Result<Self, IoError> {
-        let extension = Extension::from_path(p.as_ref())?;
-        Ok(ExtensionReader::new(
-            extension,
-            BufReader::new(File::open(p)?),
-        ))
-    }
-}
+impl Reader for Sheets {
+    type RS = BufReader<File>;
+    type Error = Error;
 
-impl<R: Read> Read for ExtensionReader<R> {
-    fn read(&mut self, buf: &mut [u8]) -> Result<usize, IoError> {
-        self.inner.read(buf)
-    }
-}
-
-impl<R: Seek> Seek for ExtensionReader<R> {
-    fn seek(&mut self, pos: SeekFrom) -> Result<u64, IoError> {
-        self.inner.seek(pos)
-    }
-}
-
-/// A reader wrapper based on file extension
-pub enum AutoReader<RS>
-where
-    RS: Read + Seek,
-{
-    /// wrapper for extension .xls
-    Xls(::xls::Xls<RS>),
-    /// wrapper for extension .xlsx or .xlsm
-    Xlsx(::xlsx::Xlsx<RS>),
-    /// wrapper for extension .xlsb
-    Xlsb(::xlsb::Xlsb<RS>),
-    /// wrapper for extension .ods
-    Ods(::ods::Ods<RS>),
-}
-
-/// An error wrapper based on file extension
-#[derive(Debug, Fail)]
-pub enum AutoError {
-    /// wrapper for extension .xls
-    #[fail(display = "{}", _0)]
-    Xls(#[cause] ::xls::XlsError),
-    /// wrapper for extension .xlsx or .xlsm
-    #[fail(display = "{}", _0)]
-    Xlsx(#[cause] ::xlsx::XlsxError),
-    /// wrapper for extension .xlsb
-    #[fail(display = "{}", _0)]
-    Xlsb(#[cause] ::xlsb::XlsbError),
-    /// wrapper for extension .ods
-    #[fail(display = "{}", _0)]
-    Ods(#[cause] ::ods::OdsError),
-    /// special io error
-    #[fail(display = "{}", _0)]
-    Io(#[cause] ::std::io::Error),
-}
-
-from_err!(IoError, AutoError, Io);
-
-macro_rules! auto {
-    ($self:expr, $fn:tt $(, $arg:expr)*) => {
-        match *$self {
-            AutoReader::Xls(ref mut e) => e.$fn($($arg,)*).map_err(AutoError::Xls),
-            AutoReader::Xlsx(ref mut e) => e.$fn($($arg,)*).map_err(AutoError::Xlsx),
-            AutoReader::Xlsb(ref mut e) => e.$fn($($arg,)*).map_err(AutoError::Xlsb),
-            AutoReader::Ods(ref mut e) => e.$fn($($arg,)*).map_err(AutoError::Ods),
-        }
-    }
-}
-
-impl<RS: Read + Seek> Reader for AutoReader<RS> {
-    type Error = AutoError;
-    type RS = ExtensionReader<RS>;
-
-    fn new(reader: Self::RS) -> Result<Self, Self::Error> {
-        Ok(match reader.extension {
-            Extension::Xls => {
-                AutoReader::Xls(::xls::Xls::new(reader.inner).map_err(AutoError::Xls)?)
-            }
-            Extension::Xlsx => {
-                AutoReader::Xlsx(::xlsx::Xlsx::new(reader.inner).map_err(AutoError::Xlsx)?)
-            }
-            Extension::Xlsb => {
-                AutoReader::Xlsb(::xlsb::Xlsb::new(reader.inner).map_err(AutoError::Xlsb)?)
-            }
-            Extension::Ods => {
-                AutoReader::Ods(::ods::Ods::new(reader.inner).map_err(AutoError::Ods)?)
-            }
-        })
+    /// Creates a new instance.
+    fn new(_reader: Self::RS) -> Result<Self, Self::Error> {
+        Err(Error::Msg("Sheets must be created from a Path"))
     }
 
+    /// Does the workbook contain a vba project
     fn has_vba(&mut self) -> bool {
         match *self {
-            AutoReader::Xls(ref mut e) => e.has_vba(),
-            AutoReader::Xlsx(ref mut e) => e.has_vba(),
-            AutoReader::Xlsb(ref mut e) => e.has_vba(),
-            AutoReader::Ods(ref mut e) => e.has_vba(),
+            Sheets::Xls(ref mut e) => e.has_vba(),
+            Sheets::Xlsx(ref mut e) => e.has_vba(),
+            Sheets::Xlsb(ref mut e) => e.has_vba(),
+            Sheets::Ods(ref mut e) => e.has_vba(),
         }
     }
 
+    /// Gets `VbaProject`
     fn vba_project(&mut self) -> Result<Cow<VbaProject>, Self::Error> {
-        auto!(self, vba_project)
+        match *self {
+            Sheets::Xls(ref mut e) => e.vba_project().map_err(Error::Xls),
+            Sheets::Xlsx(ref mut e) => e.vba_project().map_err(Error::Xlsx),
+            Sheets::Xlsb(ref mut e) => e.vba_project().map_err(Error::Xlsb),
+            Sheets::Ods(ref mut e) => e.vba_project().map_err(Error::Ods),
+        }
     }
 
+    /// Initialize
     fn metadata(&self) -> &Metadata {
         match *self {
-            AutoReader::Xls(ref e) => e.metadata(),
-            AutoReader::Xlsx(ref e) => e.metadata(),
-            AutoReader::Xlsb(ref e) => e.metadata(),
-            AutoReader::Ods(ref e) => e.metadata(),
+            Sheets::Xls(ref e) => e.metadata(),
+            Sheets::Xlsx(ref e) => e.metadata(),
+            Sheets::Xlsb(ref e) => e.metadata(),
+            Sheets::Ods(ref e) => e.metadata(),
         }
     }
 
+    /// Read worksheet data in corresponding worksheet path
     fn worksheet_range(&mut self, name: &str) -> Result<Option<Range<DataType>>, Self::Error> {
-        auto!(self, worksheet_range, name)
+        match *self {
+            Sheets::Xls(ref mut e) => e.worksheet_range(name).map_err(Error::Xls),
+            Sheets::Xlsx(ref mut e) => e.worksheet_range(name).map_err(Error::Xlsx),
+            Sheets::Xlsb(ref mut e) => e.worksheet_range(name).map_err(Error::Xlsb),
+            Sheets::Ods(ref mut e) => e.worksheet_range(name).map_err(Error::Ods),
+        }
     }
 
+    /// Read worksheet formula in corresponding worksheet path
     fn worksheet_formula(&mut self, name: &str) -> Result<Option<Range<String>>, Self::Error> {
-        auto!(self, worksheet_formula, name)
+        match *self {
+            Sheets::Xls(ref mut e) => e.worksheet_formula(name).map_err(Error::Xls),
+            Sheets::Xlsx(ref mut e) => e.worksheet_formula(name).map_err(Error::Xlsx),
+            Sheets::Xlsb(ref mut e) => e.worksheet_formula(name).map_err(Error::Xlsb),
+            Sheets::Ods(ref mut e) => e.worksheet_formula(name).map_err(Error::Ods),
+        }
     }
 }

--- a/src/cfb.rs
+++ b/src/cfb.rs
@@ -101,8 +101,13 @@ impl Cfb {
         match self.directories.iter().find(|d| &*d.name == name) {
             None => Err(CfbError::StreamNotFound(name.to_string())),
             Some(d) => {
-                let fats = if d.len < 4096 { &self.mini_fats } else { &self.fats };
-                self.sectors.get_chain(d.start, fats, r, d.len)
+                if d.len < 4096 {
+                    // TODO: Study the possibility to return a `VecArray` (stack allocated)
+                    self.mini_sectors
+                        .get_chain(d.start, &self.mini_fats, r, d.len)
+                } else {
+                    self.sectors.get_chain(d.start, &self.fats, r, d.len)
+                }
             }
         }
     }

--- a/src/datatype.rs
+++ b/src/datatype.rs
@@ -141,7 +141,10 @@ impl From<()> for DataType {
     }
 }
 
-impl<T> From<Option<T>> for DataType where DataType: From<T> {
+impl<T> From<Option<T>> for DataType
+where
+    DataType: From<T>,
+{
     fn from(v: Option<T>) -> Self {
         match v {
             Some(v) => From::from(v),

--- a/src/de.rs
+++ b/src/de.rs
@@ -99,10 +99,11 @@ impl RangeDeserializerBuilder {
     /// # Example
     ///
     /// ```
-    /// # use calamine::{Result, Sheets, RangeDeserializerBuilder};
+    /// # use calamine::{Sheets, RangeDeserializerBuilder};
+    /// # use calamine::errors::CalError;
     /// # use std::fs::File;
     /// # fn main() { example().unwrap(); }
-    /// fn example() -> Result<()> {
+    /// fn example() -> Result<(), CalError> {
     ///     let path = format!("{}/tests/tempurature.xlsx", env!("CARGO_MANIFEST_DIR"));
     ///     let mut workbook = Sheets::<File>::open(path)?;
     ///     let range = workbook.worksheet_range("Sheet1")?;
@@ -132,10 +133,11 @@ impl RangeDeserializerBuilder {
     /// # Example
     ///
     /// ```
-    /// # use calamine::{DataType, Result, Sheets, RangeDeserializerBuilder};
+    /// # use calamine::{DataType, Sheets, RangeDeserializerBuilder};
+    /// # use calamine::errors::CalError;
     /// # use std::fs::File;
     /// # fn main() { example().unwrap(); }
-    /// fn example() -> Result<()> {
+    /// fn example() -> Result<(), CalError> {
     ///     let path = format!("{}/tests/tempurature.xlsx", env!("CARGO_MANIFEST_DIR"));
     ///     let mut workbook = Sheets::<File>::open(path)?;
     ///     let range = workbook.worksheet_range("Sheet1")?;
@@ -172,10 +174,11 @@ impl RangeDeserializerBuilder {
 /// # Example
 ///
 /// ```
-/// # use calamine::{Result, Sheets, RangeDeserializerBuilder};
+/// # use calamine::{Sheets, RangeDeserializerBuilder};
+/// # use calamine::errors::CalError;
 /// # use std::fs::File;
 /// # fn main() { example().unwrap(); }
-/// fn example() -> Result<()> {
+/// fn example() -> Result<(), CalError> {
 ///     let path = format!("{}/tests/tempurature.xlsx", env!("CARGO_MANIFEST_DIR"));
 ///     let mut workbook = Sheets::<File>::open(path)?;
 ///     let range = workbook.worksheet_range("Sheet1")?;

--- a/src/de.rs
+++ b/src/de.rs
@@ -100,12 +100,12 @@ impl RangeDeserializerBuilder {
     /// # Example
     ///
     /// ```
-    /// # use calamine::{Sheets, Xlsx, RangeDeserializerBuilder};
+    /// # use calamine::{open_workbook, Xlsx, Reader, RangeDeserializerBuilder};
     /// # use calamine::errors::Error;
     /// # fn main() { example().unwrap(); }
     /// fn example() -> Result<(), Error> {
     ///     let path = format!("{}/tests/tempurature.xlsx", env!("CARGO_MANIFEST_DIR"));
-    ///     let mut workbook = Sheets::<Xlsx<_>>::open(path)?;
+    ///     let mut workbook: Xlsx<_> = open_workbook(path)?;
     ///     let range = workbook.worksheet_range("Sheet1")?
     ///         .ok_or(Error::Msg("Cannot find 'Sheet1'"))?;
     ///     let mut iter = RangeDeserializerBuilder::new().from_range(&range)?;
@@ -137,12 +137,12 @@ impl RangeDeserializerBuilder {
     /// # Example
     ///
     /// ```
-    /// # use calamine::{DataType, Sheets, Xlsx, RangeDeserializerBuilder};
+    /// # use calamine::{DataType, open_workbook, Xlsx, Reader, RangeDeserializerBuilder};
     /// # use calamine::errors::Error;
     /// # fn main() { example().unwrap(); }
     /// fn example() -> Result<(), Error> {
     ///     let path = format!("{}/tests/tempurature.xlsx", env!("CARGO_MANIFEST_DIR"));
-    ///     let mut workbook = Sheets::<Xlsx<_>>::open(path)?;
+    ///     let mut workbook: Xlsx<_> = open_workbook(path)?;
     ///     let range = workbook.worksheet_range("Sheet1")?
     ///         .ok_or(Error::Msg("Cannot find 'Sheet1'"))?;
     ///
@@ -178,12 +178,12 @@ impl RangeDeserializerBuilder {
 /// # Example
 ///
 /// ```
-/// # use calamine::{Sheets, Xlsx, RangeDeserializerBuilder};
+/// # use calamine::{open_workbook, Xlsx, Reader, RangeDeserializerBuilder};
 /// # use calamine::errors::Error;
 /// # fn main() { example().unwrap(); }
 /// fn example() -> Result<(), Error> {
 ///     let path = format!("{}/tests/tempurature.xlsx", env!("CARGO_MANIFEST_DIR"));
-///     let mut workbook = Sheets::<Xlsx<_>>::open(path)?;
+///     let mut workbook: Xlsx<_> = open_workbook(path)?;
 ///     let range = workbook.worksheet_range("Sheet1")?
 ///         .ok_or(Error::Msg("Cannot find 'Sheet1'"))?;
 ///

--- a/src/de.rs
+++ b/src/de.rs
@@ -100,8 +100,7 @@ impl RangeDeserializerBuilder {
     /// # Example
     ///
     /// ```
-    /// # use calamine::{open_workbook, Xlsx, Reader, RangeDeserializerBuilder};
-    /// # use calamine::errors::Error;
+    /// # use calamine::{open_workbook, Error, Xlsx, Reader, RangeDeserializerBuilder};
     /// # fn main() { example().unwrap(); }
     /// fn example() -> Result<(), Error> {
     ///     let path = format!("{}/tests/tempurature.xlsx", env!("CARGO_MANIFEST_DIR"));
@@ -137,8 +136,7 @@ impl RangeDeserializerBuilder {
     /// # Example
     ///
     /// ```
-    /// # use calamine::{DataType, open_workbook, Xlsx, Reader, RangeDeserializerBuilder};
-    /// # use calamine::errors::Error;
+    /// # use calamine::{DataType, Error, open_workbook, Xlsx, Reader, RangeDeserializerBuilder};
     /// # fn main() { example().unwrap(); }
     /// fn example() -> Result<(), Error> {
     ///     let path = format!("{}/tests/tempurature.xlsx", env!("CARGO_MANIFEST_DIR"));
@@ -178,8 +176,7 @@ impl RangeDeserializerBuilder {
 /// # Example
 ///
 /// ```
-/// # use calamine::{open_workbook, Xlsx, Reader, RangeDeserializerBuilder};
-/// # use calamine::errors::Error;
+/// # use calamine::{open_workbook, Error, Xlsx, Reader, RangeDeserializerBuilder};
 /// # fn main() { example().unwrap(); }
 /// fn example() -> Result<(), Error> {
 ///     let path = format!("{}/tests/tempurature.xlsx", env!("CARGO_MANIFEST_DIR"));

--- a/src/de.rs
+++ b/src/de.rs
@@ -105,8 +105,8 @@ impl RangeDeserializerBuilder {
     /// fn example() -> Result<(), Error> {
     ///     let path = format!("{}/tests/tempurature.xlsx", env!("CARGO_MANIFEST_DIR"));
     ///     let mut workbook: Xlsx<_> = open_workbook(path)?;
-    ///     let range = workbook.worksheet_range("Sheet1")?
-    ///         .ok_or(Error::Msg("Cannot find 'Sheet1'"))?;
+    ///     let range = workbook.worksheet_range("Sheet1")
+    ///         .ok_or(Error::Msg("Cannot find 'Sheet1'"))??;
     ///     let mut iter = RangeDeserializerBuilder::new().from_range(&range)?;
     ///
     ///     if let Some(result) = iter.next() {
@@ -141,8 +141,8 @@ impl RangeDeserializerBuilder {
     /// fn example() -> Result<(), Error> {
     ///     let path = format!("{}/tests/tempurature.xlsx", env!("CARGO_MANIFEST_DIR"));
     ///     let mut workbook: Xlsx<_> = open_workbook(path)?;
-    ///     let range = workbook.worksheet_range("Sheet1")?
-    ///         .ok_or(Error::Msg("Cannot find 'Sheet1'"))?;
+    ///     let range = workbook.worksheet_range("Sheet1")
+    ///         .ok_or(Error::Msg("Cannot find 'Sheet1'"))??;
     ///
     ///     let mut iter = RangeDeserializerBuilder::new()
     ///         .has_headers(false)
@@ -181,8 +181,8 @@ impl RangeDeserializerBuilder {
 /// fn example() -> Result<(), Error> {
 ///     let path = format!("{}/tests/tempurature.xlsx", env!("CARGO_MANIFEST_DIR"));
 ///     let mut workbook: Xlsx<_> = open_workbook(path)?;
-///     let range = workbook.worksheet_range("Sheet1")?
-///         .ok_or(Error::Msg("Cannot find 'Sheet1'"))?;
+///     let range = workbook.worksheet_range("Sheet1")
+///         .ok_or(Error::Msg("Cannot find 'Sheet1'"))??;
 ///
 ///     let mut iter = RangeDeserializerBuilder::new().from_range(&range)?;
 ///

--- a/src/de.rs
+++ b/src/de.rs
@@ -100,14 +100,14 @@ impl RangeDeserializerBuilder {
     /// # Example
     ///
     /// ```
-    /// # use calamine::{Sheets, RangeDeserializerBuilder};
+    /// # use calamine::{Sheets, Xlsx, RangeDeserializerBuilder};
     /// # use calamine::errors::Error;
-    /// # use std::fs::File;
     /// # fn main() { example().unwrap(); }
     /// fn example() -> Result<(), Error> {
     ///     let path = format!("{}/tests/tempurature.xlsx", env!("CARGO_MANIFEST_DIR"));
-    ///     let mut workbook = Sheets::<File>::open(path)?;
-    ///     let range = workbook.worksheet_range("Sheet1")?;
+    ///     let mut workbook = Sheets::<Xlsx<_>>::open(path)?;
+    ///     let range = workbook.worksheet_range("Sheet1")?
+    ///         .ok_or(Error::Msg("Cannot find 'Sheet1'"))?;
     ///     let mut iter = RangeDeserializerBuilder::new().from_range(&range)?;
     ///
     ///     if let Some(result) = iter.next() {
@@ -137,14 +137,14 @@ impl RangeDeserializerBuilder {
     /// # Example
     ///
     /// ```
-    /// # use calamine::{DataType, Sheets, RangeDeserializerBuilder};
+    /// # use calamine::{DataType, Sheets, Xlsx, RangeDeserializerBuilder};
     /// # use calamine::errors::Error;
-    /// # use std::fs::File;
     /// # fn main() { example().unwrap(); }
     /// fn example() -> Result<(), Error> {
     ///     let path = format!("{}/tests/tempurature.xlsx", env!("CARGO_MANIFEST_DIR"));
-    ///     let mut workbook = Sheets::<File>::open(path)?;
-    ///     let range = workbook.worksheet_range("Sheet1")?;
+    ///     let mut workbook = Sheets::<Xlsx<_>>::open(path)?;
+    ///     let range = workbook.worksheet_range("Sheet1")?
+    ///         .ok_or(Error::Msg("Cannot find 'Sheet1'"))?;
     ///
     ///     let mut iter = RangeDeserializerBuilder::new()
     ///         .has_headers(false)
@@ -178,14 +178,14 @@ impl RangeDeserializerBuilder {
 /// # Example
 ///
 /// ```
-/// # use calamine::{Sheets, RangeDeserializerBuilder};
+/// # use calamine::{Sheets, Xlsx, RangeDeserializerBuilder};
 /// # use calamine::errors::Error;
-/// # use std::fs::File;
 /// # fn main() { example().unwrap(); }
 /// fn example() -> Result<(), Error> {
 ///     let path = format!("{}/tests/tempurature.xlsx", env!("CARGO_MANIFEST_DIR"));
-///     let mut workbook = Sheets::<File>::open(path)?;
-///     let range = workbook.worksheet_range("Sheet1")?;
+///     let mut workbook = Sheets::<Xlsx<_>>::open(path)?;
+///     let range = workbook.worksheet_range("Sheet1")?
+///         .ok_or(Error::Msg("Cannot find 'Sheet1'"))?;
 ///
 ///     let mut iter = RangeDeserializerBuilder::new().from_range(&range)?;
 ///

--- a/src/de.rs
+++ b/src/de.rs
@@ -101,10 +101,10 @@ impl RangeDeserializerBuilder {
     ///
     /// ```
     /// # use calamine::{Sheets, RangeDeserializerBuilder};
-    /// # use calamine::errors::CalError;
+    /// # use calamine::errors::Error;
     /// # use std::fs::File;
     /// # fn main() { example().unwrap(); }
-    /// fn example() -> Result<(), CalError> {
+    /// fn example() -> Result<(), Error> {
     ///     let path = format!("{}/tests/tempurature.xlsx", env!("CARGO_MANIFEST_DIR"));
     ///     let mut workbook = Sheets::<File>::open(path)?;
     ///     let range = workbook.worksheet_range("Sheet1")?;
@@ -138,10 +138,10 @@ impl RangeDeserializerBuilder {
     ///
     /// ```
     /// # use calamine::{DataType, Sheets, RangeDeserializerBuilder};
-    /// # use calamine::errors::CalError;
+    /// # use calamine::errors::Error;
     /// # use std::fs::File;
     /// # fn main() { example().unwrap(); }
-    /// fn example() -> Result<(), CalError> {
+    /// fn example() -> Result<(), Error> {
     ///     let path = format!("{}/tests/tempurature.xlsx", env!("CARGO_MANIFEST_DIR"));
     ///     let mut workbook = Sheets::<File>::open(path)?;
     ///     let range = workbook.worksheet_range("Sheet1")?;
@@ -179,10 +179,10 @@ impl RangeDeserializerBuilder {
 ///
 /// ```
 /// # use calamine::{Sheets, RangeDeserializerBuilder};
-/// # use calamine::errors::CalError;
+/// # use calamine::errors::Error;
 /// # use std::fs::File;
 /// # fn main() { example().unwrap(); }
-/// fn example() -> Result<(), CalError> {
+/// fn example() -> Result<(), Error> {
 ///     let path = format!("{}/tests/tempurature.xlsx", env!("CARGO_MANIFEST_DIR"));
 ///     let mut workbook = Sheets::<File>::open(path)?;
 ///     let range = workbook.worksheet_range("Sheet1")?;

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,4 +1,4 @@
-//! `Error` management module 
+//! `Error` management module
 //! Provides all excel error conversion and description
 //! Also provides `Result` as a alias of `Result<_, Error>
 
@@ -7,33 +7,29 @@
 /// A struct to handle calamine specific errors
 #[derive(Fail, Debug)]
 pub enum CalError {
-    #[fail(display = "{}", _0)]
-    Io(#[cause] ::std::io::Error),
+    #[fail(display = "{}", _0)] Io(#[cause] ::std::io::Error),
 
-    #[fail(display = "{}", _0)]
-    Ods(#[cause] ::ods::OdsError),
-    #[fail(display = "{}", _0)]
-    Xls(#[cause] ::xls::XlsError),
-    #[fail(display = "{}", _0)]
-    Xlsb(#[cause] ::xlsb::XlsbError),
-    #[fail(display = "{}", _0)]
-    Xlsx(#[cause] ::xlsx::XlsxError),
-    #[fail(display = "{}", _0)]
-    Vba(#[cause] ::vba::VbaError),
-    #[fail(display = "{}", _0)]
-    De(#[cause] ::de::DeError),
+    #[fail(display = "{}", _0)] Ods(#[cause] ::ods::OdsError),
+    #[fail(display = "{}", _0)] Xls(#[cause] ::xls::XlsError),
+    #[fail(display = "{}", _0)] Xlsb(#[cause] ::xlsb::XlsbError),
+    #[fail(display = "{}", _0)] Xlsx(#[cause] ::xlsx::XlsxError),
+    #[fail(display = "{}", _0)] Vba(#[cause] ::vba::VbaError),
+    #[fail(display = "{}", _0)] De(#[cause] ::de::DeError),
 
-    #[fail(display = "invalid extension: '{}'", _0)]
-    InvalidExtension(String),
+    #[fail(display = "invalid extension: '{}'", _0)] InvalidExtension(String),
     #[fail(display = "there is no cell at position '{:?}'.\
-                 Minimum position is '{:?}'", try_pos, min_pos)]
-    CellOutOfRange { try_pos: (u32, u32), min_pos: (u32, u32) },
-    #[fail(display = "invalid worksheet name: '{}'", _0)]
-    WorksheetName(String),
+                      Minimum position is '{:?}'",
+           try_pos, min_pos)]
+    CellOutOfRange {
+        try_pos: (u32, u32),
+        min_pos: (u32, u32),
+    },
+    #[fail(display = "invalid worksheet name: '{}'", _0)] WorksheetName(String),
     #[fail(display = "invalid worksheet index: {}", idx)]
-    WorksheetIndex { idx: usize },
-    #[fail(display = "{}", _0)]
-    StaticMsg(&'static str),
+    WorksheetIndex {
+        idx: usize,
+    },
+    #[fail(display = "{}", _0)] StaticMsg(&'static str),
 }
 
 impl_error!(::std::io::Error, CalError, Io);

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -2,34 +2,57 @@
 //! Provides all excel error conversion and description
 //! Also provides `Result` as a alias of `Result<_, Error>
 
-#![allow(missing_docs)]
-
 /// A struct to handle calamine specific errors
 #[derive(Fail, Debug)]
 pub enum Error {
-    #[fail(display = "{}", _0)] Io(#[cause] ::std::io::Error),
+    /// IO error
+    #[fail(display = "{}", _0)]
+    Io(#[cause] ::std::io::Error),
 
-    #[fail(display = "{}", _0)] Ods(#[cause] ::ods::OdsError),
-    #[fail(display = "{}", _0)] Xls(#[cause] ::xls::XlsError),
-    #[fail(display = "{}", _0)] Xlsb(#[cause] ::xlsb::XlsbError),
-    #[fail(display = "{}", _0)] Xlsx(#[cause] ::xlsx::XlsxError),
-    #[fail(display = "{}", _0)] Vba(#[cause] ::vba::VbaError),
-    #[fail(display = "{}", _0)] De(#[cause] ::de::DeError),
+    /// Ods specific error
+    #[fail(display = "{}", _0)]
+    Ods(#[cause] ::ods::OdsError),
+    /// xls specific error
+    #[fail(display = "{}", _0)]
+    Xls(#[cause] ::xls::XlsError),
+    /// xlsb specific error
+    #[fail(display = "{}", _0)]
+    Xlsb(#[cause] ::xlsb::XlsbError),
+    /// xlsx specific error
+    #[fail(display = "{}", _0)]
+    Xlsx(#[cause] ::xlsx::XlsxError),
+    /// vba specific error
+    #[fail(display = "{}", _0)]
+    Vba(#[cause] ::vba::VbaError),
+    /// cfb specific error
+    #[fail(display = "{}", _0)]
+    De(#[cause] ::de::DeError),
 
-    #[fail(display = "invalid extension: '{}'", _0)] InvalidExtension(String),
+    /// Invalid extension: unrecognized input file
+    #[fail(display = "invalid extension: '{}'", _0)]
+    InvalidExtension(String),
+    /// Cell out of range
     #[fail(display = "there is no cell at position '{:?}'.\
                       Minimum position is '{:?}'",
            try_pos, min_pos)]
     CellOutOfRange {
+        /// position tried
         try_pos: (u32, u32),
+        /// minimum position
         min_pos: (u32, u32),
     },
-    #[fail(display = "invalid worksheet name: '{}'", _0)] WorksheetName(String),
+    /// Worksheet does not exist
+    #[fail(display = "invalid worksheet name: '{}'", _0)]
+    WorksheetName(String),
+    /// Worksheet index does not exist
     #[fail(display = "invalid worksheet index: {}", idx)]
     WorksheetIndex {
+        /// worksheet index
         idx: usize,
     },
-    #[fail(display = "{}", _0)] StaticMsg(&'static str),
+    /// General error message
+    #[fail(display = "{}", _0)]
+    StaticMsg(&'static str),
 }
 
 from_err!(::std::io::Error, Error, Io);

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -24,6 +24,9 @@ pub enum Error {
     /// vba specific error
     #[fail(display = "{}", _0)]
     Vba(#[cause] ::vba::VbaError),
+    /// Auto error
+    #[fail(display = "{}", _0)]
+    Auto(#[cause] ::auto::AutoError),
     /// cfb specific error
     #[fail(display = "{}", _0)]
     De(#[cause] ::de::DeError),
@@ -52,7 +55,7 @@ pub enum Error {
     },
     /// General error message
     #[fail(display = "{}", _0)]
-    StaticMsg(&'static str),
+    Msg(&'static str),
 }
 
 from_err!(::std::io::Error, Error, Io);
@@ -62,4 +65,4 @@ from_err!(::xlsb::XlsbError, Error, Xlsb);
 from_err!(::xlsx::XlsxError, Error, Xlsx);
 from_err!(::vba::VbaError, Error, Vba);
 from_err!(::de::DeError, Error, De);
-from_err!(&'static str, Error, StaticMsg);
+from_err!(&'static str, Error, Msg);

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,8 +1,6 @@
-//! `Error` management module
-//! Provides all excel error conversion and description
-//! Also provides `Result` as a alias of `Result<_, Error>
+//! A module to provide a convenient wrapper around all error types
 
-/// A struct to handle calamine specific errors
+/// A struct to handle any error and a message
 #[derive(Fail, Debug)]
 pub enum Error {
     /// IO error
@@ -31,28 +29,6 @@ pub enum Error {
     #[fail(display = "{}", _0)]
     De(#[cause] ::de::DeError),
 
-    /// Invalid extension: unrecognized input file
-    #[fail(display = "invalid extension: '{}'", _0)]
-    InvalidExtension(String),
-    /// Cell out of range
-    #[fail(display = "there is no cell at position '{:?}'.\
-                      Minimum position is '{:?}'",
-           try_pos, min_pos)]
-    CellOutOfRange {
-        /// position tried
-        try_pos: (u32, u32),
-        /// minimum position
-        min_pos: (u32, u32),
-    },
-    /// Worksheet does not exist
-    #[fail(display = "invalid worksheet name: '{}'", _0)]
-    WorksheetName(String),
-    /// Worksheet index does not exist
-    #[fail(display = "invalid worksheet index: {}", idx)]
-    WorksheetIndex {
-        /// worksheet index
-        idx: usize,
-    },
     /// General error message
     #[fail(display = "{}", _0)]
     Msg(&'static str),
@@ -64,5 +40,6 @@ from_err!(::xls::XlsError, Error, Xls);
 from_err!(::xlsb::XlsbError, Error, Xlsb);
 from_err!(::xlsx::XlsxError, Error, Xlsx);
 from_err!(::vba::VbaError, Error, Vba);
+from_err!(::auto::AutoError, Error, Auto);
 from_err!(::de::DeError, Error, De);
 from_err!(&'static str, Error, Msg);

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -20,6 +20,8 @@ pub enum CalError {
     Xlsx(#[cause] ::xlsx::XlsxError),
     #[fail(display = "{}", _0)]
     Vba(#[cause] ::vba::VbaError),
+    #[fail(display = "{}", _0)]
+    De(#[cause] ::de::DeError),
 
     #[fail(display = "invalid extension: '{}'", _0)]
     InvalidExtension(String),
@@ -30,6 +32,8 @@ pub enum CalError {
     WorksheetName(String),
     #[fail(display = "invalid worksheet index: {}", idx)]
     WorksheetIndex { idx: usize },
+    #[fail(display = "{}", _0)]
+    StaticMsg(&'static str),
 }
 
 impl_error!(::std::io::Error, CalError, Io);
@@ -38,3 +42,5 @@ impl_error!(::xls::XlsError, CalError, Xls);
 impl_error!(::xlsb::XlsbError, CalError, Xlsb);
 impl_error!(::xlsx::XlsxError, CalError, Xlsx);
 impl_error!(::vba::VbaError, CalError, Vba);
+impl_error!(::de::DeError, CalError, De);
+impl_error!(&'static str, CalError, StaticMsg);

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,74 +1,40 @@
-//! `Error` management module
-//!
+//! `Error` management module 
 //! Provides all excel error conversion and description
 //! Also provides `Result` as a alias of `Result<_, Error>
 
 #![allow(missing_docs)]
 
-use std::fmt;
+/// A struct to handle calamine specific errors
+#[derive(Fail, Debug)]
+pub enum CalError {
+    #[fail(display = "{}", _0)]
+    Io(#[cause] ::std::io::Error),
 
-use quick_xml::errors::Error as XmlError;
-use serde::de;
+    #[fail(display = "{}", _0)]
+    Ods(#[cause] ::ods::OdsError),
+    #[fail(display = "{}", _0)]
+    Xls(#[cause] ::xls::XlsError),
+    #[fail(display = "{}", _0)]
+    Xlsb(#[cause] ::xlsb::XlsbError),
+    #[fail(display = "{}", _0)]
+    Xlsx(#[cause] ::xlsx::XlsxError),
+    #[fail(display = "{}", _0)]
+    Vba(#[cause] ::vba::VbaError),
 
-use super::CellErrorType;
-
-error_chain! {
-    foreign_links {
-        Io(::std::io::Error);
-        Zip(::zip::result::ZipError);
-        ParseInt(::std::num::ParseIntError);
-        ParseFloat(::std::num::ParseFloatError);
-        Utf8(::std::str::Utf8Error);
-        FromUtf8(::std::string::FromUtf8Error);
-    }
-
-    errors {
-        Xml(err: XmlError) {
-            description("xml error")
-            display("an error occured while parsing xml: {:?}", err)
-        }
-        InvalidExtension(ext: String) {
-            description("invalid extension")
-            display("invalid extension: '{}'", ext)
-        }
-        CellOutOfRange(try_pos: (u32, u32), min_pos: (u32, u32)) {
-            description("no cell found at this position")
-            display("there is no cell at position '{:?}'. Minimum position is '{:?}'",
-                    try_pos, min_pos)
-        }
-        WorksheetName(name: String) {
-            description("invalid worksheet name")
-            display("invalid worksheet name: '{}'", name)
-        }
-        WorksheetIndex(idx: usize) {
-            description("invalid worksheet index")
-            display("invalid worksheet index: {}", idx)
-        }
-        UnexpectedEndOfRow(pos: (u32, u32)) {
-            description("unexpected end of row")
-            display("unexpected end of row at position '{:?}'", pos)
-        }
-        CellError(err: CellErrorType, pos: (u32, u32)) {
-            description("cell error")
-            display("cell error at position '{:?}'", pos)
-        }
-    }
+    #[fail(display = "invalid extension: '{}'", _0)]
+    InvalidExtension(String),
+    #[fail(display = "there is no cell at position '{:?}'.\
+                 Minimum position is '{:?}'", try_pos, min_pos)]
+    CellOutOfRange { try_pos: (u32, u32), min_pos: (u32, u32) },
+    #[fail(display = "invalid worksheet name: '{}'", _0)]
+    WorksheetName(String),
+    #[fail(display = "invalid worksheet index: {}", idx)]
+    WorksheetIndex { idx: usize },
 }
 
-impl From<XmlError> for Error {
-    fn from(err: XmlError) -> Error {
-        ErrorKind::Xml(err).into()
-    }
-}
-
-impl From<(XmlError, usize)> for Error {
-    fn from(err: (XmlError, usize)) -> Error {
-        ErrorKind::Xml(err.0).into()
-    }
-}
-
-impl de::Error for Error {
-    fn custom<T: fmt::Display>(msg: T) -> Self {
-        Error::from(msg.to_string())
-    }
-}
+impl_error!(::std::io::Error, CalError, Io);
+impl_error!(::ods::OdsError, CalError, Ods);
+impl_error!(::xls::XlsError, CalError, Xls);
+impl_error!(::xlsb::XlsbError, CalError, Xlsb);
+impl_error!(::xlsx::XlsxError, CalError, Xlsx);
+impl_error!(::vba::VbaError, CalError, Vba);

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -23,8 +23,6 @@ pub enum Error {
     #[fail(display = "{}", _0)]
     Vba(#[cause] ::vba::VbaError),
     /// Auto error
-    #[fail(display = "{}", _0)]
-    Auto(#[cause] ::auto::AutoError),
     /// cfb specific error
     #[fail(display = "{}", _0)]
     De(#[cause] ::de::DeError),
@@ -40,6 +38,5 @@ from_err!(::xls::XlsError, Error, Xls);
 from_err!(::xlsb::XlsbError, Error, Xlsb);
 from_err!(::xlsx::XlsxError, Error, Xlsx);
 from_err!(::vba::VbaError, Error, Vba);
-from_err!(::auto::AutoError, Error, Auto);
 from_err!(::de::DeError, Error, De);
 from_err!(&'static str, Error, Msg);

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -6,7 +6,7 @@
 
 /// A struct to handle calamine specific errors
 #[derive(Fail, Debug)]
-pub enum CalError {
+pub enum Error {
     #[fail(display = "{}", _0)] Io(#[cause] ::std::io::Error),
 
     #[fail(display = "{}", _0)] Ods(#[cause] ::ods::OdsError),
@@ -32,11 +32,11 @@ pub enum CalError {
     #[fail(display = "{}", _0)] StaticMsg(&'static str),
 }
 
-impl_error!(::std::io::Error, CalError, Io);
-impl_error!(::ods::OdsError, CalError, Ods);
-impl_error!(::xls::XlsError, CalError, Xls);
-impl_error!(::xlsb::XlsbError, CalError, Xlsb);
-impl_error!(::xlsx::XlsxError, CalError, Xlsx);
-impl_error!(::vba::VbaError, CalError, Vba);
-impl_error!(::de::DeError, CalError, De);
-impl_error!(&'static str, CalError, StaticMsg);
+from_err!(::std::io::Error, Error, Io);
+from_err!(::ods::OdsError, Error, Ods);
+from_err!(::xls::XlsError, Error, Xls);
+from_err!(::xlsb::XlsbError, Error, Xlsb);
+from_err!(::xlsx::XlsxError, Error, Xlsx);
+from_err!(::vba::VbaError, Error, Vba);
+from_err!(::de::DeError, Error, De);
+from_err!(&'static str, Error, StaticMsg);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,11 +79,11 @@ mod xlsx;
 mod xls;
 mod cfb;
 mod ods;
+mod auto;
 
 mod de;
-pub mod errors;
+mod errors;
 pub mod vba;
-pub mod auto;
 
 use std::borrow::Cow;
 use std::fmt;
@@ -99,7 +99,8 @@ pub use xls::{Xls, XlsError};
 pub use xlsx::{Xlsx, XlsxError};
 pub use xlsb::{Xlsb, XlsbError};
 pub use ods::{Ods, OdsError};
-pub use auto::{AutoError, AutoReader, Extension, ExtensionReader};
+pub use auto::{open_workbook_auto, Sheets};
+pub use errors::Error;
 
 use vba::VbaProject;
 
@@ -449,8 +450,7 @@ impl<T: CellType> Range<T> {
     /// # Example
     ///
     /// ```
-    /// # use calamine::{Reader, open_workbook, Xlsx, RangeDeserializerBuilder};
-    /// # use calamine::errors::Error;
+    /// # use calamine::{Reader, Error, open_workbook, Xlsx, RangeDeserializerBuilder};
     /// # fn main() { example().unwrap(); }
     /// fn example() -> Result<(), Error> {
     ///     let path = format!("{}/tests/tempurature.xlsx", env!("CARGO_MANIFEST_DIR"));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,15 +58,15 @@
 //! }
 //! ```
 #![deny(missing_docs)]
-#![recursion_limit="128"]
+#![recursion_limit = "128"]
 
 extern crate byteorder;
 extern crate encoding_rs;
 #[macro_use]
 extern crate failure;
+extern crate quick_xml;
 #[macro_use]
 extern crate serde;
-extern crate quick_xml;
 extern crate zip;
 
 #[macro_use]
@@ -94,7 +94,7 @@ use std::path::Path;
 use serde::de::DeserializeOwned;
 
 pub use datatype::DataType;
-pub use de::{DeError, RangeDeserializerBuilder, RangeDeserializer, ToCellDeserializer};
+pub use de::{DeError, RangeDeserializer, RangeDeserializerBuilder, ToCellDeserializer};
 use errors::CalError;
 
 use vba::VbaProject;
@@ -138,7 +138,10 @@ impl fmt::Display for CellErrorType {
 }
 
 /// File types
-enum FileType<RS> where RS: Read + Seek {
+enum FileType<RS>
+where
+    RS: Read + Seek,
+{
     /// Compound File Binary Format [MS-CFB] (xls, xla)
     Xls(xls::Xls<RS>),
     /// Regular xml zipped file (xlsx, xlsm, xlam)
@@ -161,7 +164,10 @@ struct Metadata {
 }
 
 /// A wrapper struct over the spreadsheet file
-pub struct Sheets<RS> where RS: Read + Seek {
+pub struct Sheets<RS>
+where
+    RS: Read + Seek,
+{
     file: FileType<RS>,
     metadata: Metadata,
 }
@@ -185,7 +191,10 @@ macro_rules! inner {
     }};
 }
 
-impl<RS> Sheets<RS> where RS: Read + Seek {
+impl<RS> Sheets<RS>
+where
+    RS: Read + Seek,
+{
     /// Opens a new workbook from a file.
     ///
     /// # Examples
@@ -214,7 +223,10 @@ impl<RS> Sheets<RS> where RS: Read + Seek {
 
     /// Creates a new workbook from a reader.
     /// ```
-    pub fn new(reader: RS, extension: &str) -> Result<Sheets<RS>, CalError> where RS: Read + Seek {
+    pub fn new(reader: RS, extension: &str) -> Result<Sheets<RS>, CalError>
+    where
+        RS: Read + Seek,
+    {
         let filetype = match extension {
             "xls" | "xla" => FileType::Xls(xls::Xls::new(reader)?),
             "xlsx" | "xlsm" | "xlam" => FileType::Xlsx(xlsx::Xlsx::new(reader)?),
@@ -340,7 +352,10 @@ impl<RS> Sheets<RS> where RS: Read + Seek {
 // FIXME `Reader` must only be seek `Seek` for `Xls::xls`. Because of the present API this limits
 // the kinds of readers (other) data in formats can be read from.
 /// A trait to share spreadsheets reader functions accross different `FileType`s
-trait Reader<RS>: Sized where RS: Read + Seek {
+trait Reader<RS>: Sized
+where
+    RS: Read + Seek,
+{
     /// Creates a new instance.
     fn new(reader: RS) -> Result<Self, CalError>;
     /// Does the workbook contain a vba project
@@ -506,7 +521,10 @@ impl<T: CellType> Range<T> {
     /// ```
     pub fn set_value(&mut self, absolute_position: (u32, u32), value: T) -> Result<(), CalError> {
         if self.start > absolute_position {
-            return Err(CalError::CellOutOfRange { try_pos: absolute_position, min_pos: self.start });
+            return Err(CalError::CellOutOfRange {
+                try_pos: absolute_position,
+                min_pos: self.start,
+            });
         }
 
         // check if we need to change range dimension (strangely happens sometimes ...)
@@ -561,8 +579,8 @@ impl<T: CellType> Range<T> {
     /// Panics if indexes are out of range bounds
     pub fn get_value(&self, absolute_position: (u32, u32)) -> &T {
         assert!(absolute_position <= self.end);
-        let idx = (absolute_position.0 - self.start.0) as usize * self.width() +
-            (absolute_position.1 - self.start.1) as usize;
+        let idx = (absolute_position.0 - self.start.0) as usize * self.width()
+            + (absolute_position.1 - self.start.1) as usize;
         &self.inner[idx]
     }
 
@@ -622,8 +640,9 @@ impl<T: CellType> Range<T> {
     /// }
     /// ```
     pub fn deserialize<'a, D>(&'a self) -> Result<RangeDeserializer<'a, T, D>, DeError>
-        where T: ToCellDeserializer<'a>,
-              D: DeserializeOwned,
+    where
+        T: ToCellDeserializer<'a>,
+        D: DeserializeOwned,
     {
         RangeDeserializerBuilder::new().from_range(self)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -600,10 +600,11 @@ impl<T: CellType> Range<T> {
     /// # Example
     ///
     /// ```
-    /// # use calamine::{Result, Sheets, RangeDeserializerBuilder};
+    /// # use calamine::{Sheets, RangeDeserializerBuilder};
+    /// # use calamine::errors::CalError;
     /// # use std::fs::File;
     /// # fn main() { example().unwrap(); }
-    /// fn example() -> Result<()> {
+    /// fn example() -> Result<(), CalError> {
     ///     let path = format!("{}/tests/tempurature.xlsx", env!("CARGO_MANIFEST_DIR"));
     ///     let mut workbook = Sheets::<File>::open(path)?;
     ///     let mut sheet = workbook.worksheet_range("Sheet1")?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,7 +75,6 @@ extern crate log;
 #[macro_use]
 mod utils;
 mod datatype;
-mod errors;
 mod xlsb;
 mod xlsx;
 mod xls;
@@ -83,6 +82,7 @@ mod cfb;
 mod ods;
 
 mod de;
+pub mod errors;
 pub mod vba;
 
 use std::borrow::Cow;
@@ -690,33 +690,4 @@ impl<'a, T: 'a + CellType> Iterator for Rows<'a, T> {
     fn next(&mut self) -> Option<Self::Item> {
         self.inner.as_mut().and_then(|c| c.next())
     }
-}
-
-#[test]
-fn test_parse_error() {
-    assert_eq!(
-        CellErrorType::from_str("#DIV/0!").unwrap(),
-        CellErrorType::Div0
-    );
-    assert_eq!(CellErrorType::from_str("#N/A").unwrap(), CellErrorType::NA);
-    assert_eq!(
-        CellErrorType::from_str("#NAME?").unwrap(),
-        CellErrorType::Name
-    );
-    assert_eq!(
-        CellErrorType::from_str("#NULL!").unwrap(),
-        CellErrorType::Null
-    );
-    assert_eq!(
-        CellErrorType::from_str("#NUM!").unwrap(),
-        CellErrorType::Num
-    );
-    assert_eq!(
-        CellErrorType::from_str("#REF!").unwrap(),
-        CellErrorType::Ref
-    );
-    assert_eq!(
-        CellErrorType::from_str("#VALUE!").unwrap(),
-        CellErrorType::Value
-    );
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,6 +94,10 @@ use serde::de::DeserializeOwned;
 pub use datatype::DataType;
 pub use de::{DeError, RangeDeserializer, RangeDeserializerBuilder, ToCellDeserializer};
 pub use errors::Error;
+pub use xls::{Xls, XlsError};
+pub use xlsx::{Xlsx, XlsxError};
+pub use xlsb::{Xlsb, XlsbError};
+pub use ods::{Ods, OdsError};
 
 use vba::VbaProject;
 

--- a/src/ods.rs
+++ b/src/ods.rs
@@ -25,22 +25,30 @@ type OdsReader<'a> = XmlReader<BufReader<ZipFile<'a>>>;
 #[derive(Debug, Fail)]
 pub enum OdsError {
     /// Io error
-    #[fail(display = "{}", _0)] Io(#[cause] ::std::io::Error),
+    #[fail(display = "{}", _0)]
+    Io(#[cause] ::std::io::Error),
     /// Zip error
-    #[fail(display = "{}", _0)] Zip(#[cause] ::zip::result::ZipError),
+    #[fail(display = "{}", _0)]
+    Zip(#[cause] ::zip::result::ZipError),
     /// Xml error
-    #[fail(display = "{}", _0)] Xml(#[cause] ::quick_xml::errors::Error),
+    #[fail(display = "{}", _0)]
+    Xml(#[cause] ::quick_xml::errors::Error),
     /// Error while parsing string
-    #[fail(display = "{}", _0)] Parse(#[cause] ::std::string::ParseError),
+    #[fail(display = "{}", _0)]
+    Parse(#[cause] ::std::string::ParseError),
     /// Error while parsing float
-    #[fail(display = "{}", _0)] ParseFloat(#[cause] ::std::num::ParseFloatError),
+    #[fail(display = "{}", _0)]
+    ParseFloat(#[cause] ::std::num::ParseFloatError),
 
     /// Invalid MIME
-    #[fail(display = "Invalid MIME type: {:?}", _0)] InvalidMime(Vec<u8>),
+    #[fail(display = "Invalid MIME type: {:?}", _0)]
+    InvalidMime(Vec<u8>),
     /// File not found
-    #[fail(display = "Cannot find '{}' file", _0)] FileNotFound(&'static str),
+    #[fail(display = "Cannot find '{}' file", _0)]
+    FileNotFound(&'static str),
     /// Unexpected end of file
-    #[fail(display = "Expecting {} found EOF", _0)] Eof(&'static str),
+    #[fail(display = "Expecting {} found EOF", _0)]
+    Eof(&'static str),
     /// Unexpexted error
     #[fail(display = "Expecting {} found {}", expected, found)]
     Mismatch {

--- a/src/ods.rs
+++ b/src/ods.rs
@@ -116,15 +116,9 @@ impl<RS: Read + Seek> Reader for Ods<RS> {
         })
     }
 
-    /// Does the workbook contain a vba project
-    fn has_vba(&mut self) -> bool {
-        // TODO: implement code parsing
-        false
-    }
-
     /// Gets `VbaProject`
-    fn vba_project(&mut self) -> Result<Cow<VbaProject>, OdsError> {
-        unimplemented!();
+    fn vba_project(&mut self) -> Option<Result<Cow<VbaProject>, OdsError>> {
+        None
     }
 
     /// Read sheets from workbook.xml and get their corresponding path from relationships
@@ -133,19 +127,13 @@ impl<RS: Read + Seek> Reader for Ods<RS> {
     }
 
     /// Read worksheet data in corresponding worksheet path
-    fn worksheet_range(&mut self, name: &str) -> Result<Option<Range<DataType>>, OdsError> {
-        if let Some(r) = self.sheets.get(name) {
-            return Ok(Some(r.0.to_owned()));
-        }
-        Ok(None)
+    fn worksheet_range(&mut self, name: &str) -> Option<Result<Range<DataType>, OdsError>> {
+        self.sheets.get(name).map(|r| Ok(r.0.to_owned()))
     }
 
     /// Read worksheet data in corresponding worksheet path
-    fn worksheet_formula(&mut self, name: &str) -> Result<Option<Range<String>>, OdsError> {
-        if let Some(r) = self.sheets.get(name) {
-            return Ok(Some(r.1.to_owned()));
-        }
-        Ok(None)
+    fn worksheet_formula(&mut self, name: &str) -> Option<Result<Range<String>, OdsError>> {
+        self.sheets.get(name).map(|r| Ok(r.1.to_owned()))
     }
 }
 

--- a/src/ods.rs
+++ b/src/ods.rs
@@ -24,18 +24,29 @@ type OdsReader<'a> = XmlReader<BufReader<ZipFile<'a>>>;
 /// An enum for ods specific errors
 #[derive(Debug, Fail)]
 pub enum OdsError {
+    /// Io error
     #[fail(display = "{}", _0)] Io(#[cause] ::std::io::Error),
+    /// Zip error
     #[fail(display = "{}", _0)] Zip(#[cause] ::zip::result::ZipError),
+    /// Xml error
     #[fail(display = "{}", _0)] Xml(#[cause] ::quick_xml::errors::Error),
+    /// Error while parsing string
     #[fail(display = "{}", _0)] Parse(#[cause] ::std::string::ParseError),
+    /// Error while parsing float
     #[fail(display = "{}", _0)] ParseFloat(#[cause] ::std::num::ParseFloatError),
 
+    /// Invalid MIME
     #[fail(display = "Invalid MIME type: {:?}", _0)] InvalidMime(Vec<u8>),
+    /// File not found
     #[fail(display = "Cannot find '{}' file", _0)] FileNotFound(&'static str),
+    /// Unexpected end of file
     #[fail(display = "Expecting {} found EOF", _0)] Eof(&'static str),
+    /// Unexpexted error
     #[fail(display = "Expecting {} found {}", expected, found)]
     Mismatch {
+        /// Expected
         expected: &'static str,
+        /// Found
         found: String,
     },
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2,7 +2,7 @@
 
 use encoding_rs::{self, Encoding};
 
-macro_rules! impl_error {
+macro_rules! from_err {
     ($from:ty, $to:tt, $var:tt) => {
         impl From<$from> for $to {
             fn from(e: $from) -> $to {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2,6 +2,16 @@
 
 use encoding_rs::{self, Encoding};
 
+macro_rules! impl_error {
+    ($from:ty, $to:tt, $var:tt) => {
+        impl From<$from> for $to {
+            fn from(e: $from) -> $to {
+                $to::$var(e)
+            }
+        }
+    }
+}
+
 /// Converts a &[u8] into a &[u32]
 pub fn to_u32(s: &[u8]) -> &[u32] {
     assert_eq!(s.len() % 4, 0);

--- a/src/vba.rs
+++ b/src/vba.rs
@@ -32,7 +32,7 @@ pub enum VbaError {
         /// error type
         typ: &'static str,
         /// value found
-        val: u16
+        val: u16,
     },
     /// Invalid libid format
     #[fail(display = "Unexpected libid format")]
@@ -43,7 +43,7 @@ pub enum VbaError {
         /// expected record id
         expected: u16,
         /// record if found
-        found: u16
+        found: u16,
     },
 }
 
@@ -218,7 +218,12 @@ impl Reference {
                             check_record(0x0030, stream)?;
                         }
                         0x0030 => (),
-                        e => return Err(VbaError::Unknown { typ: "token in reference control", val: e }),
+                        e => {
+                            return Err(VbaError::Unknown {
+                                typ: "token in reference control",
+                                val: e,
+                            })
+                        }
                     }
                     *stream = &stream[4..];
                     reference.set_libid(stream, encoding)?;
@@ -245,7 +250,12 @@ impl Reference {
                     read_variable_record(stream, 1)?; // project libid relative
                     *stream = &stream[6..];
                 }
-                c => return Err(VbaError::Unknown { typ: "check id", val: c }),
+                c => {
+                    return Err(VbaError::Unknown {
+                        typ: "check id",
+                        val: c,
+                    })
+                }
             }
         }
 
@@ -407,7 +417,10 @@ fn check_record(id: u16, r: &mut &[u8]) -> Result<(), VbaError> {
     debug!("check record {:x}", id);
     let record_id = r.read_u16::<LittleEndian>()?;
     if record_id != id {
-        Err(VbaError::InvalidRecordId { expected: id, found: record_id })
+        Err(VbaError::InvalidRecordId {
+            expected: id,
+            found: record_id,
+        })
     } else {
         Ok(())
     }

--- a/src/vba.rs
+++ b/src/vba.rs
@@ -118,10 +118,10 @@ impl VbaProject {
     ///
     /// # Examples
     /// ```
-    /// use calamine::{Sheets, Xlsx};
+    /// use calamine::{Reader, open_workbook, Xlsx};
     ///
     /// # let path = format!("{}/tests/vba.xlsm", env!("CARGO_MANIFEST_DIR"));
-    /// let mut xl = Sheets::<Xlsx<_>>::open(path).expect("Cannot find excel file");
+    /// let mut xl: Xlsx<_> = open_workbook(path).expect("Cannot find excel file");
     /// let mut vba = xl.vba_project().expect("Cannot find vba project");
     /// let vba = vba.to_mut();
     /// let modules = vba.get_module_names().into_iter()

--- a/src/vba.rs
+++ b/src/vba.rs
@@ -118,11 +118,10 @@ impl VbaProject {
     ///
     /// # Examples
     /// ```
-    /// use calamine::Sheets;
-    /// use std::fs::File;
+    /// use calamine::{Sheets, Xlsx};
     ///
     /// # let path = format!("{}/tests/vba.xlsm", env!("CARGO_MANIFEST_DIR"));
-    /// let mut xl = Sheets::<File>::open(path).expect("Cannot find excel file");
+    /// let mut xl = Sheets::<Xlsx<_>>::open(path).expect("Cannot find excel file");
     /// let mut vba = xl.vba_project().expect("Cannot find vba project");
     /// let vba = vba.to_mut();
     /// let modules = vba.get_module_names().into_iter()

--- a/src/vba.rs
+++ b/src/vba.rs
@@ -122,14 +122,15 @@ impl VbaProject {
     ///
     /// # let path = format!("{}/tests/vba.xlsm", env!("CARGO_MANIFEST_DIR"));
     /// let mut xl: Xlsx<_> = open_workbook(path).expect("Cannot find excel file");
-    /// let mut vba = xl.vba_project().expect("Cannot find vba project");
-    /// let vba = vba.to_mut();
-    /// let modules = vba.get_module_names().into_iter()
-    ///                  .map(|s| s.to_string()).collect::<Vec<_>>();
-    /// for m in modules {
-    ///     println!("Module {}:", m);
-    ///     println!("{}", vba.get_module(&m)
-    ///                       .expect(&format!("cannot read {:?} module", m)));
+    /// if let Some(Ok(mut vba)) = xl.vba_project() {
+    ///     let vba = vba.to_mut();
+    ///     let modules = vba.get_module_names().into_iter()
+    ///                      .map(|s| s.to_string()).collect::<Vec<_>>();
+    ///     for m in modules {
+    ///         println!("Module {}:", m);
+    ///         println!("{}", vba.get_module(&m)
+    ///                           .expect(&format!("cannot read {:?} module", m)));
+    ///     }
     /// }
     /// ```
     pub fn get_module(&self, name: &str) -> Result<String, VbaError> {

--- a/src/vba.rs
+++ b/src/vba.rs
@@ -47,8 +47,8 @@ pub enum VbaError {
     },
 }
 
-impl_error!(::cfb::CfbError, VbaError, Cfb);
-impl_error!(::std::io::Error, VbaError, Io);
+from_err!(::cfb::CfbError, VbaError, Cfb);
+from_err!(::std::io::Error, VbaError, Io);
 
 /// A struct for managing VBA reading
 #[allow(dead_code)]

--- a/src/xls.rs
+++ b/src/xls.rs
@@ -13,14 +13,18 @@ use utils::{push_column, read_slice, read_u16, read_u32};
 /// An enum to handle Xls specific errors
 pub enum XlsError {
     /// Io error
-    #[fail(display = "{}", _0)] Io(#[cause] ::std::io::Error),
+    #[fail(display = "{}", _0)]
+    Io(#[cause] ::std::io::Error),
     /// Cfb error
-    #[fail(display = "{}", _0)] Cfb(#[cause] ::cfb::CfbError),
+    #[fail(display = "{}", _0)]
+    Cfb(#[cause] ::cfb::CfbError),
     /// Vba error
-    #[fail(display = "{}", _0)] Vba(#[cause] ::vba::VbaError),
+    #[fail(display = "{}", _0)]
+    Vba(#[cause] ::vba::VbaError),
 
     /// Cannot parse formula, stack is too short
-    #[fail(display = "Invalid stack length")] StackLen,
+    #[fail(display = "Invalid stack length")]
+    StackLen,
     /// Unrecognized data
     #[fail(display = "Unrecognized {}: 0x{:0X}", typ, val)]
     Unrecognized {
@@ -30,7 +34,8 @@ pub enum XlsError {
         val: u8,
     },
     /// Workook is password protected
-    #[fail(display = "Workbook is password protected")] Password,
+    #[fail(display = "Workbook is password protected")]
+    Password,
     /// Invalid length
     #[fail(display = "Invalid {} length, expected {} maximum, found {}", typ, expected, found)]
     Len {
@@ -45,7 +50,8 @@ pub enum XlsError {
     #[fail(display = "Continued record too short while reading extended string")]
     ContinueRecordTooShort,
     /// End of stream
-    #[fail(display = "End of stream for {}", _0)] EoStream(&'static str),
+    #[fail(display = "End of stream for {}", _0)]
+    EoStream(&'static str),
 
     /// Invalid Formula
     #[fail(display = "Invalid formula (stack size: {})", stack_size)]
@@ -54,11 +60,14 @@ pub enum XlsError {
         stack_size: usize,
     },
     /// Invalid or unknown iftab
-    #[fail(display = "Invalid iftab {:X}", _0)] IfTab(usize),
+    #[fail(display = "Invalid iftab {:X}", _0)]
+    IfTab(usize),
     /// Invalid etpg
-    #[fail(display = "Invalid etpg {:X}", _0)] Etpg(u8),
+    #[fail(display = "Invalid etpg {:X}", _0)]
+    Etpg(u8),
     /// No vba project
-    #[fail(display = "No VBA project")] NoVba,
+    #[fail(display = "No VBA project")]
+    NoVba,
 }
 
 from_err!(::std::io::Error, XlsError, Io);

--- a/src/xls.rs
+++ b/src/xls.rs
@@ -4,11 +4,42 @@ use std::io::{Read, Seek};
 use std::borrow::Cow;
 use std::cmp::min;
 
-use errors::*;
 use {Cell, CellErrorType, DataType, Metadata, Range, Reader};
 use vba::VbaProject;
 use cfb::{Cfb, XlsEncoding};
 use utils::{push_column, read_slice, read_u16, read_u32};
+use errors::CalError;
+
+#[derive(Fail, Debug)]
+/// An enum to handle Xls specific errors
+pub enum XlsError {
+    #[fail(display = "{}", _0)]
+    Cfb(#[cause] ::cfb::CfbError),
+
+    #[fail(display = "Invalid stack length")]
+    StackLen,
+    #[fail(display = "Unrecognized {}: 0x{:0X}", typ, val)]
+    Unrecognized { typ: &'static str, val: u8 },
+    #[fail(display = "Workbook is password protected")]
+    Password,
+    #[fail(display = "Invalid {} length, expected {} maximum, found {}", typ, expected, found)]
+    Len { expected: usize, found: usize, typ: &'static str },
+    #[fail(display = "Continued record too short while reading extended string")]
+    ContinueRecordTooShort,
+    #[fail(display = "End of stream for {}", _0)]
+    EoStream(&'static str),
+
+    #[fail(display = "Invalid formula (stack size: {})", stack_size)]
+    InvalidFormula { stack_size: usize },
+    #[fail(display = "Invalid iftab {:X}", _0)]
+    IfTab(usize),
+    #[fail(display = "Invalid etpg {:X}", _0)]
+    Etpg(u8),
+    #[fail(display = "No VBA project")]
+    NoVba,
+}
+
+impl_error!(::cfb::CfbError, XlsError, Cfb);
 
 enum SheetsState<RS> where RS: Read + Seek {
     NotParsed(RS, Cfb),
@@ -22,11 +53,11 @@ pub struct Xls<RS> where RS: Read + Seek {
 }
 
 impl<RS> Reader<RS> for Xls<RS> where RS: Read + Seek {
-    fn new(mut reader: RS) -> Result<Self> where RS: Read + Seek {
+    fn new(mut reader: RS) -> Result<Self, CalError> where RS: Read + Seek {
         let mut cfb = {
             let offset_end = reader.seek(SeekFrom::End(0))? as usize;
             reader.seek(SeekFrom::Start(0))?;
-            Cfb::new(&mut reader, offset_end)?
+            Cfb::new(&mut reader, offset_end).map_err(XlsError::Cfb)?
         };
 
         // Reads vba once for all (better than reading all worksheets once for all)
@@ -46,15 +77,15 @@ impl<RS> Reader<RS> for Xls<RS> where RS: Read + Seek {
         self.vba.is_some()
     }
 
-    fn vba_project(&mut self) -> Result<Cow<VbaProject>> {
-        self.vba
+    fn vba_project(&mut self) -> Result<Cow<VbaProject>, CalError> {
+        Ok(self.vba
             .as_ref()
             .map(|vba| Cow::Borrowed(vba))
-            .ok_or_else(|| "No vba project".into())
+            .ok_or(XlsError::NoVba)?)
     }
 
     /// Parses Workbook stream, no need for the relationships variable
-    fn initialize(&mut self) -> Result<Metadata> {
+    fn initialize(&mut self) -> Result<Metadata, CalError> {
         let defined_names = self.parse_workbook()?;
         let sheets = match self.sheets {
             SheetsState::NotParsed(_, _) => unreachable!(),
@@ -66,29 +97,29 @@ impl<RS> Reader<RS> for Xls<RS> where RS: Read + Seek {
         })
     }
 
-    fn read_worksheet_range(&mut self, name: &str) -> Result<Range<DataType>> {
+    fn read_worksheet_range(&mut self, name: &str) -> Result<Range<DataType>, CalError> {
         let _ = self.parse_workbook()?;
         match self.sheets {
             SheetsState::NotParsed(_, _) => unreachable!(),
             SheetsState::Parsed(ref shs) => shs.get(name)
-                .ok_or_else(|| format!("Sheet '{}' does not exist", name).into())
-                .map(|r| r.0.clone()),
+                .map(|r| r.0.clone())
+                .ok_or(CalError::WorksheetName(name.into())),
         }
     }
 
-    fn read_worksheet_formula(&mut self, name: &str) -> Result<Range<String>> {
+    fn read_worksheet_formula(&mut self, name: &str) -> Result<Range<String>, CalError> {
         let _ = self.parse_workbook()?;
         match self.sheets {
             SheetsState::NotParsed(_, _) => unreachable!(),
             SheetsState::Parsed(ref shs) => shs.get(name)
-                .ok_or_else(|| format!("Sheet '{}' does not exist", name).into())
-                .map(|r| r.1.clone()),
+                .map(|r| r.1.clone())
+                .ok_or(CalError::WorksheetName(name.into()))
         }
     }
 }
 
 impl<RS> Xls<RS> where RS: Read + Seek {
-    fn parse_workbook(&mut self) -> Result<Vec<(String, String)>> {
+    fn parse_workbook(&mut self) -> Result<Vec<(String, String)>, XlsError> {
         // gets workbook and worksheets stream, or early exit
         let stream = match self.sheets {
             SheetsState::NotParsed(ref mut reader, ref mut cfb) => {
@@ -109,9 +140,7 @@ impl<RS> Xls<RS> where RS: Read + Seek {
             for record in records {
                 let mut r = record?;
                 match r.typ {
-                    0x0012 => if read_u16(r.data) != 0 {
-                        bail!("Workbook is password protected");
-                    },
+                    0x0012 if read_u16(r.data) != 0 => return Err(XlsError::Password),
                     0x0042 => encoding = XlsEncoding::from_codepage(read_u16(r.data))?, // CodePage
                     0x013D => {
                         let sheet_len = r.data.len() / 2;
@@ -127,7 +156,7 @@ impl<RS> Xls<RS> where RS: Read + Seek {
                         let mut cch = r.data[3] as usize;
                         let cce = read_u16(&r.data[4..]) as usize;
                         let name =
-                            read_unicode_string_no_cch(&mut encoding, &r.data[14..], &mut cch)?;
+                            read_unicode_string_no_cch(&mut encoding, &r.data[14..], &mut cch);
                         let rgce = &r.data[r.data.len() - cce..];
                         let formula = parse_defined_names(rgce)?;
                         defined_names.push((name, formula));
@@ -222,15 +251,15 @@ impl<RS> Xls<RS> where RS: Read + Seek {
 }
 
 /// BoundSheet8 [MS-XLS 2.4.28]
-fn parse_sheet_name(r: &mut Record, encoding: &mut XlsEncoding) -> Result<(usize, String)> {
+fn parse_sheet_name(r: &mut Record, encoding: &mut XlsEncoding) -> Result<(usize, String), XlsError> {
     let pos = read_u32(r.data) as usize;
     r.data = &r.data[6..];
     parse_short_string(r, encoding).map(|s| (pos, s))
 }
 
-fn parse_number(r: &[u8]) -> Result<Cell<DataType>> {
+fn parse_number(r: &[u8]) -> Result<Cell<DataType>, XlsError> {
     if r.len() < 14 {
-        bail!("Invalid number length");
+        return Err(XlsError::Len { typ: "number", expected: 14, found: r.len() });
     }
     let row = read_u16(r) as u32;
     let col = read_u16(&r[2..]) as u32;
@@ -238,9 +267,9 @@ fn parse_number(r: &[u8]) -> Result<Cell<DataType>> {
     Ok(Cell::new((row, col), DataType::Float(v)))
 }
 
-fn parse_bool_err(r: &[u8]) -> Result<Cell<DataType>> {
+fn parse_bool_err(r: &[u8]) -> Result<Cell<DataType>, XlsError> {
     if r.len() < 8 {
-        bail!("Invalid BoolErr length");
+        return Err(XlsError::Len { typ: "BoolErr", expected: 8, found: r.len() });
     }
     let row = read_u16(r);
     let col = read_u16(&r[2..]);
@@ -255,16 +284,16 @@ fn parse_bool_err(r: &[u8]) -> Result<Cell<DataType>> {
             0x24 => DataType::Error(CellErrorType::Num),
             0x2A => DataType::Error(CellErrorType::NA),
             0x2B => DataType::Error(CellErrorType::GettingData),
-            e => bail!("Unrecognized error {:x}", e),
+            e => return Err(XlsError::Unrecognized { typ: "error", val: e }),
         },
-        e => bail!("Unrecognized fError {:x}", e),
+        e => return Err(XlsError::Unrecognized { typ: "fError", val: e }),
     };
     Ok(Cell::new((row as u32, col as u32), v))
 }
 
-fn parse_rk(r: &[u8]) -> Result<Cell<DataType>> {
+fn parse_rk(r: &[u8]) -> Result<Cell<DataType>, XlsError> {
     if r.len() < 10 {
-        bail!("Invalid rk length");
+        return Err(XlsError::Len { typ: "rk", expected: 10, found: r.len() });
     }
     let row = read_u16(r);
     let col = read_u16(&r[2..]);
@@ -286,9 +315,9 @@ fn parse_rk(r: &[u8]) -> Result<Cell<DataType>> {
 }
 
 /// ShortXLUnicodeString [MS-XLS 2.5.240]
-fn parse_short_string(r: &mut Record, encoding: &mut XlsEncoding) -> Result<String> {
+fn parse_short_string(r: &mut Record, encoding: &mut XlsEncoding) -> Result<String, XlsError> {
     if r.data.len() < 2 {
-        bail!("Invalid short string length");
+        return Err(XlsError::Len { typ: "short string", expected: 2, found: r.data.len() });
     }
     let cch = r.data[0] as usize;
     if let Some(ref mut b) = encoding.high_byte {
@@ -296,13 +325,13 @@ fn parse_short_string(r: &mut Record, encoding: &mut XlsEncoding) -> Result<Stri
     }
     r.data = &r.data[2..];
     let mut s = String::with_capacity(cch);
-    let _ = encoding.decode_to(r.data, cch, &mut s)?;
+    let _ = encoding.decode_to(r.data, cch, &mut s);
     Ok(s)
 }
 
-fn parse_label_sst(r: &[u8], strings: &[String]) -> Result<Cell<DataType>> {
+fn parse_label_sst(r: &[u8], strings: &[String]) -> Result<Cell<DataType>, XlsError> {
     if r.len() < 10 {
-        bail!("Invalid short string length");
+        return Err(XlsError::Len { typ: "label sst", expected: 10, found: r.len() });
     }
     let row = read_u16(r);
     let col = read_u16(&r[2..]);
@@ -313,7 +342,7 @@ fn parse_label_sst(r: &[u8], strings: &[String]) -> Result<Cell<DataType>> {
     ))
 }
 
-fn parse_dimensions(r: &[u8]) -> Result<((u32, u32), (u32, u32))> {
+fn parse_dimensions(r: &[u8]) -> Result<((u32, u32), (u32, u32)), XlsError> {
     let (rf, rl, cf, cl) = match r.len() {
         10 => (
             read_u16(&r[0..2]) as u32,
@@ -327,7 +356,7 @@ fn parse_dimensions(r: &[u8]) -> Result<((u32, u32), (u32, u32))> {
             read_u16(&r[8..10]) as u32,
             read_u16(&r[10..12]) as u32,
         ),
-        _ => bail!("Invalid dimensions lengths"),
+        _ => return Err(XlsError::Len { typ: "dimensions", expected: 14, found: r.len() }),
     };
     if (1, 1) <= (rl, cl) {
         Ok(((rf, cf), (rl - 1, cl - 1)))
@@ -336,9 +365,9 @@ fn parse_dimensions(r: &[u8]) -> Result<((u32, u32), (u32, u32))> {
     }
 }
 
-fn parse_sst(r: &mut Record, encoding: &mut XlsEncoding) -> Result<Vec<String>> {
+fn parse_sst(r: &mut Record, encoding: &mut XlsEncoding) -> Result<Vec<String>, XlsError> {
     if r.data.len() < 8 {
-        bail!("Invalid sst length");
+        return Err(XlsError::Len { typ: "sst", expected: 8, found: r.data.len() });
     }
     let len = read_slice::<i32>(&r.data[4..]) as usize;
     let mut sst = Vec::with_capacity(len);
@@ -349,9 +378,9 @@ fn parse_sst(r: &mut Record, encoding: &mut XlsEncoding) -> Result<Vec<String>> 
     Ok(sst)
 }
 
-fn read_rich_extended_string(r: &mut Record, encoding: &mut XlsEncoding) -> Result<String> {
+fn read_rich_extended_string(r: &mut Record, encoding: &mut XlsEncoding) -> Result<String, XlsError> {
     if r.data.is_empty() && !r.continue_record() || r.data.len() < 3 {
-        bail!("Invalid rich extended string length");
+        return Err(XlsError::Len { typ: "rick extended string", expected: 3, found: r.data.len() } );
     }
 
     let str_len = read_u16(r.data) as usize;
@@ -380,7 +409,7 @@ fn read_rich_extended_string(r: &mut Record, encoding: &mut XlsEncoding) -> Resu
 
     while unused_len > 0 {
         if r.data.is_empty() && !r.continue_record() {
-            bail!("continued record too short while reading extended string");
+            return Err(XlsError::ContinueRecordTooShort);
         }
         let l = min(unused_len, r.data.len());
         let (_, next) = r.data.split_at(l);
@@ -391,10 +420,10 @@ fn read_rich_extended_string(r: &mut Record, encoding: &mut XlsEncoding) -> Resu
     Ok(s)
 }
 
-fn read_dbcs(encoding: &mut XlsEncoding, mut len: usize, r: &mut Record) -> Result<String> {
+fn read_dbcs(encoding: &mut XlsEncoding, mut len: usize, r: &mut Record) -> Result<String, XlsError> {
     let mut s = String::with_capacity(len);
     while len > 0 {
-        let (l, at) = encoding.decode_to(r.data, len, &mut s)?;
+        let (l, at) = encoding.decode_to(r.data, len, &mut s);
         r.data = &r.data[at..];
         len -= l;
         if len > 0 {
@@ -404,7 +433,7 @@ fn read_dbcs(encoding: &mut XlsEncoding, mut len: usize, r: &mut Record) -> Resu
                 }
                 r.data = &r.data[1..];
             } else {
-                bail!("Cannot decode entire dbcs stream");
+                return Err(XlsError::EoStream("dbcs"));
             }
         }
     }
@@ -415,7 +444,7 @@ fn read_unicode_string_no_cch(
     encoding: &mut XlsEncoding,
     buf: &[u8],
     len: &mut usize,
-) -> Result<String> {
+) -> String {
     let mut s = String::new();
     if let Some(ref mut b) = encoding.high_byte {
         *b = buf[0] & 0x1 != 0;
@@ -423,8 +452,8 @@ fn read_unicode_string_no_cch(
             *len *= 2;
         }
     }
-    let _ = encoding.decode_to(&buf[1..*len + 1], *len, &mut s)?;
-    Ok(s)
+    let _ = encoding.decode_to(&buf[1..*len + 1], *len, &mut s);
+    s
 }
 
 struct Record<'a> {
@@ -452,21 +481,19 @@ struct RecordIter<'a> {
 }
 
 impl<'a> Iterator for RecordIter<'a> {
-    type Item = Result<Record<'a>>;
+    type Item = Result<Record<'a>, XlsError>;
     fn next(&mut self) -> Option<Self::Item> {
         if self.stream.len() < 4 {
             return if self.stream.is_empty() {
                 None
             } else {
-                Some(Err(
-                    "Expecting record type and length, found end of stream".into(),
-                ))
+                Some(Err(XlsError::EoStream("record type and length")))
             };
         }
         let t = read_u16(self.stream);
         let mut len = read_u16(&self.stream[2..]) as usize;
         if self.stream.len() < len + 4 {
-            return Some(Err("Expecting record length, found end of stream".into()));
+            return Some(Err(XlsError::EoStream("record length")))
         }
         let (data, next) = self.stream.split_at(len + 4);
         self.stream = next;
@@ -478,9 +505,7 @@ impl<'a> Iterator for RecordIter<'a> {
             while self.stream.len() > 4 && read_u16(self.stream) == 0x003C {
                 len = read_u16(&self.stream[2..]) as usize;
                 if self.stream.len() < len + 4 {
-                    return Some(Err(
-                        "Expecting continue record length, found end of stream".into(),
-                    ));
+                    return Some(Err(XlsError::EoStream("continue record length")))
                 }
                 let sp = self.stream.split_at(len + 4);
                 cont.push(&sp.0[4..]);
@@ -502,7 +527,7 @@ impl<'a> Iterator for RecordIter<'a> {
 /// Formula parsing
 ///
 /// Does not implement ALL possibilities, only Area are parsed
-fn parse_defined_names(rgce: &[u8]) -> Result<(Option<usize>, String)> {
+fn parse_defined_names(rgce: &[u8]) -> Result<(Option<usize>, String), XlsError> {
     if rgce.is_empty() {
         // TODO: do something better here ...
         return Ok((None, "empty rgce".to_string()));
@@ -554,7 +579,7 @@ fn parse_formula(
     sheets: &[String],
     names: &[(String, String)],
     encoding: &mut XlsEncoding,
-) -> Result<String> {
+) -> Result<String, XlsError> {
     let mut stack = Vec::new();
     let mut formula = String::with_capacity(rgce.len());
     let cce = read_u16(rgce) as usize;
@@ -622,7 +647,7 @@ fn parse_formula(
                 // binary operation
                 let e2 = stack
                     .pop()
-                    .ok_or_else::<Error, _>(|| "Invalid stack length".into())?;
+                    .ok_or(XlsError::StackLen)?;
                 let e2 = formula.split_off(e2);
                 // imaginary 'e1' will actually already be the start of the binary op
                 let op = match ptg {
@@ -647,24 +672,18 @@ fn parse_formula(
                 formula.push_str(&e2);
             }
             0x12 => {
-                let e = stack
-                    .last()
-                    .ok_or_else::<Error, _>(|| "Invalid stack length".into())?;
+                let e = stack.last().ok_or(XlsError::StackLen)?;
                 formula.insert(*e, '+');
             }
             0x13 => {
-                let e = stack
-                    .last()
-                    .ok_or_else::<Error, _>(|| "Invalid stack length".into())?;
+                let e = stack.last().ok_or(XlsError::StackLen)?;
                 formula.insert(*e, '-');
             }
             0x14 => {
                 formula.push('%');
             }
             0x15 => {
-                let e = stack
-                    .last()
-                    .ok_or_else::<Error, _>(|| "Invalid stack length".into())?;
+                let e = stack.last().ok_or(XlsError::StackLen)?;
                 formula.insert(*e, '(');
                 formula.push(')');
             }
@@ -675,7 +694,7 @@ fn parse_formula(
                 stack.push(formula.len());
                 formula.push('\"');
                 let mut cch = rgce[0] as usize;
-                formula.push_str(&read_unicode_string_no_cch(encoding, &rgce[1..], &mut cch)?);
+                formula.push_str(&read_unicode_string_no_cch(encoding, &rgce[1..], &mut cch));
                 formula.push('\"');
                 rgce = &rgce[2 + cch..];
             }
@@ -693,13 +712,13 @@ fn parse_formula(
                         rgce = &rgce[2..];
                         let e = *stack
                             .last()
-                            .ok_or_else::<Error, _>(|| "Invalid stack length".into())?;
+                            .ok_or(XlsError::StackLen)?;
                         let e = formula.split_off(e);
                         formula.push_str("SUM(");
                         formula.push_str(&e);
                         formula.push(')');
                     }
-                    e => bail!("Unsupported etpg: 0x{:x}", e),
+                    e => return Err(XlsError::Etpg(e)),
                 }
             }
             0x1C => {
@@ -715,7 +734,7 @@ fn parse_formula(
                     0x24 => formula.push_str("#NUM!"),
                     0x2A => formula.push_str("#N/A"),
                     0x2B => formula.push_str("#GETTING_DATA"),
-                    e => bail!("Unrecognosed BErr 0x{:x}", e),
+                    e => return Err(XlsError::Unrecognized { typ: "BErr", val: e }),
                 }
             }
             0x1D => {
@@ -749,7 +768,7 @@ fn parse_formula(
                     _ => {
                         let iftab = read_u16(rgce) as usize;
                         if iftab > ::utils::FTAB_LEN {
-                            bail!("Invalid iftab");
+                            return Err(XlsError::IfTab(iftab));
                         }
                         rgce = &rgce[2..];
                         let argc = ::utils::FTAB_ARGC[iftab] as usize;
@@ -757,7 +776,7 @@ fn parse_formula(
                     }
                 };
                 if stack.len() < argc {
-                    bail!("Invalid formula, stack is too small");
+                    return Err(XlsError::StackLen);
                 }
                 if argc > 0 {
                     let args_start = stack.len() - argc;
@@ -826,13 +845,11 @@ fn parse_formula(
                 formula.push_str("#REF!");
                 rgce = &rgce[8..];
             }
-            _ => bail!("Unsupported ptg: 0x{:x}", ptg),
+            _ => return Err(XlsError::Unrecognized { typ: "ptg", val: ptg }),
         }
     }
     if stack.len() != 1 {
-        Err(
-            format!("Invalid formula, final stack size: {}", stack.len()).into(),
-        )
+        Err(XlsError::InvalidFormula { stack_size:stack.len() })
     } else {
         Ok(formula)
     }

--- a/src/xls.rs
+++ b/src/xls.rs
@@ -115,15 +115,8 @@ impl<RS: Read + Seek> Reader for Xls<RS> {
         Ok(xls)
     }
 
-    fn has_vba(&mut self) -> bool {
-        self.vba.is_some()
-    }
-
-    fn vba_project(&mut self) -> Result<Cow<VbaProject>, XlsError> {
-        self.vba
-            .as_ref()
-            .map(|vba| Cow::Borrowed(vba))
-            .ok_or(XlsError::NoVba)
+    fn vba_project(&mut self) -> Option<Result<Cow<VbaProject>, XlsError>> {
+        self.vba.as_ref().map(|vba| Ok(Cow::Borrowed(vba)))
     }
 
     /// Parses Workbook stream, no need for the relationships variable
@@ -131,12 +124,12 @@ impl<RS: Read + Seek> Reader for Xls<RS> {
         &self.metadata
     }
 
-    fn worksheet_range(&mut self, name: &str) -> Result<Option<Range<DataType>>, XlsError> {
-        Ok(self.sheets.get(name).map(|r| r.0.clone()))
+    fn worksheet_range(&mut self, name: &str) -> Option<Result<Range<DataType>, XlsError>> {
+        self.sheets.get(name).map(|r| Ok(r.0.clone()))
     }
 
-    fn worksheet_formula(&mut self, name: &str) -> Result<Option<Range<String>>, XlsError> {
-        Ok(self.sheets.get(name).map(|r| r.1.clone()))
+    fn worksheet_formula(&mut self, name: &str) -> Option<Result<Range<String>, XlsError>> {
+        self.sheets.get(name).map(|r| Ok(r.1.clone()))
     }
 }
 

--- a/src/xls.rs
+++ b/src/xls.rs
@@ -12,33 +12,52 @@ use utils::{push_column, read_slice, read_u16, read_u32};
 #[derive(Fail, Debug)]
 /// An enum to handle Xls specific errors
 pub enum XlsError {
+    /// Io error
     #[fail(display = "{}", _0)] Io(#[cause] ::std::io::Error),
+    /// Cfb error
     #[fail(display = "{}", _0)] Cfb(#[cause] ::cfb::CfbError),
+    /// Vba error
     #[fail(display = "{}", _0)] Vba(#[cause] ::vba::VbaError),
 
+    /// Cannot parse formula, stack is too short
     #[fail(display = "Invalid stack length")] StackLen,
+    /// Unrecognized data
     #[fail(display = "Unrecognized {}: 0x{:0X}", typ, val)]
     Unrecognized {
+        /// data type
         typ: &'static str,
+        /// value found
         val: u8,
     },
+    /// Workook is password protected
     #[fail(display = "Workbook is password protected")] Password,
+    /// Invalid length
     #[fail(display = "Invalid {} length, expected {} maximum, found {}", typ, expected, found)]
     Len {
+        /// expected length
         expected: usize,
+        /// found length
         found: usize,
+        /// length type
         typ: &'static str,
     },
+    /// Continue Record is too short
     #[fail(display = "Continued record too short while reading extended string")]
     ContinueRecordTooShort,
+    /// End of stream
     #[fail(display = "End of stream for {}", _0)] EoStream(&'static str),
 
+    /// Invalid Formula
     #[fail(display = "Invalid formula (stack size: {})", stack_size)]
     InvalidFormula {
+        /// stack size
         stack_size: usize,
     },
+    /// Invalid or unknown iftab
     #[fail(display = "Invalid iftab {:X}", _0)] IfTab(usize),
+    /// Invalid etpg
     #[fail(display = "Invalid etpg {:X}", _0)] Etpg(u8),
+    /// No vba project
     #[fail(display = "No VBA project")] NoVba,
 }
 

--- a/src/xlsb.rs
+++ b/src/xlsb.rs
@@ -18,13 +18,17 @@ use utils::{push_column, read_slice, read_usize, read_u16, read_u32};
 #[derive(Debug, Fail)]
 pub enum XlsbError {
     /// Io error
-    #[fail(display = "{}", _0)] Io(#[cause] ::std::io::Error),
+    #[fail(display = "{}", _0)]
+    Io(#[cause] ::std::io::Error),
     /// Zip error
-    #[fail(display = "{}", _0)] Zip(#[cause] ::zip::result::ZipError),
+    #[fail(display = "{}", _0)]
+    Zip(#[cause] ::zip::result::ZipError),
     /// Xml error
-    #[fail(display = "{}", _0)] Xml(#[cause] ::quick_xml::errors::Error),
+    #[fail(display = "{}", _0)]
+    Xml(#[cause] ::quick_xml::errors::Error),
     /// Vba error
-    #[fail(display = "{}", _0)] Vba(#[cause] ::vba::VbaError),
+    #[fail(display = "{}", _0)]
+    Vba(#[cause] ::vba::VbaError),
 
     /// Mismatch value
     #[fail(display = "Expecting {}, got {:X}", expected, found)]
@@ -35,22 +39,30 @@ pub enum XlsbError {
         found: u16,
     },
     /// File not found
-    #[fail(display = "File not found: '{}'", _0)] FileNotFound(String),
+    #[fail(display = "File not found: '{}'", _0)]
+    FileNotFound(String),
     /// Invalid formula, stack length too short
-    #[fail(display = "Invalid stack length")] StackLen,
+    #[fail(display = "Invalid stack length")]
+    StackLen,
 
     /// Unsupported type
-    #[fail(display = "Unsupported type {:X}", _0)] UnsupportedType(u16),
+    #[fail(display = "Unsupported type {:X}", _0)]
+    UnsupportedType(u16),
     /// Unsupported etpg
-    #[fail(display = "Unsupported etpg {:X}", _0)] Etpg(u8),
+    #[fail(display = "Unsupported etpg {:X}", _0)]
+    Etpg(u8),
     /// Unsupported iftab
-    #[fail(display = "Unsupported iftab {:X}", _0)] IfTab(usize),
+    #[fail(display = "Unsupported iftab {:X}", _0)]
+    IfTab(usize),
     /// Unsupported BErr
-    #[fail(display = "Unsupported BErr {:X}", _0)] BErr(u8),
+    #[fail(display = "Unsupported BErr {:X}", _0)]
+    BErr(u8),
     /// Unsupported Ptg
-    #[fail(display = "Unsupported Ptg {:X}", _0)] Ptg(u8),
+    #[fail(display = "Unsupported Ptg {:X}", _0)]
+    Ptg(u8),
     /// Unsupported cell error code
-    #[fail(display = "Unsupported Cell Error code {:X}", _0)] CellError(u8),
+    #[fail(display = "Unsupported Cell Error code {:X}", _0)]
+    CellError(u8),
     /// Wide str length too long
     #[fail(display = "Wide str length {} exceeds buffer length {}", ws_len, buf_len)]
     WideStr {

--- a/src/xlsb.rs
+++ b/src/xlsb.rs
@@ -14,30 +14,49 @@ use {Cell, CellErrorType, DataType, Metadata, Range, Reader};
 use vba::VbaProject;
 use utils::{push_column, read_slice, read_usize, read_u16, read_u32};
 
+/// A Xlsb specific error
 #[derive(Debug, Fail)]
 pub enum XlsbError {
+    /// Io error
     #[fail(display = "{}", _0)] Io(#[cause] ::std::io::Error),
+    /// Zip error
     #[fail(display = "{}", _0)] Zip(#[cause] ::zip::result::ZipError),
+    /// Xml error
     #[fail(display = "{}", _0)] Xml(#[cause] ::quick_xml::errors::Error),
+    /// Vba error
     #[fail(display = "{}", _0)] Vba(#[cause] ::vba::VbaError),
 
+    /// Mismatch value
     #[fail(display = "Expecting {}, got {:X}", expected, found)]
     Mismatch {
+        /// expected
         expected: &'static str,
+        /// found
         found: u16,
     },
+    /// File not found
     #[fail(display = "File not found: '{}'", _0)] FileNotFound(String),
+    /// Invalid formula, stack length too short
     #[fail(display = "Invalid stack length")] StackLen,
 
+    /// Unsupported type
     #[fail(display = "Unsupported type {:X}", _0)] UnsupportedType(u16),
+    /// Unsupported etpg
     #[fail(display = "Unsupported etpg {:X}", _0)] Etpg(u8),
+    /// Unsupported iftab
     #[fail(display = "Unsupported iftab {:X}", _0)] IfTab(usize),
+    /// Unsupported BErr
     #[fail(display = "Unsupported BErr {:X}", _0)] BErr(u8),
+    /// Unsupported Ptg
     #[fail(display = "Unsupported Ptg {:X}", _0)] Ptg(u8),
+    /// Unsupported cell error code
     #[fail(display = "Unsupported Cell Error code {:X}", _0)] CellError(u8),
+    /// Wide str length too long
     #[fail(display = "Wide str length {} exceeds buffer length {}", ws_len, buf_len)]
     WideStr {
+        /// wide str length
         ws_len: usize,
+        /// buffer length
         buf_len: usize,
     },
 }
@@ -46,6 +65,7 @@ from_err!(::std::io::Error, XlsbError, Io);
 from_err!(::zip::result::ZipError, XlsbError, Zip);
 from_err!(::quick_xml::errors::Error, XlsbError, Xml);
 
+/// A Xlsb reader
 pub struct Xlsb<RS>
 where
     RS: Read + Seek,

--- a/src/xlsx.rs
+++ b/src/xlsx.rs
@@ -19,41 +19,57 @@ type XlsReader<'a> = XmlReader<BufReader<ZipFile<'a>>>;
 #[derive(Debug, Fail)]
 pub enum XlsxError {
     /// Io error
-    #[fail(display = "{}", _0)] Io(#[cause] ::std::io::Error),
+    #[fail(display = "{}", _0)]
+    Io(#[cause] ::std::io::Error),
     /// Zip error
-    #[fail(display = "{}", _0)] Zip(#[cause] ::zip::result::ZipError),
+    #[fail(display = "{}", _0)]
+    Zip(#[cause] ::zip::result::ZipError),
     /// Vba error
-    #[fail(display = "{}", _0)] Vba(#[cause] ::vba::VbaError),
+    #[fail(display = "{}", _0)]
+    Vba(#[cause] ::vba::VbaError),
     /// Xml error
-    #[fail(display = "{}", _0)] Xml(#[cause] ::quick_xml::errors::Error),
+    #[fail(display = "{}", _0)]
+    Xml(#[cause] ::quick_xml::errors::Error),
     /// Parse error
-    #[fail(display = "{}", _0)] Parse(#[cause] ::std::string::ParseError),
+    #[fail(display = "{}", _0)]
+    Parse(#[cause] ::std::string::ParseError),
     /// Float error
-    #[fail(display = "{}", _0)] ParseFloat(#[cause] ::std::num::ParseFloatError),
+    #[fail(display = "{}", _0)]
+    ParseFloat(#[cause] ::std::num::ParseFloatError),
     /// ParseInt error
-    #[fail(display = "{}", _0)] ParseInt(#[cause] ::std::num::ParseIntError),
+    #[fail(display = "{}", _0)]
+    ParseInt(#[cause] ::std::num::ParseIntError),
 
     /// Unexpected end of xml
-    #[fail(display = "Unexpected end of xml, expecting '</{}>'", _0)] XmlEof(&'static str),
+    #[fail(display = "Unexpected end of xml, expecting '</{}>'", _0)]
+    XmlEof(&'static str),
     /// Unexpected node
-    #[fail(display = "Expecting '{}' node", _0)] UnexpectedNode(&'static str),
+    #[fail(display = "Expecting '{}' node", _0)]
+    UnexpectedNode(&'static str),
     /// File not found
-    #[fail(display = "File not found '{}'", _0)] FileNotFound(String),
+    #[fail(display = "File not found '{}'", _0)]
+    FileNotFound(String),
     /// Expecting alphanumeri character
-    #[fail(display = "Expecting alphanumeric character, got {:X}", _0)] Alphanumeric(u8),
+    #[fail(display = "Expecting alphanumeric character, got {:X}", _0)]
+    Alphanumeric(u8),
     /// Numeric column
     #[fail(display = "Numeric character is not allowed for column name, got {}", _0)]
     NumericColumn(u8),
     /// Wrong dimension count
-    #[fail(display = "Range dimension must be lower than 2. Got {}", _0)] DimensionCount(usize),
+    #[fail(display = "Range dimension must be lower than 2. Got {}", _0)]
+    DimensionCount(usize),
     /// Cell 't' attribute error
-    #[fail(display = "Unknown cell 't' attribute: {:?}", _0)] CellTAttribute(String),
+    #[fail(display = "Unknown cell 't' attribute: {:?}", _0)]
+    CellTAttribute(String),
     /// Cell 'r' attribute error
-    #[fail(display = "Cell missing 'r' attribute")] CellRAttribute,
+    #[fail(display = "Cell missing 'r' attribute")]
+    CellRAttribute,
     /// Unexpected error
-    #[fail(display = "{}", _0)] Unexpected(&'static str),
+    #[fail(display = "{}", _0)]
+    Unexpected(&'static str),
     /// Cell error
-    #[fail(display = "Unsupported cell error value '{}'", _0)] CellError(String),
+    #[fail(display = "Unsupported cell error value '{}'", _0)]
+    CellError(String),
 }
 
 from_err!(::std::io::Error, XlsxError, Io);

--- a/src/xlsx.rs
+++ b/src/xlsx.rs
@@ -18,24 +18,41 @@ type XlsReader<'a> = XmlReader<BufReader<ZipFile<'a>>>;
 /// An enum for Xlsx specific errors
 #[derive(Debug, Fail)]
 pub enum XlsxError {
+    /// Io error
     #[fail(display = "{}", _0)] Io(#[cause] ::std::io::Error),
+    /// Zip error
     #[fail(display = "{}", _0)] Zip(#[cause] ::zip::result::ZipError),
+    /// Vba error
     #[fail(display = "{}", _0)] Vba(#[cause] ::vba::VbaError),
+    /// Xml error
     #[fail(display = "{}", _0)] Xml(#[cause] ::quick_xml::errors::Error),
+    /// Parse error
     #[fail(display = "{}", _0)] Parse(#[cause] ::std::string::ParseError),
+    /// Float error
     #[fail(display = "{}", _0)] ParseFloat(#[cause] ::std::num::ParseFloatError),
+    /// ParseInt error
     #[fail(display = "{}", _0)] ParseInt(#[cause] ::std::num::ParseIntError),
 
+    /// Unexpected end of xml
     #[fail(display = "Unexpected end of xml, expecting '</{}>'", _0)] XmlEof(&'static str),
+    /// Unexpected node
     #[fail(display = "Expecting '{}' node", _0)] UnexpectedNode(&'static str),
+    /// File not found
     #[fail(display = "File not found '{}'", _0)] FileNotFound(String),
+    /// Expecting alphanumeri character
     #[fail(display = "Expecting alphanumeric character, got {:X}", _0)] Alphanumeric(u8),
+    /// Numeric column
     #[fail(display = "Numeric character is not allowed for column name, got {}", _0)]
     NumericColumn(u8),
+    /// Wrong dimension count
     #[fail(display = "Range dimension must be lower than 2. Got {}", _0)] DimensionCount(usize),
+    /// Cell 't' attribute error
     #[fail(display = "Unknown cell 't' attribute: {:?}", _0)] CellTAttribute(String),
+    /// Cell 'r' attribute error
     #[fail(display = "Cell missing 'r' attribute")] CellRAttribute,
+    /// Unexpected error
     #[fail(display = "{}", _0)] Unexpected(&'static str),
+    /// Cell error
     #[fail(display = "Unsupported cell error value '{}'", _0)] CellError(String),
 }
 

--- a/src/xlsx.rs
+++ b/src/xlsx.rs
@@ -2,6 +2,7 @@ use std::io::BufReader;
 use std::io::{Read, Seek};
 use std::collections::HashMap;
 use std::borrow::Cow;
+use std::str::FromStr;
 
 use zip::read::{ZipArchive, ZipFile};
 use zip::result::ZipError;
@@ -60,7 +61,7 @@ impl_error!(::std::string::ParseError, XlsxError, Parse);
 impl_error!(::std::num::ParseFloatError, XlsxError, ParseFloat);
 impl_error!(::std::num::ParseIntError, XlsxError, ParseInt);
 
-impl ::std::str::FromStr for CellErrorType {
+impl FromStr for CellErrorType {
     type Err = XlsxError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
@@ -564,4 +565,33 @@ fn test_dimensions() {
     assert_eq!(get_row_column(b"A1").unwrap(), (0, 0));
     assert_eq!(get_row_column(b"C107").unwrap(), (106, 2));
     assert_eq!(get_dimension(b"C2:D35").unwrap(), ((1, 2), (34, 3)));
+}
+
+#[test]
+fn test_parse_error() {
+    assert_eq!(
+        CellErrorType::from_str("#DIV/0!").unwrap(),
+        CellErrorType::Div0
+    );
+    assert_eq!(CellErrorType::from_str("#N/A").unwrap(), CellErrorType::NA);
+    assert_eq!(
+        CellErrorType::from_str("#NAME?").unwrap(),
+        CellErrorType::Name
+    );
+    assert_eq!(
+        CellErrorType::from_str("#NULL!").unwrap(),
+        CellErrorType::Null
+    );
+    assert_eq!(
+        CellErrorType::from_str("#NUM!").unwrap(),
+        CellErrorType::Num
+    );
+    assert_eq!(
+        CellErrorType::from_str("#REF!").unwrap(),
+        CellErrorType::Ref
+    );
+    assert_eq!(
+        CellErrorType::from_str("#VALUE!").unwrap(),
+        CellErrorType::Value
+    );
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,6 +1,6 @@
 extern crate calamine;
 
-use calamine::{Ods, Sheets, Xls, Xlsb, Xlsx};
+use calamine::{open_workbook, Ods, Reader, Xls, Xlsb, Xlsx};
 use calamine::DataType::{Bool, Empty, Error, Float, String};
 use calamine::CellErrorType::*;
 use std::io::Cursor;
@@ -19,7 +19,7 @@ macro_rules! range_eq {
 #[test]
 fn issue_2() {
     let path = format!("{}/tests/issues.xlsx", env!("CARGO_MANIFEST_DIR"));
-    let mut excel = Sheets::<Xlsx<_>>::open(&path).unwrap();
+    let mut excel: Xlsx<_> = open_workbook(&path).unwrap();
 
     let range = excel.worksheet_range("issue2").unwrap().unwrap();
     range_eq!(
@@ -36,7 +36,7 @@ fn issue_2() {
 fn issue_3() {
     // test if sheet is resolved with only one row
     let path = format!("{}/tests/issue3.xlsm", env!("CARGO_MANIFEST_DIR"));
-    let mut excel = Sheets::<Xlsx<_>>::open(&path).unwrap();
+    let mut excel: Xlsx<_> = open_workbook(&path).unwrap();
 
     let range = excel.worksheet_range("Sheet1").unwrap().unwrap();
     range_eq!(range, [[Float(1.), String("a".to_string())]]);
@@ -46,7 +46,7 @@ fn issue_3() {
 fn issue_4() {
     // test if sheet is resolved with only one row
     let path = format!("{}/tests/issues.xlsx", env!("CARGO_MANIFEST_DIR"));
-    let mut excel = Sheets::<Xlsx<_>>::open(&path).unwrap();
+    let mut excel: Xlsx<_> = open_workbook(&path).unwrap();
 
     let range = excel.worksheet_range("issue5").unwrap().unwrap();
     range_eq!(range, [[Float(0.5)]]);
@@ -56,7 +56,7 @@ fn issue_4() {
 fn issue_6() {
     // test if sheet is resolved with only one row
     let path = format!("{}/tests/issues.xlsx", env!("CARGO_MANIFEST_DIR"));
-    let mut excel = Sheets::<Xlsx<_>>::open(&path).unwrap();
+    let mut excel: Xlsx<_> = open_workbook(&path).unwrap();
 
     let range = excel.worksheet_range("issue6").unwrap().unwrap();
     range_eq!(
@@ -73,7 +73,7 @@ fn issue_6() {
 #[test]
 fn error_file() {
     let path = format!("{}/tests/errors.xlsx", env!("CARGO_MANIFEST_DIR"));
-    let mut excel = Sheets::<Xlsx<_>>::open(&path).unwrap();
+    let mut excel: Xlsx<_> = open_workbook(&path).unwrap();
 
     let range = excel.worksheet_range("Feuil1").unwrap().unwrap();
     range_eq!(
@@ -93,7 +93,7 @@ fn error_file() {
 #[test]
 fn issue_9() {
     let path = format!("{}/tests/issue9.xlsx", env!("CARGO_MANIFEST_DIR"));
-    let mut excel = Sheets::<Xlsx<_>>::open(&path).unwrap();
+    let mut excel: Xlsx<_> = open_workbook(&path).unwrap();
 
     let range = excel.worksheet_range("Feuil1").unwrap().unwrap();
     range_eq!(
@@ -110,7 +110,7 @@ fn issue_9() {
 #[test]
 fn vba() {
     let path = format!("{}/tests/vba.xlsm", env!("CARGO_MANIFEST_DIR"));
-    let mut excel = Sheets::<Xlsx<_>>::open(&path).unwrap();
+    let mut excel: Xlsx<_> = open_workbook(&path).unwrap();
 
     let mut vba = excel.vba_project().unwrap();
     assert_eq!(
@@ -123,7 +123,7 @@ fn vba() {
 #[test]
 fn xlsb() {
     let path = format!("{}/tests/issues.xlsb", env!("CARGO_MANIFEST_DIR"));
-    let mut excel = Sheets::<Xlsb<_>>::open(&path).unwrap();
+    let mut excel: Xlsb<_> = open_workbook(&path).unwrap();
 
     let range = excel.worksheet_range("issue2").unwrap().unwrap();
     range_eq!(
@@ -139,7 +139,7 @@ fn xlsb() {
 #[test]
 fn xls() {
     let path = format!("{}/tests/issues.xls", env!("CARGO_MANIFEST_DIR"));
-    let mut excel = Sheets::<Xls<_>>::open(&path).unwrap();
+    let mut excel: Xls<_> = open_workbook(&path).unwrap();
 
     let range = excel.worksheet_range("issue2").unwrap().unwrap();
     range_eq!(
@@ -155,7 +155,7 @@ fn xls() {
 #[test]
 fn ods() {
     let path = format!("{}/tests/issues.ods", env!("CARGO_MANIFEST_DIR"));
-    let mut excel = Sheets::<Ods<_>>::open(&path).unwrap();
+    let mut excel: Ods<_> = open_workbook(&path).unwrap();
 
     let range = excel.worksheet_range("datatypes").unwrap().unwrap();
     range_eq!(
@@ -187,7 +187,7 @@ fn ods() {
 #[test]
 fn special_chrs_xlsx() {
     let path = format!("{}/tests/issues.xlsx", env!("CARGO_MANIFEST_DIR"));
-    let mut excel = Sheets::<Xlsx<_>>::open(&path).unwrap();
+    let mut excel: Xlsx<_> = open_workbook(&path).unwrap();
 
     let range = excel.worksheet_range("spc_chrs").unwrap().unwrap();
     range_eq!(
@@ -208,7 +208,7 @@ fn special_chrs_xlsx() {
 #[test]
 fn special_chrs_xlsb() {
     let path = format!("{}/tests/issues.xlsb", env!("CARGO_MANIFEST_DIR"));
-    let mut excel = Sheets::<Xlsb<_>>::open(&path).unwrap();
+    let mut excel: Xlsb<_> = open_workbook(&path).unwrap();
 
     let range = excel.worksheet_range("spc_chrs").unwrap().unwrap();
     range_eq!(
@@ -229,7 +229,7 @@ fn special_chrs_xlsb() {
 #[test]
 fn special_chrs_ods() {
     let path = format!("{}/tests/issues.ods", env!("CARGO_MANIFEST_DIR"));
-    let mut excel = Sheets::<Ods<_>>::open(&path).unwrap();
+    let mut excel: Ods<_> = open_workbook(&path).unwrap();
 
     let range = excel.worksheet_range("spc_chrs").unwrap().unwrap();
     range_eq!(
@@ -253,7 +253,7 @@ fn richtext_namespaced() {
         "{}/tests/richtext-namespaced.xlsx",
         env!("CARGO_MANIFEST_DIR")
     );
-    let mut excel = Sheets::<Xlsx<_>>::open(&path).unwrap();
+    let mut excel: Xlsx<_> = open_workbook(&path).unwrap();
 
     let range = excel.worksheet_range("Sheet1").unwrap().unwrap();
     range_eq!(
@@ -276,9 +276,9 @@ fn richtext_namespaced() {
 #[test]
 fn defined_names_xlsx() {
     let path = format!("{}/tests/issues.xlsx", env!("CARGO_MANIFEST_DIR"));
-    let excel = Sheets::<Xlsx<_>>::open(&path).unwrap();
+    let excel: Xlsx<_> = open_workbook(&path).unwrap();
 
-    let mut defined_names = excel.defined_names().unwrap().to_vec();
+    let mut defined_names = excel.defined_names().to_vec();
     defined_names.sort();
     assert_eq!(
         defined_names,
@@ -293,9 +293,9 @@ fn defined_names_xlsx() {
 #[test]
 fn defined_names_xlsb() {
     let path = format!("{}/tests/issues.xlsb", env!("CARGO_MANIFEST_DIR"));
-    let excel = Sheets::<Xlsb<_>>::open(&path).unwrap();
+    let excel: Xlsb<_> = open_workbook(&path).unwrap();
 
-    let mut defined_names = excel.defined_names().unwrap().to_vec();
+    let mut defined_names = excel.defined_names().to_vec();
     defined_names.sort();
     assert_eq!(
         defined_names,
@@ -310,9 +310,9 @@ fn defined_names_xlsb() {
 #[test]
 fn defined_names_xls() {
     let path = format!("{}/tests/issues.xls", env!("CARGO_MANIFEST_DIR"));
-    let excel = Sheets::<Xls<_>>::open(&path).unwrap();
+    let excel: Xls<_> = open_workbook(&path).unwrap();
 
-    let mut defined_names = excel.defined_names().unwrap().to_vec();
+    let mut defined_names = excel.defined_names().to_vec();
     defined_names.sort();
     assert_eq!(
         defined_names,
@@ -327,9 +327,9 @@ fn defined_names_xls() {
 #[test]
 fn defined_names_ods() {
     let path = format!("{}/tests/issues.ods", env!("CARGO_MANIFEST_DIR"));
-    let excel = Sheets::<Ods<_>>::open(&path).unwrap();
+    let excel: Ods<_> = open_workbook(&path).unwrap();
 
-    let mut defined_names = excel.defined_names().unwrap().to_vec();
+    let mut defined_names = excel.defined_names().to_vec();
     defined_names.sort();
     assert_eq!(
         defined_names,
@@ -353,22 +353,22 @@ fn parse_sheet_names_in_xls() {
         "{}/tests/sheet_name_parsing.xls",
         env!("CARGO_MANIFEST_DIR")
     );
-    let excel = Sheets::<Xls<_>>::open(&path).unwrap();
-    assert_eq!(excel.sheet_names().unwrap(), vec!["Sheet1"]);
+    let excel: Xls<_> = open_workbook(&path).unwrap();
+    assert_eq!(excel.sheet_names(), &["Sheet1"]);
 }
 
 #[test]
 fn read_xls_from_memory() {
     const DATA_XLS: &[u8] = include_bytes!("sheet_name_parsing.xls");
     let reader = Cursor::new(DATA_XLS);
-    let excel = Sheets::<Xls<Cursor<&[u8]>>>::new(reader).unwrap();
-    assert_eq!(excel.sheet_names().unwrap(), vec!["Sheet1"]);
+    let excel = Xls::new(reader).unwrap();
+    assert_eq!(excel.sheet_names(), &["Sheet1"]);
 }
 
 #[test]
 fn search_references() {
     let path = format!("{}/tests/vba.xlsm", env!("CARGO_MANIFEST_DIR"));
-    let mut excel = Sheets::<Xlsx<_>>::open(&path).unwrap();
+    let mut excel: Xlsx<_> = open_workbook(&path).unwrap();
     let vba = excel.vba_project().unwrap();
     let references = vba.get_references();
     let names = references.iter().map(|r| &*r.name).collect::<Vec<&str>>();
@@ -378,9 +378,9 @@ fn search_references() {
 #[test]
 fn formula_xlsx() {
     let path = format!("{}/tests/issues.xlsx", env!("CARGO_MANIFEST_DIR"));
-    let mut excel = Sheets::<Xlsx<_>>::open(&path).unwrap();
+    let mut excel: Xlsx<_> = open_workbook(&path).unwrap();
 
-    let sheets = excel.sheet_names().unwrap();
+    let sheets = excel.sheet_names().to_owned();
     for s in sheets {
         let _ = excel.worksheet_formula(&s).unwrap().unwrap();
     }
@@ -392,9 +392,9 @@ fn formula_xlsx() {
 #[test]
 fn formula_xlsb() {
     let path = format!("{}/tests/issues.xlsb", env!("CARGO_MANIFEST_DIR"));
-    let mut excel = Sheets::<Xlsb<_>>::open(&path).unwrap();
+    let mut excel: Xlsb<_> = open_workbook(&path).unwrap();
 
-    let sheets = excel.sheet_names().unwrap();
+    let sheets = excel.sheet_names().to_owned();
     for s in sheets {
         let _ = excel.worksheet_formula(&s).unwrap().unwrap();
     }
@@ -406,9 +406,9 @@ fn formula_xlsb() {
 #[test]
 fn formula_xls() {
     let path = format!("{}/tests/issues.xls", env!("CARGO_MANIFEST_DIR"));
-    let mut excel = Sheets::<Xls<_>>::open(&path).unwrap();
+    let mut excel: Xls<_> = open_workbook(&path).unwrap();
 
-    let sheets = excel.sheet_names().unwrap();
+    let sheets = excel.sheet_names().to_owned();
     for s in sheets {
         let _ = excel.worksheet_formula(&s).unwrap().unwrap();
     }
@@ -420,10 +420,9 @@ fn formula_xls() {
 #[test]
 fn formula_ods() {
     let path = format!("{}/tests/issues.ods", env!("CARGO_MANIFEST_DIR"));
-    let mut excel = Sheets::<Ods<_>>::open(&path).unwrap();
+    let mut excel: Ods<_> = open_workbook(&path).unwrap();
 
-    let sheets = excel.sheet_names().unwrap();
-    for s in sheets {
+    for s in excel.sheet_names().to_owned() {
         let _ = excel.worksheet_formula(&s).unwrap().unwrap();
     }
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -20,7 +20,7 @@ macro_rules! range_eq {
 #[test]
 fn issue_2() {
     let path = format!("{}/tests/issues.xlsx", env!("CARGO_MANIFEST_DIR"));
-    let mut excel = Sheets::<File>::open(&path).expect("cannot open excel file");
+    let mut excel = Sheets::<Xlsx>::open(&path).expect("cannot open excel file");
 
     let range = excel.worksheet_range("issue2").unwrap();
     range_eq!(

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,9 +1,8 @@
 extern crate calamine;
 
-use calamine::Sheets;
+use calamine::{Ods, Sheets, Xls, Xlsb, Xlsx};
 use calamine::DataType::{Bool, Empty, Error, Float, String};
 use calamine::CellErrorType::*;
-use std::fs::File;
 use std::io::Cursor;
 
 macro_rules! range_eq {
@@ -20,9 +19,9 @@ macro_rules! range_eq {
 #[test]
 fn issue_2() {
     let path = format!("{}/tests/issues.xlsx", env!("CARGO_MANIFEST_DIR"));
-    let mut excel = Sheets::<Xlsx>::open(&path).expect("cannot open excel file");
+    let mut excel = Sheets::<Xlsx<_>>::open(&path).unwrap();
 
-    let range = excel.worksheet_range("issue2").unwrap();
+    let range = excel.worksheet_range("issue2").unwrap().unwrap();
     range_eq!(
         range,
         [
@@ -37,9 +36,9 @@ fn issue_2() {
 fn issue_3() {
     // test if sheet is resolved with only one row
     let path = format!("{}/tests/issue3.xlsm", env!("CARGO_MANIFEST_DIR"));
-    let mut excel = Sheets::<File>::open(&path).expect("cannot open excel file");
+    let mut excel = Sheets::<Xlsx<_>>::open(&path).unwrap();
 
-    let range = excel.worksheet_range("Sheet1").unwrap();
+    let range = excel.worksheet_range("Sheet1").unwrap().unwrap();
     range_eq!(range, [[Float(1.), String("a".to_string())]]);
 }
 
@@ -47,9 +46,9 @@ fn issue_3() {
 fn issue_4() {
     // test if sheet is resolved with only one row
     let path = format!("{}/tests/issues.xlsx", env!("CARGO_MANIFEST_DIR"));
-    let mut excel = Sheets::<File>::open(&path).expect("cannot open excel file");
+    let mut excel = Sheets::<Xlsx<_>>::open(&path).unwrap();
 
-    let range = excel.worksheet_range("issue5").unwrap();
+    let range = excel.worksheet_range("issue5").unwrap().unwrap();
     range_eq!(range, [[Float(0.5)]]);
 }
 
@@ -57,9 +56,9 @@ fn issue_4() {
 fn issue_6() {
     // test if sheet is resolved with only one row
     let path = format!("{}/tests/issues.xlsx", env!("CARGO_MANIFEST_DIR"));
-    let mut excel = Sheets::<File>::open(&path).expect("cannot open excel file");
+    let mut excel = Sheets::<Xlsx<_>>::open(&path).unwrap();
 
-    let range = excel.worksheet_range("issue6").unwrap();
+    let range = excel.worksheet_range("issue6").unwrap().unwrap();
     range_eq!(
         range,
         [
@@ -74,9 +73,9 @@ fn issue_6() {
 #[test]
 fn error_file() {
     let path = format!("{}/tests/errors.xlsx", env!("CARGO_MANIFEST_DIR"));
-    let mut excel = Sheets::<File>::open(&path).expect("cannot open excel file");
+    let mut excel = Sheets::<Xlsx<_>>::open(&path).unwrap();
 
-    let range = excel.worksheet_range("Feuil1").unwrap();
+    let range = excel.worksheet_range("Feuil1").unwrap().unwrap();
     range_eq!(
         range,
         [
@@ -94,9 +93,9 @@ fn error_file() {
 #[test]
 fn issue_9() {
     let path = format!("{}/tests/issue9.xlsx", env!("CARGO_MANIFEST_DIR"));
-    let mut excel = Sheets::<File>::open(&path).expect("cannot open excel file");
+    let mut excel = Sheets::<Xlsx<_>>::open(&path).unwrap();
 
-    let range = excel.worksheet_range("Feuil1").unwrap();
+    let range = excel.worksheet_range("Feuil1").unwrap().unwrap();
     range_eq!(
         range,
         [
@@ -111,7 +110,7 @@ fn issue_9() {
 #[test]
 fn vba() {
     let path = format!("{}/tests/vba.xlsm", env!("CARGO_MANIFEST_DIR"));
-    let mut excel = Sheets::<File>::open(&path).expect("cannot open excel file");
+    let mut excel = Sheets::<Xlsx<_>>::open(&path).unwrap();
 
     let mut vba = excel.vba_project().unwrap();
     assert_eq!(
@@ -124,9 +123,9 @@ fn vba() {
 #[test]
 fn xlsb() {
     let path = format!("{}/tests/issues.xlsb", env!("CARGO_MANIFEST_DIR"));
-    let mut excel = Sheets::<File>::open(&path).expect("cannot open excel file");
+    let mut excel = Sheets::<Xlsb<_>>::open(&path).unwrap();
 
-    let range = excel.worksheet_range("issue2").unwrap();
+    let range = excel.worksheet_range("issue2").unwrap().unwrap();
     range_eq!(
         range,
         [
@@ -140,9 +139,9 @@ fn xlsb() {
 #[test]
 fn xls() {
     let path = format!("{}/tests/issues.xls", env!("CARGO_MANIFEST_DIR"));
-    let mut excel = Sheets::<File>::open(&path).expect("cannot open excel file");
+    let mut excel = Sheets::<Xls<_>>::open(&path).unwrap();
 
-    let range = excel.worksheet_range("issue2").unwrap();
+    let range = excel.worksheet_range("issue2").unwrap().unwrap();
     range_eq!(
         range,
         [
@@ -156,9 +155,9 @@ fn xls() {
 #[test]
 fn ods() {
     let path = format!("{}/tests/issues.ods", env!("CARGO_MANIFEST_DIR"));
-    let mut excel = Sheets::<File>::open(&path).expect("cannot open excel file");
+    let mut excel = Sheets::<Ods<_>>::open(&path).unwrap();
 
-    let range = excel.worksheet_range("datatypes").unwrap();
+    let range = excel.worksheet_range("datatypes").unwrap().unwrap();
     range_eq!(
         range,
         [
@@ -171,7 +170,7 @@ fn ods() {
         ]
     );
 
-    let range = excel.worksheet_range("issue2").unwrap();
+    let range = excel.worksheet_range("issue2").unwrap().unwrap();
     range_eq!(
         range,
         [
@@ -181,16 +180,16 @@ fn ods() {
         ]
     );
 
-    let range = excel.worksheet_range("issue5").unwrap();
+    let range = excel.worksheet_range("issue5").unwrap().unwrap();
     range_eq!(range, [[Float(0.5)]]);
 }
 
 #[test]
 fn special_chrs_xlsx() {
     let path = format!("{}/tests/issues.xlsx", env!("CARGO_MANIFEST_DIR"));
-    let mut excel = Sheets::<File>::open(&path).expect("cannot open excel file");
+    let mut excel = Sheets::<Xlsx<_>>::open(&path).unwrap();
 
-    let range = excel.worksheet_range("spc_chrs").unwrap();
+    let range = excel.worksheet_range("spc_chrs").unwrap().unwrap();
     range_eq!(
         range,
         [
@@ -209,9 +208,9 @@ fn special_chrs_xlsx() {
 #[test]
 fn special_chrs_xlsb() {
     let path = format!("{}/tests/issues.xlsb", env!("CARGO_MANIFEST_DIR"));
-    let mut excel = Sheets::<File>::open(&path).expect("cannot open excel file");
+    let mut excel = Sheets::<Xlsb<_>>::open(&path).unwrap();
 
-    let range = excel.worksheet_range("spc_chrs").unwrap();
+    let range = excel.worksheet_range("spc_chrs").unwrap().unwrap();
     range_eq!(
         range,
         [
@@ -230,9 +229,9 @@ fn special_chrs_xlsb() {
 #[test]
 fn special_chrs_ods() {
     let path = format!("{}/tests/issues.ods", env!("CARGO_MANIFEST_DIR"));
-    let mut excel = Sheets::<File>::open(&path).expect("cannot open excel file");
+    let mut excel = Sheets::<Ods<_>>::open(&path).unwrap();
 
-    let range = excel.worksheet_range("spc_chrs").unwrap();
+    let range = excel.worksheet_range("spc_chrs").unwrap().unwrap();
     range_eq!(
         range,
         [
@@ -254,9 +253,9 @@ fn richtext_namespaced() {
         "{}/tests/richtext-namespaced.xlsx",
         env!("CARGO_MANIFEST_DIR")
     );
-    let mut excel = Sheets::<File>::open(&path).expect("cannot open excel file");
+    let mut excel = Sheets::<Xlsx<_>>::open(&path).unwrap();
 
-    let range = excel.worksheet_range("Sheet1").unwrap();
+    let range = excel.worksheet_range("Sheet1").unwrap().unwrap();
     range_eq!(
         range,
         [
@@ -277,7 +276,7 @@ fn richtext_namespaced() {
 #[test]
 fn defined_names_xlsx() {
     let path = format!("{}/tests/issues.xlsx", env!("CARGO_MANIFEST_DIR"));
-    let mut excel = Sheets::<File>::open(&path).expect("cannot open excel file");
+    let excel = Sheets::<Xlsx<_>>::open(&path).unwrap();
 
     let mut defined_names = excel.defined_names().unwrap().to_vec();
     defined_names.sort();
@@ -294,7 +293,7 @@ fn defined_names_xlsx() {
 #[test]
 fn defined_names_xlsb() {
     let path = format!("{}/tests/issues.xlsb", env!("CARGO_MANIFEST_DIR"));
-    let mut excel = Sheets::<File>::open(&path).expect("cannot open excel file");
+    let excel = Sheets::<Xlsb<_>>::open(&path).unwrap();
 
     let mut defined_names = excel.defined_names().unwrap().to_vec();
     defined_names.sort();
@@ -311,7 +310,7 @@ fn defined_names_xlsb() {
 #[test]
 fn defined_names_xls() {
     let path = format!("{}/tests/issues.xls", env!("CARGO_MANIFEST_DIR"));
-    let mut excel = Sheets::<File>::open(&path).expect("cannot open excel file");
+    let excel = Sheets::<Xls<_>>::open(&path).unwrap();
 
     let mut defined_names = excel.defined_names().unwrap().to_vec();
     defined_names.sort();
@@ -328,7 +327,7 @@ fn defined_names_xls() {
 #[test]
 fn defined_names_ods() {
     let path = format!("{}/tests/issues.ods", env!("CARGO_MANIFEST_DIR"));
-    let mut excel = Sheets::<File>::open(&path).expect("cannot open excel file");
+    let excel = Sheets::<Ods<_>>::open(&path).unwrap();
 
     let mut defined_names = excel.defined_names().unwrap().to_vec();
     defined_names.sort();
@@ -354,7 +353,7 @@ fn parse_sheet_names_in_xls() {
         "{}/tests/sheet_name_parsing.xls",
         env!("CARGO_MANIFEST_DIR")
     );
-    let mut excel = Sheets::<File>::open(&path).expect("cannot open excel file");
+    let excel = Sheets::<Xls<_>>::open(&path).unwrap();
     assert_eq!(excel.sheet_names().unwrap(), vec!["Sheet1"]);
 }
 
@@ -362,14 +361,14 @@ fn parse_sheet_names_in_xls() {
 fn read_xls_from_memory() {
     const DATA_XLS: &[u8] = include_bytes!("sheet_name_parsing.xls");
     let reader = Cursor::new(DATA_XLS);
-    let mut excel = Sheets::new(reader, "xls").unwrap();
+    let excel = Sheets::<Xls<Cursor<&[u8]>>>::new(reader).unwrap();
     assert_eq!(excel.sheet_names().unwrap(), vec!["Sheet1"]);
 }
 
 #[test]
 fn search_references() {
     let path = format!("{}/tests/vba.xlsm", env!("CARGO_MANIFEST_DIR"));
-    let mut excel = Sheets::<File>::open(&path).expect("cannot open excel file");
+    let mut excel = Sheets::<Xlsx<_>>::open(&path).unwrap();
     let vba = excel.vba_project().unwrap();
     let references = vba.get_references();
     let names = references.iter().map(|r| &*r.name).collect::<Vec<&str>>();
@@ -379,55 +378,55 @@ fn search_references() {
 #[test]
 fn formula_xlsx() {
     let path = format!("{}/tests/issues.xlsx", env!("CARGO_MANIFEST_DIR"));
-    let mut excel = Sheets::<File>::open(&path).expect("cannot open excel file");
+    let mut excel = Sheets::<Xlsx<_>>::open(&path).unwrap();
 
     let sheets = excel.sheet_names().unwrap();
     for s in sheets {
-        let _ = excel.worksheet_formula(&s).unwrap();
+        let _ = excel.worksheet_formula(&s).unwrap().unwrap();
     }
 
-    let formula = excel.worksheet_formula("Sheet1").unwrap();
+    let formula = excel.worksheet_formula("Sheet1").unwrap().unwrap();
     range_eq!(formula, [["B1+OneRange".to_string()]]);
 }
 
 #[test]
 fn formula_xlsb() {
     let path = format!("{}/tests/issues.xlsb", env!("CARGO_MANIFEST_DIR"));
-    let mut excel = Sheets::<File>::open(&path).expect("cannot open excel file");
+    let mut excel = Sheets::<Xlsb<_>>::open(&path).unwrap();
 
     let sheets = excel.sheet_names().unwrap();
     for s in sheets {
-        let _ = excel.worksheet_formula(&s).unwrap();
+        let _ = excel.worksheet_formula(&s).unwrap().unwrap();
     }
 
-    let formula = excel.worksheet_formula("Sheet1").unwrap();
+    let formula = excel.worksheet_formula("Sheet1").unwrap().unwrap();
     range_eq!(formula, [["B1+OneRange".to_string()]]);
 }
 
 #[test]
 fn formula_xls() {
     let path = format!("{}/tests/issues.xls", env!("CARGO_MANIFEST_DIR"));
-    let mut excel = Sheets::<File>::open(&path).expect("cannot open excel file");
+    let mut excel = Sheets::<Xls<_>>::open(&path).unwrap();
 
     let sheets = excel.sheet_names().unwrap();
     for s in sheets {
-        let _ = excel.worksheet_formula(&s).unwrap();
+        let _ = excel.worksheet_formula(&s).unwrap().unwrap();
     }
 
-    let formula = excel.worksheet_formula("Sheet1").unwrap();
+    let formula = excel.worksheet_formula("Sheet1").unwrap().unwrap();
     range_eq!(formula, [["B1+OneRange".to_string()]]);
 }
 
 #[test]
 fn formula_ods() {
     let path = format!("{}/tests/issues.ods", env!("CARGO_MANIFEST_DIR"));
-    let mut excel = Sheets::<File>::open(&path).expect("cannot open excel file");
+    let mut excel = Sheets::<Ods<_>>::open(&path).unwrap();
 
     let sheets = excel.sheet_names().unwrap();
     for s in sheets {
-        let _ = excel.worksheet_formula(&s).unwrap();
+        let _ = excel.worksheet_formula(&s).unwrap().unwrap();
     }
 
-    let formula = excel.worksheet_formula("Sheet1").unwrap();
+    let formula = excel.worksheet_formula("Sheet1").unwrap().unwrap();
     range_eq!(formula, [["of:=[.B1]+$$OneRange".to_string()]]);
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -112,7 +112,7 @@ fn vba() {
     let path = format!("{}/tests/vba.xlsm", env!("CARGO_MANIFEST_DIR"));
     let mut excel: Xlsx<_> = open_workbook(&path).unwrap();
 
-    let mut vba = excel.vba_project().unwrap();
+    let mut vba = excel.vba_project().unwrap().unwrap();
     assert_eq!(
         vba.to_mut().get_module("testVBA").unwrap(),
         "Attribute VB_Name = \"testVBA\"\r\nPublic Sub test()\r\n    MsgBox \"Hello from \
@@ -369,7 +369,7 @@ fn read_xls_from_memory() {
 fn search_references() {
     let path = format!("{}/tests/vba.xlsm", env!("CARGO_MANIFEST_DIR"));
     let mut excel: Xlsx<_> = open_workbook(&path).unwrap();
-    let vba = excel.vba_project().unwrap();
+    let vba = excel.vba_project().unwrap().unwrap();
     let references = vba.get_references();
     let names = references.iter().map(|r| &*r.name).collect::<Vec<&str>>();
     assert_eq!(names, vec!["stdole", "Office"]);


### PR DESCRIPTION
This is a big breaking change and comes with lot of cleaning.
Each document has its own error enum and CalError is wrapping them all.
Every `bail!` call have been removed for a dedicated enum variant.

Closes #110 