### PR TITLE
fix `u32` overflow in `xls::parse_dimensions()` when (rl>0 && cl==0)

### DIFF
--- a/src/xls.rs
+++ b/src/xls.rs
@@ -446,7 +446,7 @@ fn parse_dimensions(r: &[u8]) -> Result<((u32, u32), (u32, u32)), XlsError> {
             });
         }
     };
-    if (1, 1) <= (rl, cl) {
+    if 1 <= rl && 1 <= cl {
         Ok(((rf, cf), (rl - 1, cl - 1)))
     } else {
         Ok(((rf, cf), (rf, cf)))


### PR DESCRIPTION
This PR fixes issue #150 .

I don't really know what `rf`, `cf`, `rl`, `cl` means. But `(1, 1) <= (rl, cl)` seems weird. This is not a pattern matching and comparing, is a comparison between tuples instead. 

`(A, B) <= (rl, cl)` means `A <= rl || B <= cl`, doesn't mean `A <= rl && B <= cl`.

I think `1 <= rl && 1 <= cl` is the intended code which guards the substraction of `(rl - 1, cl - 1)`. 

Please review this PR carefully. Thanks.