### PR TITLE
deprecate failure and impl std::error::Error for all errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calamine"
-version = "0.15.6"
+version = "0.16.0"
 authors = ["Johann Tuffe <tafia973@gmail.com>"]
 repository = "https://github.com/tafia/calamine"
 documentation = "https://docs.rs/calamine"
@@ -17,14 +17,12 @@ appveyor = { repository = "tafia/calamine" }
 [dependencies]
 byteorder = "1.3.2"
 codepage = "0.1.1"
-encoding_rs = "0.8.17"
-failure = "0.1.5"
-failure_derive = "0.1.5"
-log = "0.4.6"
+encoding_rs = "0.8.20"
+log = "0.4.8"
 serde = "1.0.99"
-quick-xml = { version = "0.16", features = ["encoding", "use-failure"] }
+quick-xml = { version = "0.17", features = ["encoding"] }
 zip = { version = "0.5.3", default-features = false, features = ["deflate"] }
 
 [dev-dependencies]
 glob = "0.3"
-env_logger = "0.6"
+env_logger = "0.7"

--- a/src/de.rs
+++ b/src/de.rs
@@ -59,17 +59,8 @@ impl fmt::Display for DeError {
     }
 }
 
-impl ::std::error::Error for DeError {
-    fn description(&self) -> &str {
-        match *self {
-            DeError::CellOutOfRange { .. } => "cell out of range",
-            DeError::CellError { .. } => "error in cell value",
-            DeError::UnexpectedEndOfRow { .. } => "unexpected end of row",
-            DeError::HeaderNotFound { .. } => "header not found",
-            DeError::Custom(ref s) => &**s,
-        }
-    }
-    fn cause(&self) -> Option<&::std::error::Error> {
+impl std::error::Error for DeError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         None
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,34 +1,25 @@
 //! A module to provide a convenient wrapper around all error types
 
 /// A struct to handle any error and a message
-#[derive(Fail, Debug)]
+#[derive(Debug)]
 pub enum Error {
     /// IO error
-    #[fail(display = "{}", _0)]
-    Io(#[cause] ::std::io::Error),
+    Io(::std::io::Error),
 
     /// Ods specific error
-    #[fail(display = "{}", _0)]
-    Ods(#[cause] ::ods::OdsError),
+    Ods(::ods::OdsError),
     /// xls specific error
-    #[fail(display = "{}", _0)]
-    Xls(#[cause] ::xls::XlsError),
+    Xls(::xls::XlsError),
     /// xlsb specific error
-    #[fail(display = "{}", _0)]
-    Xlsb(#[cause] ::xlsb::XlsbError),
+    Xlsb(::xlsb::XlsbError),
     /// xlsx specific error
-    #[fail(display = "{}", _0)]
-    Xlsx(#[cause] ::xlsx::XlsxError),
+    Xlsx(::xlsx::XlsxError),
     /// vba specific error
-    #[fail(display = "{}", _0)]
-    Vba(#[cause] ::vba::VbaError),
-    /// Auto error
+    Vba(::vba::VbaError),
     /// cfb specific error
-    #[fail(display = "{}", _0)]
-    De(#[cause] ::de::DeError),
+    De(::de::DeError),
 
     /// General error message
-    #[fail(display = "{}", _0)]
     Msg(&'static str),
 }
 
@@ -40,3 +31,33 @@ from_err!(::xlsx::XlsxError, Error, Xlsx);
 from_err!(::vba::VbaError, Error, Vba);
 from_err!(::de::DeError, Error, De);
 from_err!(&'static str, Error, Msg);
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Error::Io(e) => write!(f, "I/O error: {}", e),
+            Error::Ods(e) => write!(f, "Ods error: {}", e),
+            Error::Xls(e) => write!(f, "Xls error: {}", e),
+            Error::Xlsx(e) => write!(f, "Xlsx error: {}", e),
+            Error::Xlsb(e) => write!(f, "Xlsb error: {}", e),
+            Error::Vba(e) => write!(f, "Vba error: {}", e),
+            Error::De(e) => write!(f, "Deserializer error: {}", e),
+            Error::Msg(msg) => write!(f, "{}", msg),
+        }
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Error::Io(e) => Some(e),
+            Error::Ods(e) => Some(e),
+            Error::Xls(e) => Some(e),
+            Error::Xlsb(e) => Some(e),
+            Error::Xlsx(e) => Some(e),
+            Error::Vba(e) => Some(e),
+            Error::De(e) => Some(e),
+            _ => None,
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,8 +61,6 @@
 extern crate byteorder;
 extern crate codepage;
 extern crate encoding_rs;
-#[macro_use]
-extern crate failure;
 extern crate quick_xml;
 #[macro_use]
 extern crate serde;

--- a/src/xlsx.rs
+++ b/src/xlsx.rs
@@ -16,62 +16,42 @@ use {Cell, CellErrorType, DataType, Metadata, Range, Reader};
 type XlsReader<'a> = XmlReader<BufReader<ZipFile<'a>>>;
 
 /// An enum for Xlsx specific errors
-#[derive(Debug, Fail)]
+#[derive(Debug)]
 pub enum XlsxError {
     /// Io error
-    #[fail(display = "{}", _0)]
-    Io(#[cause] ::std::io::Error),
+    Io(::std::io::Error),
     /// Zip error
-    #[fail(display = "{}", _0)]
-    Zip(#[cause] ::zip::result::ZipError),
+    Zip(::zip::result::ZipError),
     /// Vba error
-    #[fail(display = "{}", _0)]
-    Vba(#[cause] ::vba::VbaError),
+    Vba(::vba::VbaError),
     /// Xml error
-    #[fail(display = "{}", _0)]
-    Xml(#[cause] ::quick_xml::Error),
+    Xml(::quick_xml::Error),
     /// Parse error
-    #[fail(display = "{}", _0)]
-    Parse(#[cause] ::std::string::ParseError),
+    Parse(::std::string::ParseError),
     /// Float error
-    #[fail(display = "{}", _0)]
-    ParseFloat(#[cause] ::std::num::ParseFloatError),
+    ParseFloat(::std::num::ParseFloatError),
     /// ParseInt error
-    #[fail(display = "{}", _0)]
-    ParseInt(#[cause] ::std::num::ParseIntError),
+    ParseInt(::std::num::ParseIntError),
 
     /// Unexpected end of xml
-    #[fail(display = "Unexpected end of xml, expecting '</{}>'", _0)]
     XmlEof(&'static str),
     /// Unexpected node
-    #[fail(display = "Expecting '{}' node", _0)]
     UnexpectedNode(&'static str),
     /// File not found
-    #[fail(display = "File not found '{}'", _0)]
     FileNotFound(String),
     /// Expecting alphanumeri character
-    #[fail(display = "Expecting alphanumeric character, got {:X}", _0)]
     Alphanumeric(u8),
     /// Numeric column
-    #[fail(
-        display = "Numeric character is not allowed for column name, got {}",
-        _0
-    )]
     NumericColumn(u8),
     /// Wrong dimension count
-    #[fail(display = "Range dimension must be lower than 2. Got {}", _0)]
     DimensionCount(usize),
     /// Cell 't' attribute error
-    #[fail(display = "Unknown cell 't' attribute: {:?}", _0)]
     CellTAttribute(String),
     /// Cell 'r' attribute error
-    #[fail(display = "Cell missing 'r' attribute")]
     CellRAttribute,
     /// Unexpected error
-    #[fail(display = "{}", _0)]
     Unexpected(&'static str),
     /// Cell error
-    #[fail(display = "Unsupported cell error value '{}'", _0)]
     CellError(String),
 }
 
@@ -82,6 +62,54 @@ from_err!(::quick_xml::Error, XlsxError, Xml);
 from_err!(::std::string::ParseError, XlsxError, Parse);
 from_err!(::std::num::ParseFloatError, XlsxError, ParseFloat);
 from_err!(::std::num::ParseIntError, XlsxError, ParseInt);
+
+impl std::fmt::Display for XlsxError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            XlsxError::Io(e) => write!(f, "I/O error: {}", e),
+            XlsxError::Zip(e) => write!(f, "Zip error: {}", e),
+            XlsxError::Xml(e) => write!(f, "Xml error: {}", e),
+            XlsxError::Vba(e) => write!(f, "Vba error: {}", e),
+            XlsxError::Parse(e) => write!(f, "Parse string error: {}", e),
+            XlsxError::ParseInt(e) => write!(f, "Parse integer error: {}", e),
+            XlsxError::ParseFloat(e) => write!(f, "Parse float error: {}", e),
+
+            XlsxError::XmlEof(e) => write!(f, "Unexpected end of xml, expecting '</{}>'", e),
+            XlsxError::UnexpectedNode(e) => write!(f, "Expecting '{}' node", e),
+            XlsxError::FileNotFound(e) => write!(f, "File not found '{}'", e),
+            XlsxError::Alphanumeric(e) => {
+                write!(f, "Expecting alphanumeric character, got {:X}", e)
+            }
+            XlsxError::NumericColumn(e) => write!(
+                f,
+                "Numeric character is not allowed for column name, got {}",
+                e
+            ),
+            XlsxError::DimensionCount(e) => {
+                write!(f, "Range dimension must be lower than 2. Got {}", e)
+            }
+            XlsxError::CellTAttribute(e) => write!(f, "Unknown cell 't' attribute: {:?}", e),
+            XlsxError::CellRAttribute => write!(f, "Cell missing 'r' attribute"),
+            XlsxError::Unexpected(e) => write!(f, "{}", e),
+            XlsxError::CellError(e) => write!(f, "Unsupported cell error value '{}'", e),
+        }
+    }
+}
+
+impl std::error::Error for XlsxError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            XlsxError::Io(e) => Some(e),
+            XlsxError::Zip(e) => Some(e),
+            XlsxError::Xml(e) => Some(e),
+            XlsxError::Vba(e) => Some(e),
+            XlsxError::Parse(e) => Some(e),
+            XlsxError::ParseInt(e) => Some(e),
+            XlsxError::ParseFloat(e) => Some(e),
+            _ => None,
+        }
+    }
+}
 
 impl FromStr for CellErrorType {
     type Err = XlsxError;
@@ -570,7 +598,7 @@ fn get_row_column(range: &[u8]) -> Result<(u32, u32), XlsxError> {
     let mut readrow = true;
     for c in range.iter().rev() {
         match *c {
-            c @ b'0'...b'9' => {
+            c @ b'0'..=b'9' => {
                 if readrow {
                     row += ((c - b'0') as u32) * pow;
                     pow *= 10;
@@ -578,7 +606,7 @@ fn get_row_column(range: &[u8]) -> Result<(u32, u32), XlsxError> {
                     return Err(XlsxError::NumericColumn(c));
                 }
             }
-            c @ b'A'...b'Z' => {
+            c @ b'A'..=b'Z' => {
                 if readrow {
                     pow = 1;
                     readrow = false;
@@ -586,7 +614,7 @@ fn get_row_column(range: &[u8]) -> Result<(u32, u32), XlsxError> {
                 col += ((c - b'A') as u32 + 1) * pow;
                 pow *= 26;
             }
-            c @ b'a'...b'z' => {
+            c @ b'a'..=b'z' => {
                 if readrow {
                     pow = 1;
                     readrow = false;


### PR DESCRIPTION
close #154 