### PR TITLE
Exclude tests from package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ license = "MIT"
 readme = "README.md"
 keywords = ["excel", "vba", "office", "ods", "serde"]
 categories = ["encoding", "parsing", "text-processing"]
+exclude = ["tests/**/*"]
 
 [badges]
 travis-ci = { repository = "tafia/calamine" }


### PR DESCRIPTION
Following [issues](https://github.com/rust-lang/crates.io/issues/1866) I had to publish v0.16.0, this PR exclude `tests` folder from being published.

This reduces crate size from 4.4M to 56K!