### PR TITLE
add with_headers to prefilter columns before deserializing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calamine"
-version = "0.14.7"
+version = "0.14.8"
 authors = ["Johann Tuffe <tafia973@gmail.com>"]
 repository = "https://github.com/tafia/calamine"
 documentation = "https://docs.rs/calamine"
@@ -15,14 +15,14 @@ travis-ci = { repository = "tafia/calamine" }
 appveyor = { repository = "tafia/calamine" }
 
 [dependencies]
-byteorder = "1.2.6"
-encoding_rs = "0.8.6"
-failure = "0.1.2"
-failure_derive = "0.1.2"
-log = "0.4.4"
-serde = "1.0.75"
-quick-xml = "0.12.2"
-zip = { version = "0.4.2", default-features = false, features = ["deflate"] }
+byteorder = "1.2.7"
+encoding_rs = "0.8.12"
+failure = "0.1.3"
+failure_derive = "0.1.3"
+log = "0.4.6"
+serde = "1.0.80"
+quick-xml = "0.13.1"
+zip = { version = "0.5.0", default-features = false, features = ["deflate"] }
 
 [dev-dependencies]
 glob = "0.2.11"


### PR DESCRIPTION
Add a `RangeDeserializerBuilder::with_headers` to work with only a subset of all columns.