### PR TITLE
Add big endian test to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: rust
 cache: cargo
 sudo: false
 
+arch:
+  - amd64
+  - s390x
+
 rust:
   - nightly
   - beta


### PR DESCRIPTION
While I was making my last PR, I noticed that the data decoding was assuming a little endian machine.

I just added a big endian arch to travis in order to test both major endianness models. This obviously makes tests fail, but at least it is a good starting point to fix things.