### PR TITLE
Remove unsafe

### DIFF
--- a/src/cfb.rs
+++ b/src/cfb.rs
@@ -83,7 +83,7 @@ impl Cfb {
         debug!("load difat");
         let mut sector_id = h.difat_start;
         while sector_id < RESERVED_SECTORS {
-            difat.extend_from_slice(to_u32(sectors.get(sector_id, reader)?));
+            difat.extend(to_u32(sectors.get(sector_id, reader)?));
             sector_id = difat.pop().unwrap(); //TODO: check if in infinite loop
         }
 
@@ -91,7 +91,7 @@ impl Cfb {
         debug!("load fat");
         let mut fats = Vec::with_capacity(h.fat_len);
         for id in difat.into_iter().filter(|id| *id != FREESECT) {
-            fats.extend_from_slice(to_u32(sectors.get(id, reader)?));
+            fats.extend(to_u32(sectors.get(id, reader)?));
         }
 
         // get the list of directory sectors
@@ -116,7 +116,7 @@ impl Cfb {
             reader,
             h.mini_fat_len * h.sector_size,
         )?;
-        let minifat = to_u32(&minifat).to_vec();
+        let minifat = to_u32(&minifat).collect();
         Ok(Cfb {
             directories: dirs,
             sectors,
@@ -208,7 +208,7 @@ impl Header {
         let difat_len = read_usize(&buf[62..76]);
 
         let mut difat = Vec::with_capacity(difat_len);
-        difat.extend_from_slice(to_u32(&buf[76..512]));
+        difat.extend(to_u32(&buf[76..512]));
 
         Ok((
             Header {

--- a/src/cfb.rs
+++ b/src/cfb.rs
@@ -245,9 +245,7 @@ impl Sectors {
         let end = start + self.size;
         if end > self.data.len() {
             let mut len = self.data.len();
-            unsafe {
-                self.data.set_len(end);
-            }
+            self.data.resize(end, 0);
             // read_exact or stop if EOF
             while len < end {
                 let read = r.read(&mut self.data[len..end]).map_err(CfbError::Io)?;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -19,16 +19,43 @@ pub fn to_u32(s: &[u8]) -> impl ExactSizeIterator<Item = u32> + '_ {
         .map(|data| u32::from_ne_bytes([data[0], data[1], data[2], data[3]]))
 }
 
-pub fn read_slice<T>(s: &[u8]) -> T {
-    unsafe { std::ptr::read(&s[..std::mem::size_of::<T>()] as *const [u8] as *const T) }
+pub(crate) fn read_slice_u16(s: &[u8]) -> impl ExactSizeIterator<Item = u16> + '_ {
+    s.chunks(2)
+        .map(|chunk| u16::from_ne_bytes([chunk[0], chunk[1]]))
+}
+
+pub(crate) fn read_slice_i32(s: &[u8]) -> impl ExactSizeIterator<Item = i32> + '_ {
+    s.chunks(4)
+        .map(|chunk| i32::from_ne_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]))
+}
+
+pub(crate) fn read_slice_u32(s: &[u8]) -> impl ExactSizeIterator<Item = u32> + '_ {
+    s.chunks(4)
+        .map(|chunk| u32::from_ne_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]))
+}
+
+pub(crate) fn read_slice_u64(s: &[u8]) -> impl ExactSizeIterator<Item = u64> + '_ {
+    s.chunks(8).map(|chunk| {
+        u64::from_ne_bytes([
+            chunk[0], chunk[1], chunk[2], chunk[3], chunk[4], chunk[5], chunk[6], chunk[7],
+        ])
+    })
+}
+
+pub(crate) fn read_slice_f64(s: &[u8]) -> impl ExactSizeIterator<Item = f64> + '_ {
+    s.chunks(8).map(|chunk| {
+        f64::from_ne_bytes([
+            chunk[0], chunk[1], chunk[2], chunk[3], chunk[4], chunk[5], chunk[6], chunk[7],
+        ])
+    })
 }
 
 pub fn read_u32(s: &[u8]) -> u32 {
-    read_slice(s)
+    read_slice_u32(s).next().unwrap()
 }
 
 pub fn read_u16(s: &[u8]) -> u16 {
-    read_slice(s)
+    read_slice_u16(s).next().unwrap()
 }
 
 pub fn read_usize(s: &[u8]) -> usize {
@@ -1043,26 +1070,6 @@ mod tests {
         assert_eq!(
             to_u32(data).collect::<Vec<_>>(),
             [u32::from_ne_bytes(*b"ABCD"), u32::from_ne_bytes(*b"EFGH")]
-        );
-    }
-
-    #[test]
-    fn sound_read_slice() {
-        #[derive(Debug, PartialEq, Eq)]
-        struct A {
-            a: u8,
-            b: u16,
-            c: u64,
-        }
-
-        let data = [b'a'; 24];
-        assert_eq!(
-            read_slice::<A>(&data),
-            A {
-                a: b'a',
-                b: u16::from_ne_bytes([b'a'; 2]),
-                c: u64::from_ne_bytes([b'a'; 8])
-            }
         );
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1030,3 +1030,37 @@ pub const FTAB_ARGC: [u8; FTAB_LEN] = [
     3,   // "AVERAGEIF",
     129, // "AVERAGEIFS"
 ];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sound_to_u32() {
+        let data = b"ABCDEFGH";
+        assert_eq!(
+            to_u32(data),
+            &[u32::from_ne_bytes(*b"ABCD"), u32::from_ne_bytes(*b"EFGH")]
+        );
+    }
+
+    #[test]
+    fn sound_read_slice() {
+        #[derive(Debug, PartialEq, Eq)]
+        struct A {
+            a: u8,
+            b: u16,
+            c: u64,
+        }
+
+        let data = [b'a'; 24];
+        assert_eq!(
+            read_slice::<A>(&data),
+            A {
+                a: b'a',
+                b: u16::from_ne_bytes([b'a'; 2]),
+                c: u64::from_ne_bytes([b'a'; 8])
+            }
+        );
+    }
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -15,27 +15,27 @@ macro_rules! from_err {
 /// Converts a &[u8] into an iterator of `u32`s
 pub fn to_u32(s: &[u8]) -> impl ExactSizeIterator<Item = u32> + '_ {
     assert_eq!(s.len() % 4, 0);
-    s.chunks(4)
+    s.chunks_exact(4)
         .map(|data| u32::from_ne_bytes([data[0], data[1], data[2], data[3]]))
 }
 
 pub(crate) fn read_slice_u16(s: &[u8]) -> impl ExactSizeIterator<Item = u16> + '_ {
-    s.chunks(2)
+    s.chunks_exact(2)
         .map(|chunk| u16::from_ne_bytes([chunk[0], chunk[1]]))
 }
 
 pub(crate) fn read_slice_i32(s: &[u8]) -> impl ExactSizeIterator<Item = i32> + '_ {
-    s.chunks(4)
+    s.chunks_exact(4)
         .map(|chunk| i32::from_ne_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]))
 }
 
 pub(crate) fn read_slice_u32(s: &[u8]) -> impl ExactSizeIterator<Item = u32> + '_ {
