### PR TITLE
Use codepage/encoding_rs for codepage mapping and single-byte check

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ appveyor = { repository = "tafia/calamine" }
 
 [dependencies]
 byteorder = "1.2.7"
+codepage = "0.1.1"
 encoding_rs = "0.8.12"
 failure = "0.1.3"
 failure_derive = "0.1.3"

--- a/src/cfb.rs
+++ b/src/cfb.rs
@@ -397,8 +397,8 @@ pub struct XlsEncoding {
 
 impl XlsEncoding {
     pub fn from_codepage(codepage: u16) -> Result<XlsEncoding, CfbError> {
-        let e = codepage::to_encoding(codepage)
-            .ok_or_else(|| CfbError::CodePageNotFound(codepage))?;
+        let e =
+            codepage::to_encoding(codepage).ok_or_else(|| CfbError::CodePageNotFound(codepage))?;
         let high_byte = if e == UTF_8 || e.is_single_byte() {
             None
         } else {

--- a/src/cfb.rs
+++ b/src/cfb.rs
@@ -4,7 +4,7 @@ use std::borrow::Cow;
 use std::cmp::min;
 use std::io::Read;
 
-use encoding_rs::{Encoding, UTF_16LE};
+use encoding_rs::{Encoding, UTF_16LE, UTF_8};
 
 use utils::*;
 
@@ -397,20 +397,12 @@ pub struct XlsEncoding {
 
 impl XlsEncoding {
     pub fn from_codepage(codepage: u16) -> Result<XlsEncoding, CfbError> {
-        let e = encoding_from_windows_code_page(codepage as usize)
+        let e = codepage::to_encoding(codepage)
             .ok_or_else(|| CfbError::CodePageNotFound(codepage))?;
-        let high_byte = match codepage {
-            20127
-            | 65000
-            | 65001
-            | 20866
-            | 21866
-            | 10000
-            | 10007
-            | 874
-            | 1250...1258
-            | 28591...28605 => None, // SingleByte encodings
-            _ => Some(false),
+        let high_byte = if e == UTF_8 || e.is_single_byte() {
+            None
+        } else {
+            Some(false)
         };
 
         Ok(XlsEncoding {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,7 @@
 #![deny(missing_docs)]
 
 extern crate byteorder;
+extern crate codepage;
 extern crate encoding_rs;
 #[macro_use]
 extern crate failure;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,7 +1,5 @@
 //! Internal module providing handy function
 
-use encoding_rs::{self, Encoding};
-
 macro_rules! from_err {
     ($from:ty, $to:tt, $var:tt) => {
         impl From<$from> for $to {
@@ -31,57 +29,6 @@ pub fn read_u16(s: &[u8]) -> u16 {
 
 pub fn read_usize(s: &[u8]) -> usize {
     read_u32(s) as usize
-}
-
-/// Returns an encoding from Windows code page number.
-/// http://msdn.microsoft.com/en-us/library/windows/desktop/dd317756%28v=vs.85%29.aspx
-/// Sometimes it can return a *superset* of the requested encoding, e.g. for several CJK encodings.
-///
-/// The code is copied from [rust-encoding](https://github.com/lifthrasiir/rust-encoding)
-pub fn encoding_from_windows_code_page(cp: usize) -> Option<&'static Encoding> {
-    match cp {
-        65001 => Some(encoding_rs::UTF_8),
-        866 => Some(encoding_rs::IBM866),
-        28592 => Some(encoding_rs::ISO_8859_2),
-        28593 => Some(encoding_rs::ISO_8859_3),
-        28594 => Some(encoding_rs::ISO_8859_4),
-        28595 => Some(encoding_rs::ISO_8859_5),
-        28596 => Some(encoding_rs::ISO_8859_6),
-        28597 => Some(encoding_rs::ISO_8859_7),
-        28598 => Some(encoding_rs::ISO_8859_8),
-        28603 => Some(encoding_rs::ISO_8859_13),
-        28605 => Some(encoding_rs::ISO_8859_15),
-        20866 => Some(encoding_rs::KOI8_R),
-        21866 => Some(encoding_rs::KOI8_U),
-        10000 => Some(encoding_rs::MACINTOSH),
-        874 => Some(encoding_rs::WINDOWS_874),
-        1250 => Some(encoding_rs::WINDOWS_1250),
-        1251 => Some(encoding_rs::WINDOWS_1251),
-        1252 => Some(encoding_rs::WINDOWS_1252),
-        1253 => Some(encoding_rs::WINDOWS_1253),
-        1254 => Some(encoding_rs::WINDOWS_1254),
-        1255 => Some(encoding_rs::WINDOWS_1255),
-        1256 => Some(encoding_rs::WINDOWS_1256),
-        1257 => Some(encoding_rs::WINDOWS_1257),
-        1258 => Some(encoding_rs::WINDOWS_1258),
-        1259 | 10007 => Some(encoding_rs::X_MAC_CYRILLIC),
-        936 | 54936 => Some(encoding_rs::GB18030), // XXX technicencoding_rsy wrong
-        950 => Some(encoding_rs::BIG5),
-        20932 => Some(encoding_rs::EUC_JP),
-        50220 => Some(encoding_rs::ISO_2022_JP),
-        932 => Some(encoding_rs::SHIFT_JIS),
-        1201 => Some(encoding_rs::UTF_16BE),
-        1200 => Some(encoding_rs::UTF_16LE),
-        949 => Some(encoding_rs::EUC_KR),
-        // This is actually not a valid codepage but it happens with some unknown writer
-        // Looking on internet, it looks like excel treats this as codepage 1200
-        21010 => Some(encoding_rs::UTF_16LE),
-        // Not available because not in the Encoding Standard
-        //28591 => Some(encoding_rs::ISO_8859_1),
-        //38598 => Some(encoding_rs::whatwg::ISO_8859_8_I),
-        //52936 => Some(encoding_rs::HZ),
-        _ => None,
-    }
 }
 
 /// Push literal column into a String buffer


### PR DESCRIPTION
This should not change observable behavior. It just uses encoding_rs and its companion codepage crate for some operations that they provide.

The codepage crate knows about the 21010 special case.