### PR TITLE
do not accept empty value as valid map key

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calamine"
-version = "0.14.8"
+version = "0.14.9"
 authors = ["Johann Tuffe <tafia973@gmail.com>"]
 repository = "https://github.com/tafia/calamine"
 documentation = "https://docs.rs/calamine"

--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,9 @@
   - test: Adding missing tests
   - chore: Changes to the build process or auxiliary tools/libraries/documentation
 
+## 0.14.9
+- fix: do not return map keys for empty cells. Fixes not working `#[serde(default)]`
+
 ## 0.14.8
 - feat: bump dependencies
 - feat: add a `RangeDeserializerBuilder::with_headers` fn to improve serde deserializer


### PR DESCRIPTION
Without this change, `#[serde(default)]` doesn't work.