### PR TITLE
Update path formatting to Rust 2018

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target
 Cargo.lock
 *.bk
+.vim

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 keywords = ["excel", "vba", "office", "ods", "serde"]
 categories = ["encoding", "parsing", "text-processing"]
 exclude = ["tests/**/*"]
+edition = "2018"
 
 [badges]
 travis-ci = { repository = "tafia/calamine" }

--- a/benches/basic.rs
+++ b/benches/basic.rs
@@ -1,6 +1,5 @@
 #![feature(test)]
 
-extern crate calamine;
 extern crate test;
 
 use calamine::{open_workbook, Ods, Reader, Xls, Xlsb, Xlsx};

--- a/examples/excel_to_csv.rs
+++ b/examples/excel_to_csv.rs
@@ -1,5 +1,3 @@
-extern crate calamine;
-
 use calamine::{open_workbook_auto, DataType, Range, Reader};
 use std::env;
 use std::fs::File;
@@ -31,7 +29,7 @@ fn main() {
     write_range(&mut dest, &range).unwrap();
 }
 
-fn write_range<W: Write>(dest: &mut W, range: &Range<DataType>) -> ::std::io::Result<()> {
+fn write_range<W: Write>(dest: &mut W, range: &Range<DataType>) -> std::io::Result<()> {
     let n = range.get_size().1 - 1;
     for r in range.rows() {
         for (i, c) in r.iter().enumerate() {

--- a/examples/search_errors.rs
+++ b/examples/search_errors.rs
@@ -1,6 +1,3 @@
-extern crate calamine;
-extern crate glob;
-
 use std::env;
 use std::fs::File;
 use std::io::{BufWriter, Write};

--- a/src/auto.rs
+++ b/src/auto.rs
@@ -45,7 +45,7 @@ impl Reader for Sheets {
     }
 
     /// Gets `VbaProject`
-    fn vba_project(&mut self) -> Option<Result<Cow<VbaProject>, Self::Error>> {
+    fn vba_project(&mut self) -> Option<Result<Cow<'_, VbaProject>, Self::Error>> {
         match *self {
             Sheets::Xls(ref mut e) => e.vba_project().map(|vba| vba.map_err(Error::Xls)),
             Sheets::Xlsx(ref mut e) => e.vba_project().map(|vba| vba.map_err(Error::Xlsx)),

--- a/src/auto.rs
+++ b/src/auto.rs
@@ -1,12 +1,12 @@
 //! A module to convert file extension to reader
 
-use errors::Error;
+use crate::errors::Error;
+use crate::vba::VbaProject;
+use crate::{open_workbook, DataType, Metadata, Ods, Range, Reader, Xls, Xlsb, Xlsx};
 use std::borrow::Cow;
 use std::fs::File;
 use std::io::BufReader;
 use std::path::Path;
-use vba::VbaProject;
-use {open_workbook, DataType, Metadata, Ods, Range, Reader, Xls, Xlsb, Xlsx};
 
 /// A wrapper over all sheets when the file type is not known at static time
 pub enum Sheets {

--- a/src/cfb.rs
+++ b/src/cfb.rs
@@ -4,9 +4,11 @@ use std::borrow::Cow;
 use std::cmp::min;
 use std::io::Read;
 
+use log::debug;
+
 use encoding_rs::{Encoding, UTF_16LE, UTF_8};
 
-use utils::*;
+use crate::utils::*;
 
 const ENDOFCHAIN: u32 = 0xFFFF_FFFE;
 const FREESECT: u32 = 0xFFFF_FFFF;
@@ -15,7 +17,7 @@ const RESERVED_SECTORS: u32 = 0xFFFF_FFFA;
 /// A Cfb specific error enum
 #[derive(Debug)]
 pub enum CfbError {
-    Io(::std::io::Error),
+    Io(std::io::Error),
 
     Ole,
     EmptyRootDir,

--- a/src/cfb.rs
+++ b/src/cfb.rs
@@ -31,7 +31,7 @@ pub enum CfbError {
 }
 
 impl std::fmt::Display for CfbError {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             CfbError::Io(e) => write!(f, "I/O error: {}", e),
             CfbError::Ole => write!(f, "Invalid OLE signature (not an office document?)"),

--- a/src/datatype.rs
+++ b/src/datatype.rs
@@ -162,7 +162,7 @@ impl PartialEq<i64> for DataType {
 }
 
 impl fmt::Display for DataType {
-    fn fmt(&self, f: &mut fmt::Formatter) -> std::result::Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::result::Result<(), fmt::Error> {
         match *self {
             DataType::Int(ref e) => write!(f, "{}", e),
             DataType::Float(ref e) => write!(f, "{}", e),
@@ -185,7 +185,7 @@ impl<'de> Deserialize<'de> for DataType {
         impl<'de> Visitor<'de> for DataTypeVisitor {
             type Value = DataType;
 
-            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
                 formatter.write_str("any valid JSON value")
             }
 

--- a/src/datatype.rs
+++ b/src/datatype.rs
@@ -162,7 +162,7 @@ impl PartialEq<i64> for DataType {
 }
 
 impl fmt::Display for DataType {
-    fn fmt(&self, f: &mut fmt::Formatter) -> ::std::result::Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> std::result::Result<(), fmt::Error> {
         match *self {
             DataType::Int(ref e) => write!(f, "{}", e),
             DataType::Float(ref e) => write!(f, "{}", e),
@@ -287,13 +287,11 @@ where
 
 #[cfg(all(test, feature = "dates"))]
 mod tests {
-    extern crate chrono;
-
     use super::*;
 
     #[test]
     fn test_dates() {
-        use self::chrono::{Duration, NaiveDate, NaiveDateTime, NaiveTime};
+        use chrono::{Duration, NaiveDate, NaiveDateTime, NaiveTime};
 
         let unix_epoch = DataType::Float(25569.);
         assert_eq!(

--- a/src/de.rs
+++ b/src/de.rs
@@ -1,6 +1,6 @@
 use serde::de::value::BorrowedStrDeserializer;
 use serde::de::{self, DeserializeOwned, DeserializeSeed, SeqAccess, Visitor};
-use serde::{self, Deserialize};
+use serde::{self, forward_to_deserialize_any, Deserialize};
 use std::marker::PhantomData;
 use std::{fmt, slice, str};
 
@@ -542,10 +542,14 @@ macro_rules! deserialize_num {
                     err: err.clone(),
                     pos: self.pos,
                 }),
-                ref d => Err(DeError::Custom(format!("Expecting {}, got {:?}", stringify!($typ), d))),
+                ref d => Err(DeError::Custom(format!(
+                    "Expecting {}, got {:?}",
+                    stringify!($typ),
+                    d
+                ))),
             }
         }
-    }
+    };
 }
 
 /// A deserializer for the `DataType` type.

--- a/src/de.rs
+++ b/src/de.rs
@@ -35,7 +35,7 @@ pub enum DeError {
 }
 
 impl fmt::Display for DeError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         match *self {
             DeError::CellOutOfRange {
                 ref try_pos,
@@ -72,7 +72,7 @@ impl de::Error for DeError {
 }
 
 #[derive(Clone)]
-pub enum Headers<'h, H: 'h> {
+pub enum Headers<'h, H> {
     None,
     All,
     Custom(&'h [H]),
@@ -83,7 +83,7 @@ pub enum Headers<'h, H: 'h> {
 /// This can be used to optionally parse the first row as a header. Once built,
 /// a `RangeDeserializer`s cannot be changed.
 #[derive(Clone)]
-pub struct RangeDeserializerBuilder<'h, H: 'h> {
+pub struct RangeDeserializerBuilder<'h, H> {
     headers: Headers<'h, H>,
 }
 
@@ -237,7 +237,7 @@ impl<'h, H: AsRef<str> + Clone + 'h> RangeDeserializerBuilder<'h, H> {
 /// ```
 pub struct RangeDeserializer<'cell, T, D>
 where
-    T: 'cell + ToCellDeserializer<'cell>,
+    T: ToCellDeserializer<'cell>,
     D: DeserializeOwned,
 {
     column_indexes: Vec<usize>,
@@ -346,7 +346,7 @@ where
 
 struct RowDeserializer<'header, 'cell, T>
 where
-    T: 'cell + ToCellDeserializer<'cell>,
+    T: ToCellDeserializer<'cell>,
 {
     cells: &'cell [T],
     headers: Option<&'header [String]>,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -33,7 +33,7 @@ from_err!(crate::de::DeError, Error, De);
 from_err!(&'static str, Error, Msg);
 
 impl std::fmt::Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Error::Io(e) => write!(f, "I/O error: {}", e),
             Error::Ods(e) => write!(f, "Ods error: {}", e),

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -4,32 +4,32 @@
 #[derive(Debug)]
 pub enum Error {
     /// IO error
-    Io(::std::io::Error),
+    Io(std::io::Error),
 
     /// Ods specific error
-    Ods(::ods::OdsError),
+    Ods(crate::ods::OdsError),
     /// xls specific error
-    Xls(::xls::XlsError),
+    Xls(crate::xls::XlsError),
     /// xlsb specific error
-    Xlsb(::xlsb::XlsbError),
+    Xlsb(crate::xlsb::XlsbError),
     /// xlsx specific error
-    Xlsx(::xlsx::XlsxError),
+    Xlsx(crate::xlsx::XlsxError),
     /// vba specific error
-    Vba(::vba::VbaError),
+    Vba(crate::vba::VbaError),
     /// cfb specific error
-    De(::de::DeError),
+    De(crate::de::DeError),
 
     /// General error message
     Msg(&'static str),
 }
 
-from_err!(::std::io::Error, Error, Io);
-from_err!(::ods::OdsError, Error, Ods);
-from_err!(::xls::XlsError, Error, Xls);
-from_err!(::xlsb::XlsbError, Error, Xlsb);
-from_err!(::xlsx::XlsxError, Error, Xlsx);
-from_err!(::vba::VbaError, Error, Vba);
-from_err!(::de::DeError, Error, De);
+from_err!(std::io::Error, Error, Io);
+from_err!(crate::ods::OdsError, Error, Ods);
+from_err!(crate::xls::XlsError, Error, Xls);
+from_err!(crate::xlsb::XlsbError, Error, Xlsb);
+from_err!(crate::xlsx::XlsxError, Error, Xlsx);
+from_err!(crate::vba::VbaError, Error, Vba);
+from_err!(crate::de::DeError, Error, De);
 from_err!(&'static str, Error, Msg);
 
 impl std::fmt::Display for Error {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,19 +58,9 @@
 //! ```
 #![deny(missing_docs)]
 
-extern crate byteorder;
-extern crate codepage;
-extern crate encoding_rs;
-extern crate quick_xml;
-#[macro_use]
-extern crate serde;
-extern crate zip;
-
-#[macro_use]
-extern crate log;
-
 #[macro_use]
 mod utils;
+
 mod auto;
 mod cfb;
 mod datatype;
@@ -92,16 +82,16 @@ use std::io::{BufReader, Read, Seek};
 use std::ops::{Index, IndexMut};
 use std::path::Path;
 
-pub use auto::{open_workbook_auto, Sheets};
-pub use datatype::DataType;
-pub use de::{DeError, RangeDeserializer, RangeDeserializerBuilder, ToCellDeserializer};
-pub use errors::Error;
-pub use ods::{Ods, OdsError};
-pub use xls::{Xls, XlsError};
-pub use xlsb::{Xlsb, XlsbError};
-pub use xlsx::{Xlsx, XlsxError};
+pub use crate::auto::{open_workbook_auto, Sheets};
+pub use crate::datatype::DataType;
+pub use crate::de::{DeError, RangeDeserializer, RangeDeserializerBuilder, ToCellDeserializer};
+pub use crate::errors::Error;
+pub use crate::ods::{Ods, OdsError};
+pub use crate::xls::{Xls, XlsError};
+pub use crate::xlsb::{Xlsb, XlsbError};
+pub use crate::xlsx::{Xlsx, XlsxError};
 
-use vba::VbaProject;
+use crate::vba::VbaProject;
 
 // https://msdn.microsoft.com/en-us/library/office/ff839168.aspx
 /// An enum to represent all different errors that can appear as
@@ -159,7 +149,7 @@ pub trait Reader: Sized {
     /// Inner reader type
     type RS: Read + Seek;
     /// Error specific to file type
-    type Error: ::std::fmt::Debug + From<::std::io::Error>;
+    type Error: std::fmt::Debug + From<std::io::Error>;
 
     /// Creates a new instance.
     fn new(reader: Self::RS) -> Result<Self, Self::Error>;
@@ -194,12 +184,7 @@ pub trait Reader: Sized {
     /// Get the nth worksheet. Shortcut for getting the nth
     /// sheet_name, then the corresponding worksheet.
     fn worksheet_range_at(&mut self, n: usize) -> Option<Result<Range<DataType>, Self::Error>> {
-        let name = if let Some(name) = self.sheet_names().get(n) {
-            name
-        } else {
-            return None;
-        }
-        .to_string();
+        let name = self.sheet_names().get(n)?.to_string();
         self.worksheet_range(&name)
     }
 }
@@ -353,7 +338,7 @@ impl<T: CellType> Range<T> {
             // search bounds
             let row_start = cells.first().unwrap().pos.0;
             let row_end = cells.last().unwrap().pos.0;
-            let mut col_start = ::std::u32::MAX;
+            let mut col_start = std::u32::MAX;
             let mut col_end = 0;
             for c in cells.iter().map(|c| c.pos.1) {
                 if c < col_start {
@@ -682,7 +667,7 @@ impl<T: CellType> IndexMut<(usize, usize)> for Range<T> {
 #[derive(Debug)]
 pub struct Cells<'a, T: 'a + CellType> {
     width: usize,
-    inner: ::std::iter::Enumerate<::std::slice::Iter<'a, T>>,
+    inner: std::iter::Enumerate<std::slice::Iter<'a, T>>,
 }
 
 impl<'a, T: 'a + CellType> Iterator for Cells<'a, T> {
@@ -715,7 +700,7 @@ impl<'a, T: 'a + CellType> ExactSizeIterator for Cells<'a, T> {}
 #[derive(Debug)]
 pub struct UsedCells<'a, T: 'a + CellType> {
     width: usize,
-    inner: ::std::iter::Enumerate<::std::slice::Iter<'a, T>>,
+    inner: std::iter::Enumerate<std::slice::Iter<'a, T>>,
 }
 
 impl<'a, T: 'a + CellType> Iterator for UsedCells<'a, T> {
@@ -752,7 +737,7 @@ impl<'a, T: 'a + CellType> DoubleEndedIterator for UsedCells<'a, T> {
 /// An iterator to read `Range` struct row by row
 #[derive(Debug)]
 pub struct Rows<'a, T: 'a + CellType> {
-    inner: Option<::std::slice::Chunks<'a, T>>,
+    inner: Option<std::slice::Chunks<'a, T>>,
 }
 
 impl<'a, T: 'a + CellType> Iterator for Rows<'a, T> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,7 +117,7 @@ pub enum CellErrorType {
 }
 
 impl fmt::Display for CellErrorType {
-    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         match *self {
             CellErrorType::Div0 => write!(f, "#DIV/0!"),
             CellErrorType::NA => write!(f, "#N/A"),
@@ -154,7 +154,7 @@ pub trait Reader: Sized {
     /// Creates a new instance.
     fn new(reader: Self::RS) -> Result<Self, Self::Error>;
     /// Gets `VbaProject`
-    fn vba_project(&mut self) -> Option<Result<Cow<VbaProject>, Self::Error>>;
+    fn vba_project(&mut self) -> Option<Result<Cow<'_, VbaProject>, Self::Error>>;
     /// Initialize
     fn metadata(&self) -> &Metadata;
     /// Read worksheet data in corresponding worksheet path
@@ -489,7 +489,7 @@ impl<T: CellType> Range<T> {
     /// // with rows item row: &[DataType]
     /// assert_eq!(range.rows().map(|r| r.len()).sum::<usize>(), 18);
     /// ```
-    pub fn rows(&self) -> Rows<T> {
+    pub fn rows(&self) -> Rows<'_, T> {
         if self.inner.is_empty() {
             Rows { inner: None }
         } else {
@@ -501,7 +501,7 @@ impl<T: CellType> Range<T> {
     }
 
     /// Get an iterator over used cells only
-    pub fn used_cells(&self) -> UsedCells<T> {
+    pub fn used_cells(&self) -> UsedCells<'_, T> {
         UsedCells {
             width: self.width(),
             inner: self.inner.iter().enumerate(),
@@ -509,7 +509,7 @@ impl<T: CellType> Range<T> {
     }
 
     /// Get an iterator over all cells in this range
-    pub fn cells(&self) -> Cells<T> {
+    pub fn cells(&self) -> Cells<'_, T> {
         Cells {
             width: self.width(),
             inner: self.inner.iter().enumerate(),
@@ -665,7 +665,7 @@ impl<T: CellType> IndexMut<(usize, usize)> for Range<T> {
 
 /// A struct to iterate over all cells
 #[derive(Debug)]
-pub struct Cells<'a, T: 'a + CellType> {
+pub struct Cells<'a, T: CellType> {
     width: usize,
     inner: std::iter::Enumerate<std::slice::Iter<'a, T>>,
 }
@@ -698,7 +698,7 @@ impl<'a, T: 'a + CellType> ExactSizeIterator for Cells<'a, T> {}
 
 /// A struct to iterate over used cells
 #[derive(Debug)]
-pub struct UsedCells<'a, T: 'a + CellType> {
+pub struct UsedCells<'a, T: CellType> {
     width: usize,
     inner: std::iter::Enumerate<std::slice::Iter<'a, T>>,
 }
@@ -736,7 +736,7 @@ impl<'a, T: 'a + CellType> DoubleEndedIterator for UsedCells<'a, T> {
 
 /// An iterator to read `Range` struct row by row
 #[derive(Debug)]
-pub struct Rows<'a, T: 'a + CellType> {
+pub struct Rows<'a, T: CellType> {
     inner: Option<std::slice::Chunks<'a, T>>,
 }
 

--- a/src/ods.rs
+++ b/src/ods.rs
@@ -60,7 +60,7 @@ from_err!(std::string::ParseError, OdsError, Parse);
 from_err!(std::num::ParseFloatError, OdsError, ParseFloat);
 
 impl std::fmt::Display for OdsError {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             OdsError::Io(e) => write!(f, "I/O error: {}", e),
             OdsError::Zip(e) => write!(f, "Zip error: {}", e),
@@ -147,7 +147,7 @@ impl<RS: Read + Seek> Reader for Ods<RS> {
     }
 
     /// Gets `VbaProject`
-    fn vba_project(&mut self) -> Option<Result<Cow<VbaProject>, OdsError>> {
+    fn vba_project(&mut self) -> Option<Result<Cow<'_, VbaProject>, OdsError>> {
         None
     }
 
@@ -223,7 +223,7 @@ fn parse_content<RS: Read + Seek>(mut zip: ZipArchive<RS>) -> Result<Content, Od
     })
 }
 
-fn read_table(reader: &mut OdsReader) -> Result<(Range<DataType>, Range<String>), OdsError> {
+fn read_table(reader: &mut OdsReader<'_>) -> Result<(Range<DataType>, Range<String>), OdsError> {
     let mut cells = Vec::new();
     let mut formulas = Vec::new();
     let mut cols = Vec::new();
@@ -308,7 +308,7 @@ fn get_range<T: Default + Clone + PartialEq>(mut cells: Vec<T>, cols: &[usize]) 
 }
 
 fn read_row(
-    reader: &mut OdsReader,
+    reader: &mut OdsReader<'_>,
     row_buf: &mut Vec<u8>,
     cell_buf: &mut Vec<u8>,
     cells: &mut Vec<DataType>,
@@ -358,8 +358,8 @@ fn read_row(
 ///
 /// ODF 1.2-19.385
 fn get_datatype(
-    reader: &mut OdsReader,
-    atts: Attributes,
+    reader: &mut OdsReader<'_>,
+    atts: Attributes<'_>,
     buf: &mut Vec<u8>,
 ) -> Result<(DataType, String, bool), OdsError> {
     let mut is_string = false;
@@ -429,7 +429,7 @@ fn get_datatype(
     }
 }
 
-fn read_named_expressions(reader: &mut OdsReader) -> Result<Vec<(String, String)>, OdsError> {
+fn read_named_expressions(reader: &mut OdsReader<'_>) -> Result<Vec<(String, String)>, OdsError> {
     let mut defined_names = Vec::new();
     let mut buf = Vec::new();
     loop {

--- a/src/ods.rs
+++ b/src/ods.rs
@@ -14,9 +14,9 @@ use quick_xml::Reader as XmlReader;
 use zip::read::{ZipArchive, ZipFile};
 use zip::result::ZipError;
 
+use crate::vba::VbaProject;
+use crate::{DataType, Metadata, Range, Reader};
 use std::marker::PhantomData;
-use vba::VbaProject;
-use {DataType, Metadata, Range, Reader};
 
 const MIMETYPE: &[u8] = b"application/vnd.oasis.opendocument.spreadsheet";
 
@@ -26,17 +26,17 @@ type OdsReader<'a> = XmlReader<BufReader<ZipFile<'a>>>;
 #[derive(Debug)]
 pub enum OdsError {
     /// Io error
-    Io(::std::io::Error),
+    Io(std::io::Error),
     /// Zip error
-    Zip(::zip::result::ZipError),
+    Zip(zip::result::ZipError),
     /// Xml error
-    Xml(::quick_xml::Error),
+    Xml(quick_xml::Error),
     /// Error while parsing string
-    Parse(::std::string::ParseError),
+    Parse(std::string::ParseError),
     /// Error while parsing integer
-    ParseInt(::std::num::ParseIntError),
+    ParseInt(std::num::ParseIntError),
     /// Error while parsing float
-    ParseFloat(::std::num::ParseFloatError),
+    ParseFloat(std::num::ParseFloatError),
 
     /// Invalid MIME
     InvalidMime(Vec<u8>),
@@ -53,11 +53,11 @@ pub enum OdsError {
     },
 }
 
-from_err!(::std::io::Error, OdsError, Io);
-from_err!(::zip::result::ZipError, OdsError, Zip);
-from_err!(::quick_xml::Error, OdsError, Xml);
-from_err!(::std::string::ParseError, OdsError, Parse);
-from_err!(::std::num::ParseFloatError, OdsError, ParseFloat);
+from_err!(std::io::Error, OdsError, Io);
+from_err!(zip::result::ZipError, OdsError, Zip);
+from_err!(quick_xml::Error, OdsError, Xml);
+from_err!(std::string::ParseError, OdsError, Parse);
+from_err!(std::num::ParseFloatError, OdsError, ParseFloat);
 
 impl std::fmt::Display for OdsError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
@@ -256,7 +256,7 @@ fn get_range<T: Default + Clone + PartialEq>(mut cells: Vec<T>, cols: &[usize]) 
     // find smallest area with non empty Cells
     let mut row_min = None;
     let mut row_max = 0;
-    let mut col_min = ::std::usize::MAX;
+    let mut col_min = std::usize::MAX;
     let mut col_max = 0;
     {
         for (i, w) in cols.windows(2).enumerate() {
@@ -413,11 +413,11 @@ fn get_datatype(
                     if first_paragraph {
                         first_paragraph = false;
                     } else {
-                        s.push_str("\n");
+                        s.push('\n');
                     }
                 }
                 Ok(Event::Start(ref e)) if e.name() == b"text:s" => {
-                    s.push_str(" ");
+                    s.push(' ');
                 }
                 Err(e) => return Err(OdsError::Xml(e)),
                 Ok(Event::Eof) => return Err(OdsError::Eof("table:table-cell")),

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -15,10 +15,10 @@ macro_rules! from_err {
 /// Converts a &[u8] into a &[u32]
 pub fn to_u32(s: &[u8]) -> &[u32] {
     assert_eq!(s.len() % 4, 0);
-    unsafe { ::std::slice::from_raw_parts(s as *const [u8] as *const u32, s.len() / 4) }
+    unsafe { std::slice::from_raw_parts(s as *const [u8] as *const u32, s.len() / 4) }
 }
 pub fn read_slice<T>(s: &[u8]) -> T {
-    unsafe { ::std::ptr::read(&s[..::std::mem::size_of::<T>()] as *const [u8] as *const T) }
+    unsafe { std::ptr::read(&s[..std::mem::size_of::<T>()] as *const [u8] as *const T) }
 }
 
 pub fn read_u32(s: &[u8]) -> u32 {

--- a/src/vba.rs
+++ b/src/vba.rs
@@ -45,7 +45,7 @@ from_err!(crate::cfb::CfbError, VbaError, Cfb);
 from_err!(std::io::Error, VbaError, Io);
 
 impl std::fmt::Display for VbaError {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             VbaError::Io(e) => write!(f, "I/O error: {}", e),
             VbaError::Cfb(e) => write!(f, "Cfb error: {}", e),

--- a/src/vba.rs
+++ b/src/vba.rs
@@ -8,18 +8,18 @@ use std::io::Read;
 use std::path::PathBuf;
 
 use byteorder::{LittleEndian, ReadBytesExt};
-use log::Level;
+use log::{debug, log_enabled, warn, Level};
 
-use cfb::{Cfb, XlsEncoding};
-use utils::read_u16;
+use crate::cfb::{Cfb, XlsEncoding};
+use crate::utils::read_u16;
 
 /// A VBA specific error enum
 #[derive(Debug)]
 pub enum VbaError {
     /// Error comes from a cfb parsing
-    Cfb(::cfb::CfbError),
+    Cfb(crate::cfb::CfbError),
     /// Io error
-    Io(::std::io::Error),
+    Io(std::io::Error),
 
     /// Cannot find module
     ModuleNotFound(String),
@@ -41,8 +41,8 @@ pub enum VbaError {
     },
 }
 
-from_err!(::cfb::CfbError, VbaError, Cfb);
-from_err!(::std::io::Error, VbaError, Io);
+from_err!(crate::cfb::CfbError, VbaError, Cfb);
+from_err!(std::io::Error, VbaError, Io);
 
 impl std::fmt::Display for VbaError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
@@ -94,7 +94,7 @@ impl VbaProject {
     pub fn from_cfb<R: Read>(r: &mut R, cfb: &mut Cfb) -> Result<VbaProject, VbaError> {
         // dir stream
         let stream = cfb.get_stream("dir", r)?;
-        let stream = ::cfb::decompress_stream(&*stream)?;
+        let stream = crate::cfb::decompress_stream(&*stream)?;
         let stream = &mut &*stream;
 
         // read dir information record (not used)
@@ -111,7 +111,7 @@ impl VbaProject {
             .into_iter()
             .map(|m| {
                 cfb.get_stream(&m.stream_name, r).and_then(|s| {
-                    ::cfb::decompress_stream(&s[m.text_offset..]).map(move |s| (m.name, s))
+                    crate::cfb::decompress_stream(&s[m.text_offset..]).map(move |s| (m.name, s))
                 })
             })
             .collect::<Result<HashMap<_, _>, _>>()?;

--- a/src/xls.rs
+++ b/src/xls.rs
@@ -64,7 +64,7 @@ from_err!(crate::cfb::CfbError, XlsError, Cfb);
 from_err!(crate::vba::VbaError, XlsError, Vba);
 
 impl std::fmt::Display for XlsError {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             XlsError::Io(e) => write!(f, "I/O error: {}", e),
             XlsError::Cfb(e) => write!(f, "Cfb error: {}", e),
@@ -147,7 +147,7 @@ impl<RS: Read + Seek> Reader for Xls<RS> {
         Ok(xls)
     }
 
-    fn vba_project(&mut self) -> Option<Result<Cow<VbaProject>, XlsError>> {
+    fn vba_project(&mut self) -> Option<Result<Cow<'_, VbaProject>, XlsError>> {
         self.vba.as_ref().map(|vba| Ok(Cow::Borrowed(vba)))
     }
 
@@ -299,7 +299,7 @@ impl<RS: Read + Seek> Xls<RS> {
 
 /// BoundSheet8 [MS-XLS 2.4.28]
 fn parse_sheet_name(
-    r: &mut Record,
+    r: &mut Record<'_>,
     encoding: &mut XlsEncoding,
 ) -> Result<(usize, String), XlsError> {
     let pos = read_u32(r.data) as usize;
@@ -424,7 +424,7 @@ fn rk_num(rk: &[u8]) -> DataType {
 }
 
 /// ShortXLUnicodeString [MS-XLS 2.5.240]
-fn parse_short_string(r: &mut Record, encoding: &mut XlsEncoding) -> Result<String, XlsError> {
+fn parse_short_string(r: &mut Record<'_>, encoding: &mut XlsEncoding) -> Result<String, XlsError> {
     if r.data.len() < 2 {
         return Err(XlsError::Len {
             typ: "short string",
@@ -499,7 +499,7 @@ fn parse_dimensions(r: &[u8]) -> Result<Dimensions, XlsError> {
     }
 }
 
-fn parse_sst(r: &mut Record, encoding: &mut XlsEncoding) -> Result<Vec<String>, XlsError> {
+fn parse_sst(r: &mut Record<'_>, encoding: &mut XlsEncoding) -> Result<Vec<String>, XlsError> {
     if r.data.len() < 8 {
         return Err(XlsError::Len {
             typ: "sst",
@@ -517,7 +517,7 @@ fn parse_sst(r: &mut Record, encoding: &mut XlsEncoding) -> Result<Vec<String>, 
 }
 
 fn read_rich_extended_string(
-    r: &mut Record,
+    r: &mut Record<'_>,
     encoding: &mut XlsEncoding,
 ) -> Result<String, XlsError> {
     if r.data.is_empty() && !r.continue_record() || r.data.len() < 3 {
@@ -568,7 +568,7 @@ fn read_rich_extended_string(
 fn read_dbcs(
     encoding: &mut XlsEncoding,
     mut len: usize,
-    r: &mut Record,
+    r: &mut Record<'_>,
 ) -> Result<String, XlsError> {
     let mut s = String::with_capacity(len);
     while len > 0 {

--- a/src/xlsb.rs
+++ b/src/xlsb.rs
@@ -66,7 +66,7 @@ from_err!(zip::result::ZipError, XlsbError, Zip);
 from_err!(quick_xml::Error, XlsbError, Xml);
 
 impl std::fmt::Display for XlsbError {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             XlsbError::Io(e) => write!(f, "I/O error: {}", e),
             XlsbError::Zip(e) => write!(f, "Zip error: {}", e),
@@ -492,7 +492,7 @@ impl<RS: Read + Seek> Reader for Xlsb<RS> {
         Ok(xlsb)
     }
 
-    fn vba_project(&mut self) -> Option<Result<Cow<VbaProject>, XlsbError>> {
+    fn vba_project(&mut self) -> Option<Result<Cow<'_, VbaProject>, XlsbError>> {
         self.zip.by_name("xl/vbaProject.bin").ok().map(|mut f| {
             let len = f.size() as usize;
             VbaProject::new(&mut f, len)

--- a/src/xlsx.rs
+++ b/src/xlsx.rs
@@ -10,8 +10,8 @@ use quick_xml::Reader as XmlReader;
 use zip::read::{ZipArchive, ZipFile};
 use zip::result::ZipError;
 
-use vba::VbaProject;
-use {Cell, CellErrorType, DataType, Metadata, Range, Reader};
+use crate::vba::VbaProject;
+use crate::{Cell, CellErrorType, DataType, Metadata, Range, Reader};
 
 type XlsReader<'a> = XmlReader<BufReader<ZipFile<'a>>>;
 
@@ -19,19 +19,19 @@ type XlsReader<'a> = XmlReader<BufReader<ZipFile<'a>>>;
 #[derive(Debug)]
 pub enum XlsxError {
     /// Io error
-    Io(::std::io::Error),
+    Io(std::io::Error),
     /// Zip error
-    Zip(::zip::result::ZipError),
+    Zip(zip::result::ZipError),
     /// Vba error
-    Vba(::vba::VbaError),
+    Vba(crate::vba::VbaError),
     /// Xml error
-    Xml(::quick_xml::Error),
+    Xml(quick_xml::Error),
     /// Parse error
-    Parse(::std::string::ParseError),
+    Parse(std::string::ParseError),
     /// Float error
-    ParseFloat(::std::num::ParseFloatError),
+    ParseFloat(std::num::ParseFloatError),
     /// ParseInt error
-    ParseInt(::std::num::ParseIntError),
+    ParseInt(std::num::ParseIntError),
 
     /// Unexpected end of xml
     XmlEof(&'static str),
@@ -55,13 +55,13 @@ pub enum XlsxError {
     CellError(String),
 }
 
-from_err!(::std::io::Error, XlsxError, Io);
-from_err!(::zip::result::ZipError, XlsxError, Zip);
-from_err!(::vba::VbaError, XlsxError, Vba);
-from_err!(::quick_xml::Error, XlsxError, Xml);
-from_err!(::std::string::ParseError, XlsxError, Parse);
-from_err!(::std::num::ParseFloatError, XlsxError, ParseFloat);
-from_err!(::std::num::ParseIntError, XlsxError, ParseInt);
+from_err!(std::io::Error, XlsxError, Io);
+from_err!(zip::result::ZipError, XlsxError, Zip);
+from_err!(crate::vba::VbaError, XlsxError, Vba);
+from_err!(quick_xml::Error, XlsxError, Xml);
+from_err!(std::string::ParseError, XlsxError, Parse);
+from_err!(std::num::ParseFloatError, XlsxError, ParseFloat);
+from_err!(std::num::ParseIntError, XlsxError, ParseInt);
 
 impl std::fmt::Display for XlsxError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
@@ -543,9 +543,7 @@ fn read_sheet_data(
                 ))
             }
             Some(t) => {
-                let t = ::std::str::from_utf8(t)
-                    .unwrap_or("<utf8 error>")
-                    .to_string();
+                let t = std::str::from_utf8(t).unwrap_or("<utf8 error>").to_string();
                 Err(XlsxError::CellTAttribute(t))
             }
         }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,6 +1,3 @@
-extern crate calamine;
-extern crate env_logger;
-
 use calamine::CellErrorType::*;
 use calamine::DataType::{Bool, Empty, Error, Float, String};
 use calamine::{open_workbook, open_workbook_auto, Ods, Reader, Xls, Xlsb, Xlsx};
@@ -12,7 +9,7 @@ static INIT: Once = Once::new();
 /// Setup function that is only run once, even if called multiple times.
 fn setup() {
     INIT.call_once(|| {
-        ::env_logger::init();
+        env_logger::init();
     });
 }
 


### PR DESCRIPTION
See https://doc.rust-lang.org/edition-guide/rust-2018/module-system/path-clarity.html and https://doc.rust-lang.org/edition-guide/editions/transitioning-an-existing-project-to-a-new-edition.html

The changes are pretty small overall, mostly just removing the `extern crate` declarations and adding a few anonymous lifetime markers on structs.