-    s.chunks(4)
+    s.chunks_exact(4)
         .map(|chunk| u32::from_ne_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]))
 }
 
 pub(crate) fn read_slice_u64(s: &[u8]) -> impl ExactSizeIterator<Item = u64> + '_ {
-    s.chunks(8).map(|chunk| {
+    s.chunks_exact(8).map(|chunk| {
         u64::from_ne_bytes([
             chunk[0], chunk[1], chunk[2], chunk[3], chunk[4], chunk[5], chunk[6], chunk[7],
         ])
@@ -43,7 +43,7 @@ pub(crate) fn read_slice_u64(s: &[u8]) -> impl ExactSizeIterator<Item = u64> + '
 }
 
 pub(crate) fn read_slice_f64(s: &[u8]) -> impl ExactSizeIterator<Item = f64> + '_ {
-    s.chunks(8).map(|chunk| {
+    s.chunks_exact(8).map(|chunk| {
         f64::from_ne_bytes([
             chunk[0], chunk[1], chunk[2], chunk[3], chunk[4], chunk[5], chunk[6], chunk[7],
         ])

--- a/src/xlsb.rs
+++ b/src/xlsb.rs
@@ -12,7 +12,7 @@ use quick_xml::Reader as XmlReader;
 use zip::read::{ZipArchive, ZipFile};
 use zip::result::ZipError;
 
-use crate::utils::{push_column, read_slice, read_u16, read_u32, read_usize};
+use crate::utils::{push_column, read_slice_f64, read_slice_i32, read_u16, read_u32, read_usize};
 use crate::vba::VbaProject;
 use crate::{Cell, CellErrorType, DataType, Metadata, Range, Reader};
 
@@ -255,7 +255,7 @@ impl<RS: Read + Seek> Xlsb<RS> {
                     let extern_sheets = buf[4..]
                         .chunks(12)
                         .map(|xti| {
-                            match read_slice::<i32>(&xti[4..8]) {
+                            match read_slice_i32(&xti[4..8]).next().unwrap() {
                                 -2 => "#ThisWorkbook",
                                 -1 => "#InvalidWorkSheet",
                                 p if p >= 0 && (p as usize) < sheets.len() => &sheets[p as usize].0,
@@ -337,7 +337,7 @@ impl<RS: Read + Seek> Xlsb<RS> {
                     let is_int = (buf[8] & 2) != 0;
                     buf[8] &= 0xFC;
                     if is_int {
-                        let v = (read_slice::<i32>(&buf[8..12]) >> 2) as i64;
+                        let v = (read_slice_i32(&buf[8..12]).next().unwrap() >> 2) as i64;
                         if d100 {
                             DataType::Float((v as f64) / 100.0)
                         } else {
@@ -346,7 +346,7 @@ impl<RS: Read + Seek> Xlsb<RS> {
                     } else {
                         let mut v = [0u8; 8];
                         v[4..].copy_from_slice(&buf[8..12]);
-                        let v = read_slice(&v);
+                        let v = read_slice_f64(&v).next().unwrap();
                         DataType::Float(if d100 { v / 100.0 } else { v })
                     }
                 }
@@ -366,7 +366,7 @@ impl<RS: Read + Seek> Xlsb<RS> {
                     DataType::Error(error)
                 }
                 0x0004 | 0x000A => DataType::Bool(buf[8] != 0), // BrtCellBool or BrtFmlaBool
-                0x0005 | 0x0009 => DataType::Float(read_slice(&buf[8..16])), // BrtCellReal or BrtFmlaFloat
+                0x0005 | 0x0009 => DataType::Float(read_slice_f64(&buf[8..16]).next().unwrap()), // BrtCellReal or BrtFmlaFloat
                 0x0006 | 0x0008 => DataType::String(wide_str(&buf[8..], &mut 0)?.into_owned()), // BrtCellSt or BrtFmlaString
                 0x0007 => {
                     // BrtCellIsst
@@ -809,7 +809,7 @@ fn parse_formula(
             }
             0x1F => {
                 stack.push(formula.len());
-                formula.push_str(&format!("{}", read_slice::<f64>(rgce)));
+                formula.push_str(&format!("{}", read_slice_f64(rgce).next().unwrap()));
                 rgce = &rgce[8..];
             }
             0x20 | 0x40 | 0x60 => {


### PR DESCRIPTION
This PR fixes the following issues:
* Issue #199
* Unsound implementation of `to_u32`
* Unsound implementation of `read_slice`

The unsoundness of the last two issues is reproducible after commit https://github.com/tafia/calamine/commit/d06428a7a4a34ffe6447b0718f6fe27b5da2f595 using miri.
`to_u32` has been modified in order to return an iterator of `u32`s.
Similarly, `read_slice` has been removed and an implementation has been written for each type. Unfortunately, with the current limitations of the trait system, it is not possible to create a generalized version because of the lifetime of the output iterator. I noticed that most of the time only the first value from the iterator is really needed. Moreover, to maintain the current behavior, it is assumed that the value is always obtained, therefore `unwrap` has been used, but a proper error handling is recommended.

I also recommend at least a patch version bump after this PR is merged.
Fixes #199 

*EDIT*: I forgot to say that I introduced usage of `TryFrom`, therefore I could have bumped MSRV to 1.34,