### PR TITLE
typo in fn description

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -313,7 +313,7 @@ impl<T: CellType> Range<T> {
         }
     }
 
-    /// Get column width
+    /// Get column height
     #[inline]
     pub fn height(&self) -> usize {
         if self.is_empty() {


### PR DESCRIPTION
fn height has `Get column width` description now, so it goes to docs.rs docs also.