### PR TITLE
Make it more user friendly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calamine"
-version = "0.15.2"
+version = "0.15.3"
 authors = ["Johann Tuffe <tafia973@gmail.com>"]
 repository = "https://github.com/tafia/calamine"
 documentation = "https://docs.rs/calamine"

--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,15 @@
   - test: Adding missing tests
   - chore: Changes to the build process or auxiliary tools/libraries/documentation
 
+# 0.15.3
+- feat: add several new convenient fn to `DataType`
+- feat: add a `Range::range` fn to get subranges
+- feat: add a new `Range::cells` iterator
+- feat: impl DoubleEndedIterator when possible
+- perf: add some missing `size_hint` impl in iterators
+- feat: add a `Range::get` fn (similar to slice's)
+- perf: add some `ExactSizeIterator`
+
 # 0.15.2
 - feat: consider empty cell as empty str if deserializing to str or String
 

--- a/src/datatype.rs
+++ b/src/datatype.rs
@@ -29,6 +29,49 @@ impl Default for DataType {
     }
 }
 
+impl DataType {
+    /// Assess if `self == DataType::Empty`
+    pub fn is_empty(&self) -> bool {
+        *self == DataType::Empty
+    }
+}
+
+impl PartialEq<str> for DataType {
+    fn eq(&self, other: &str) -> bool {
+        match *self {
+            DataType::String(ref s) if s == other => true,
+            _ => false,
+        }
+    }
+}
+
+impl PartialEq<f64> for DataType {
+    fn eq(&self, other: &f64) -> bool {
+        match *self {
+            DataType::Float(ref s) if *s == *other => true,
+            _ => false,
+        }
+    }
+}
+
+impl PartialEq<bool> for DataType {
+    fn eq(&self, other: &bool) -> bool {
+        match *self {
+            DataType::Bool(ref s) if *s == *other => true,
+            _ => false,
+        }
+    }
+}
+
+impl PartialEq<i64> for DataType {
+    fn eq(&self, other: &i64) -> bool {
+        match *self {
+            DataType::Int(ref s) if *s == *other => true,
+            _ => false,
+        }
+    }
+}
+
 impl fmt::Display for DataType {
     fn fmt(&self, f: &mut fmt::Formatter) -> ::std::result::Result<(), fmt::Error> {
         match *self {

--- a/src/datatype.rs
+++ b/src/datatype.rs
@@ -30,9 +30,41 @@ impl Default for DataType {
 }
 
 impl DataType {
-    /// Assess if `self == DataType::Empty`
+    /// Assess if datatype is empty
     pub fn is_empty(&self) -> bool {
         *self == DataType::Empty
+    }
+    /// Assess if datatype is a int
+    pub fn is_int(&self) -> bool {
+        if let DataType::Int(_) = *self {
+            true
+        } else {
+            false
+        }
+    }
+    /// Assess if datatype is a float
+    pub fn is_float(&self) -> bool {
+        if let DataType::Float(_) = *self {
+            true
+        } else {
+            false
+        }
+    }
+    /// Assess if datatype is a bool
+    pub fn is_bool(&self) -> bool {
+        if let DataType::Bool(_) = *self {
+            true
+        } else {
+            false
+        }
+    }
+    /// Assess if datatype is a string
+    pub fn is_string(&self) -> bool {
+        if let DataType::String(_) = *self {
+            true
+        } else {
+            false
+        }
     }
 }
 

--- a/src/datatype.rs
+++ b/src/datatype.rs
@@ -66,6 +66,39 @@ impl DataType {
             false
         }
     }
+
+    /// Try getting int value
+    pub fn get_int(&self) -> Option<i64> {
+        if let DataType::Int(v) = self {
+            Some(*v)
+        } else {
+            None
+        }
+    }
+    /// Try getting float value
+    pub fn get_float(&self) -> Option<f64> {
+        if let DataType::Float(v) = self {
+            Some(*v)
+        } else {
+            None
+        }
+    }
+    /// Try getting bool value
+    pub fn get_bool(&self) -> Option<bool> {
+        if let DataType::Bool(v) = self {
+            Some(*v)
+        } else {
+            None
+        }
+    }
+    /// Try getting string value
+    pub fn get_string(&self) -> Option<&str> {
+        if let DataType::String(v) = self {
+            Some(&**v)
+        } else {
+            None
+        }
+    }
 }
 
 impl PartialEq<str> for DataType {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -709,3 +709,9 @@ impl<'a, T: 'a + CellType> Iterator for Rows<'a, T> {
             .map_or((0, Some(0)), |ch| ch.size_hint())
     }
 }
+
+impl<'a, T: 'a + CellType> DoubleEndedIterator for Rows<'a, T> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.inner.as_mut().and_then(|c| c.next_back())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -590,6 +590,23 @@ impl<'a, T: 'a + CellType> Iterator for UsedCells<'a, T> {
                 (row, col, v)
             })
     }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let (_, up) = self.inner.size_hint();
+        (0, up)
+    }
+}
+
+impl<'a, T: 'a + CellType> DoubleEndedIterator for UsedCells<'a, T> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.inner
+            .by_ref()
+            .rfind(|&(_, v)| v != &T::default())
+            .map(|(i, v)| {
+                let row = i / self.width;
+                let col = i % self.width;
+                (row, col, v)
+            })
+    }
 }
 
 /// An iterator to read `Range` struct row by row
@@ -602,5 +619,10 @@ impl<'a, T: 'a + CellType> Iterator for Rows<'a, T> {
     type Item = &'a [T];
     fn next(&mut self) -> Option<Self::Item> {
         self.inner.as_mut().and_then(|c| c.next())
+    }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner
+            .as_ref()
+            .map_or((0, Some(0)), |ch| ch.size_hint())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -470,11 +470,18 @@ impl<T: CellType> Range<T> {
     pub fn get_value(&self, absolute_position: (u32, u32)) -> Option<&T> {
         let p = absolute_position;
         if p.0 >= self.start.0 && p.0 <= self.end.0 && p.1 >= self.start.1 && p.1 <= self.end.1 {
-            let idx = (absolute_position.0 - self.start.0) as usize * self.width()
-                + (absolute_position.1 - self.start.1) as usize;
-            return Some(&self.inner[idx]);
+            return self.get((
+                (absolute_position.0 - self.start.0) as usize,
+                (absolute_position.1 - self.start.1) as usize,
+            ));
         }
         None
+    }
+
+    /// Get cell value from **relative position**.
+    pub fn get(&self, relative_position: (usize, usize)) -> Option<&T> {
+        let (row, col) = relative_position;
+        self.inner.get(row * self.width() + col)
     }
 
     /// Get an iterator over inner rows


### PR DESCRIPTION
- `DataType`: 
  - impl `PartialEq` for easy filtering
  - add convenient `is_...` and `get_...` function to avoid destructuring (one-liners)
- iterators
  - add `size_hint`s (perf)
  - add `DoubleEndedIterator` (perf when searching from the end)
  - add `ExactSizeIterator` useful when collecting
  - add a new simple `Cells` iterator ... which iterates over empty and non empty cells
- `Range`
  - add a `Range::range` fn which creates a sub-range from this range (clones or empty).

Closes #141 
