### PR TITLE
Allow sector with length after EOF to be read

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ rust:
 
 before_script:
   - export PATH=$HOME/.cargo/bin:$HOME/.local/bin:$PATH
-  - rustup component add rustfmt
+  - if [[ $(rustup show active-toolchain) == stable* ]]; then rustup component add rustfmt; fi;
 
 script:
   - cargo build

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ rust:
 
 before_script:
   - export PATH=$HOME/.cargo/bin:$HOME/.local/bin:$PATH
-  - rustup component add rustfmt-preview
+  - rustup component add rustfmt
 
 script:
   - cargo build

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calamine"
-version = "0.15.0"
+version = "0.15.1"
 authors = ["Johann Tuffe <tafia973@gmail.com>"]
 repository = "https://github.com/tafia/calamine"
 documentation = "https://docs.rs/calamine"

--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,9 @@
   - test: Adding missing tests
   - chore: Changes to the build process or auxiliary tools/libraries/documentation
 
+# 0.15.1
+- fix: xls - allow sectors ending after eof (truncate them!)
+
 # 0.15.0
 - feat: codepage/encoding_rs for codpage mapping 
 

--- a/examples/search_errors.rs
+++ b/examples/search_errors.rs
@@ -30,7 +30,8 @@ fn main() {
             ':' => None,
             '/' | '\\' | ' ' => Some('_'),
             c => Some(c),
-        }).collect::<String>();
+        })
+        .collect::<String>();
     output.push_str("_errors.csv");
     let mut output = BufWriter::new(File::create(output).unwrap());
 
@@ -44,7 +45,8 @@ fn main() {
                 writeln!(output, "{:?}~{:?}~{}", f, missing, cell_errors)
             }
             Err(e) => writeln!(output, "{:?}", e),
-        }.unwrap_or_else(|e| println!("{:?}", e))
+        }
+        .unwrap_or_else(|e| println!("{:?}", e))
     }
 
     println!("Found {} excel files", filecount);
@@ -89,7 +91,8 @@ fn run(f: GlobResult) -> Result<(PathBuf, Option<usize>, usize), FileStatus> {
                         false
                     }
                 })
-            }).count();
+            })
+            .count();
     }
 
     Ok((f, missing, cell_errors))

--- a/src/cfb.rs
+++ b/src/cfb.rs
@@ -24,12 +24,7 @@ pub enum CfbError {
     EmptyRootDir,
     #[fail(display = "Cannot find {} stream", _0)]
     StreamNotFound(String),
-    #[fail(
-        display = "Invalid {}, expecting {} found {:X}",
-        name,
-        expected,
-        found
-    )]
+    #[fail(display = "Invalid {}, expecting {} found {:X}", name, expected, found)]
     Invalid {
         name: &'static str,
         expected: &'static str,

--- a/src/cfb.rs
+++ b/src/cfb.rs
@@ -226,12 +226,18 @@ impl Sectors {
         let start = id as usize * self.size;
         let end = start + self.size;
         if end > self.data.len() {
-            let len = self.data.len();
+            let mut len = self.data.len();
             unsafe {
                 self.data.set_len(end);
             }
-            r.read_exact(&mut self.data[len..end])
-                .map_err(CfbError::Io)?;
+            // read_exact or stop if EOF
+            while len < end {
+                let read = r.read(&mut self.data[len..end]).map_err(CfbError::Io)?;
+                if read == 0 {
+                    return Ok(&self.data[start..len]);
+                }
+                len += read;
+            }
         }
         Ok(&self.data[start..end])
     }

--- a/src/de.rs
+++ b/src/de.rs
@@ -304,7 +304,8 @@ where
                                 .iter()
                                 .position(|header| header.trim() == h)
                                 .ok_or_else(|| DeError::HeaderNotFound(h.to_owned()))
-                        }).collect::<Result<Vec<_>, DeError>>()?;
+                        })
+                        .collect::<Result<Vec<_>, DeError>>()?;
                     (custom_indexes, Some(all_headers))
                 } else {
                     (Vec::new(), None)

--- a/src/ods.rs
+++ b/src/ods.rs
@@ -169,18 +169,20 @@ fn parse_content<RS: Read + Seek>(
     let mut sheet_names = Vec::new();
     loop {
         match reader.read_event(&mut buf) {
-            Ok(Event::Start(ref e)) if e.name() == b"table:table" => if let Some(ref a) = e
-                .attributes()
-                .filter_map(|a| a.ok())
-                .find(|a| a.key == b"table:name")
-            {
-                let name = a
-                    .unescape_and_decode_value(&reader)
-                    .map_err(OdsError::Xml)?;
-                let (range, formulas) = read_table(&mut reader)?;
-                sheet_names.push(name.clone());
-                sheets.insert(name, (range, formulas));
-            },
+            Ok(Event::Start(ref e)) if e.name() == b"table:table" => {
+                if let Some(ref a) = e
+                    .attributes()
+                    .filter_map(|a| a.ok())
+                    .find(|a| a.key == b"table:name")
+                {
+                    let name = a
+                        .unescape_and_decode_value(&reader)
+                        .map_err(OdsError::Xml)?;
+                    let (range, formulas) = read_table(&mut reader)?;
+                    sheet_names.push(name.clone());
+                    sheets.insert(name, (range, formulas));
+                }
+            }
             Ok(Event::Start(ref e)) if e.name() == b"table:named-expressions" => {
                 defined_names = read_named_expressions(&mut reader)?;
             }

--- a/src/vba.rs
+++ b/src/vba.rs
@@ -40,8 +40,7 @@ pub enum VbaError {
     /// Invalid record id
     #[fail(
         display = "Invalid record id: expecting {:X} found {:X}",
-        expected,
-        found
+        expected, found
     )]
     InvalidRecordId {
         /// expected record id
@@ -95,7 +94,8 @@ impl VbaProject {
                 cfb.get_stream(&m.stream_name, r).and_then(|s| {
                     ::cfb::decompress_stream(&s[m.text_offset..]).map(move |s| (m.name, s))
                 })
-            }).collect::<Result<HashMap<_, _>, _>>()?;
+            })
+            .collect::<Result<HashMap<_, _>, _>>()?;
 
         Ok(VbaProject {
             references: refs,

--- a/src/xls.rs
+++ b/src/xls.rs
@@ -39,9 +39,7 @@ pub enum XlsError {
     /// Invalid length
     #[fail(
         display = "Invalid {} length, expected {} maximum, found {}",
-        typ,
-        expected,
-        found
+        typ, expected, found
     )]
     Len {
         /// expected length
@@ -205,7 +203,8 @@ impl<RS: Read + Seek> Xls<RS> {
                 } else {
                     (name, f)
                 }
-            }).collect::<Vec<_>>();
+            })
+            .collect::<Vec<_>>();
 
         let mut sheets = HashMap::with_capacity(sheet_names.len());
         let fmla_sheet_names = sheet_names
