### PR TITLE
Add `dates` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,12 @@ log = "0.4.8"
 serde = "1.0.99"
 quick-xml = { version = "0.17", features = ["encoding"] }
 zip = { version = "0.5.3", default-features = false, features = ["deflate"] }
+chrono = { version = "0.4.9", features = ["serde"], optional = true }
 
 [dev-dependencies]
 glob = "0.3"
 env_logger = "0.7"
+
+[features]
+default = []
+dates = ["chrono"]

--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,9 @@
   - test: Adding missing tests
   - chore: Changes to the build process or auxiliary tools/libraries/documentation
 
+## 0.16.0
+- feat: deprecate failure and impl `std::error::Error` for all errors.
+
 ## 0.15.6
 - feat: update dependencies
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,7 @@
 
 ## 0.16.0
 - feat: deprecate failure and impl `std::error::Error` for all errors.
+- feat: add `dates` feature to enrich `DataType` with date conversions fns.
 
 ## 0.15.6
 - feat: update dependencies

--- a/README.md
+++ b/README.md
@@ -116,6 +116,10 @@ for s in sheets {
 }
 ```
 
+## Features
+
+- `dates`: Add date related fn to `DataType`. 
+
 ### Others
 
 Browse the [examples](https://github.com/tafia/calamine/tree/master/examples) directory.
@@ -134,6 +138,7 @@ The main unsupported items are:
 - no support for writing excel files, this is a read-only library
 - no support for reading extra contents, such as formatting, excel parameter, encrypted components etc ...
 - no support for reading VB for opendocuments
+- dates: dates detection is not supported and will return `DataType::Float`. You can use the `dates` feature to get friendly conversions fn.
 
 ## Credits
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,4 +14,4 @@ build: false
 
 test_script:
   - cargo build
-  - cargo test
+  - cargo test --feature dates

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,4 +14,4 @@ build: false
 
 test_script:
   - cargo build
-  - cargo test --feature dates
+  - cargo test --features dates


### PR DESCRIPTION
This PR adds new fn to convert from `DataType` into `NaiveDate(Time)`s.
As it requires importing the whole chrono crate, this is behind a `dates` feature.