@@ -241,7 +240,8 @@ impl<RS: Read + Seek> Xls<RS> {
                             &fmla_sheet_names,
                             &defined_names,
                             &mut encoding,
-                        ).unwrap_or_else(|e| {
+                        )
+                        .unwrap_or_else(|e| {
                             format!(
                                 "Unrecognised formula \
                                  for cell ({}, {}): {:?}",
@@ -565,12 +565,14 @@ impl<'a> Record<'a> {
     fn continue_record(&mut self) -> bool {
         match self.cont {
             None => false,
-            Some(ref mut v) => if v.is_empty() {
-                false
-            } else {
-                self.data = v.remove(0);
-                true
-            },
+            Some(ref mut v) => {
+                if v.is_empty() {
+                    false
+                } else {
+                    self.data = v.remove(0);
+                    true
+                }
+            }
         }
     }
 }

--- a/src/xlsb.rs
+++ b/src/xlsb.rs
@@ -66,8 +66,7 @@ pub enum XlsbError {
     /// Wide str length too long
     #[fail(
         display = "Wide str length {} exceeds buffer length {}",
-        ws_len,
-        buf_len
+        ws_len, buf_len
     )]
     WideStr {
         /// wide str length
@@ -236,8 +235,10 @@ impl<RS: Read + Seek> Xlsb<RS> {
                                 -1 => "#InvalidWorkSheet",
                                 p if p >= 0 && (p as usize) < sheets.len() => &sheets[p as usize].0,
                                 _ => "#Unknown",
-                            }.to_string()
-                        }).take(cxti)
+                            }
+                            .to_string()
+                        })
+                        .take(cxti)
                         .collect();
                     self.extern_sheets = extern_sheets;
                 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -596,7 +596,8 @@ fn issue_127() {
 
     let ordered_names: Vec<std::string::String> = vec![
         "Sheet1", "Sheet2", "Sheet3", "Sheet4", "Sheet5", "Sheet6", "Sheet7", "Sheet8",
-    ].iter()
+    ]
+    .iter()
     .map(|&s| s.to_owned())
     .collect();
 


### PR DESCRIPTION
This is some edge case for .xls files.

Some sectors length are said to be too large and exceed file EOF. I stop reading the sector if it happens and instead exit with a truncated buffer.

Unfortunately I cannot provide a test file as I cannot disclose its content and I can't reproduce it intentionally either.