### PR TITLE
Improve conversions from raw data to primitives

### DIFF
--- a/src/cfb.rs
+++ b/src/cfb.rs
@@ -2,6 +2,7 @@
 
 use std::borrow::Cow;
 use std::cmp::min;
+use std::convert::TryInto;
 use std::io::Read;
 
 use log::debug;
@@ -167,7 +168,10 @@ impl Header {
         f.read_exact(&mut buf).map_err(CfbError::Io)?;
 
         // check ole signature
-        if read_slice_u64(buf.as_ref()).next() != Some(0xE11A_B1A1_E011_CFD0) {
+        let signature = buf
+            .get(0..8)
+            .map(|slice| u64::from_le_bytes(slice.try_into().unwrap()));
+        if signature != Some(0xE11A_B1A1_E011_CFD0) {
             return Err(CfbError::Ole);
         }
 
@@ -291,20 +295,15 @@ struct Directory {
 
 impl Directory {
     fn from_slice(buf: &[u8], sector_size: usize) -> Directory {
-        use std::convert::TryFrom;
-
         let mut name = UTF_16LE.decode(&buf[..64]).0.into_owned();
         if let Some(l) = name.as_bytes().iter().position(|b| *b == 0) {
             name.truncate(l);
         }
         let start = read_u32(&buf[116..120]);
-        let len = if sector_size == 512 {
-            read_slice_u32(&buf[120..124]).next().unwrap() as usize
+        let len: usize = if sector_size == 512 {
+            read_u32(&buf[120..124]).try_into().unwrap()
         } else {
-            read_slice_u64(&buf[120..128])
-                .next()
-                .and_then(|x| usize::try_from(x).ok())
-                .unwrap()
+            read_u64(&buf[120..128]).try_into().unwrap()
         };
 
         Directory { start, len, name }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,6 @@
 //! Internal module providing handy function
 
-#![allow(clippy::cast_ptr_alignment)]
+use std::convert::TryInto;
 
 macro_rules! from_err {
     ($from:ty, $to:tt, $var:tt) => {
@@ -16,50 +16,37 @@ macro_rules! from_err {
 pub fn to_u32(s: &[u8]) -> impl ExactSizeIterator<Item = u32> + '_ {
     assert_eq!(s.len() % 4, 0);
     s.chunks_exact(4)
-        .map(|data| u32::from_ne_bytes([data[0], data[1], data[2], data[3]]))
+        .map(|data| u32::from_le_bytes(data.try_into().unwrap()))
 }
 
-pub(crate) fn read_slice_u16(s: &[u8]) -> impl ExactSizeIterator<Item = u16> + '_ {
-    s.chunks_exact(2)
-        .map(|chunk| u16::from_ne_bytes([chunk[0], chunk[1]]))
-}
-
-pub(crate) fn read_slice_i32(s: &[u8]) -> impl ExactSizeIterator<Item = i32> + '_ {
-    s.chunks_exact(4)
-        .map(|chunk| i32::from_ne_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]))
-}
-
-pub(crate) fn read_slice_u32(s: &[u8]) -> impl ExactSizeIterator<Item = u32> + '_ {
-    s.chunks_exact(4)
-        .map(|chunk| u32::from_ne_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]))
-}
-
-pub(crate) fn read_slice_u64(s: &[u8]) -> impl ExactSizeIterator<Item = u64> + '_ {
-    s.chunks_exact(8).map(|chunk| {
-        u64::from_ne_bytes([
-            chunk[0], chunk[1], chunk[2], chunk[3], chunk[4], chunk[5], chunk[6], chunk[7],
-        ])
-    })
-}
-
-pub(crate) fn read_slice_f64(s: &[u8]) -> impl ExactSizeIterator<Item = f64> + '_ {
-    s.chunks_exact(8).map(|chunk| {
-        f64::from_ne_bytes([
-            chunk[0], chunk[1], chunk[2], chunk[3], chunk[4], chunk[5], chunk[6], chunk[7],
-        ])
-    })
-}
-
+#[inline]
 pub fn read_u32(s: &[u8]) -> u32 {
-    read_slice_u32(s).next().unwrap()
+    u32::from_le_bytes(s[..4].try_into().unwrap())
 }
 
+#[inline]
+pub fn read_i32(s: &[u8]) -> i32 {
+    i32::from_le_bytes(s[..4].try_into().unwrap())
+}
+
+#[inline]
 pub fn read_u16(s: &[u8]) -> u16 {
-    read_slice_u16(s).next().unwrap()
+    u16::from_le_bytes(s[..2].try_into().unwrap())
 }
 
+#[inline]
+pub fn read_u64(s: &[u8]) -> u64 {
+    u64::from_le_bytes(s[..8].try_into().unwrap())
+}
+
+#[inline]
 pub fn read_usize(s: &[u8]) -> usize {
-    read_u32(s) as usize
+    read_u32(s).try_into().unwrap()
+}
+
+#[inline]
+pub fn read_f64(s: &[u8]) -> f64 {
+    f64::from_le_bytes(s[..8].try_into().unwrap())
 }
 
 /// Push literal column into a String buffer
@@ -1069,7 +1056,7 @@ mod tests {
         let data = b"ABCDEFGH";
         assert_eq!(
             to_u32(data).collect::<Vec<_>>(),
-            [u32::from_ne_bytes(*b"ABCD"), u32::from_ne_bytes(*b"EFGH")]
+            [u32::from_le_bytes(*b"ABCD"), u32::from_le_bytes(*b"EFGH")]
         );
     }
 }

--- a/src/xls.rs
+++ b/src/xls.rs
@@ -1,14 +1,14 @@
 use std::borrow::Cow;
 use std::cmp::min;
 use std::collections::HashMap;
-use std::convert::TryFrom;
+use std::convert::{TryFrom, TryInto};
 use std::io::{Read, Seek, SeekFrom};
 use std::marker::PhantomData;
 
 use log::debug;
 
 use crate::cfb::{Cfb, XlsEncoding};
-use crate::utils::{push_column, read_slice_f64, read_slice_i32, read_u16, read_u32};
+use crate::utils::{push_column, read_f64, read_i32, read_u16, read_u32};
 use crate::vba::VbaProject;
 use crate::{Cell, CellErrorType, DataType, Metadata, Range, Reader};
 
@@ -318,7 +318,7 @@ fn parse_number(r: &[u8]) -> Result<Cell<DataType>, XlsError> {
     }
     let row = read_u16(r) as u32;
     let col = read_u16(&r[2..]) as u32;
-    let v = read_slice_f64(&r[6..]).next().unwrap();
+    let v = read_f64(&r[6..]);
     Ok(Cell::new((row, col), DataType::Float(v)))
 }
 
@@ -412,14 +412,14 @@ fn rk_num(rk: &[u8]) -> DataType {
     v[4..].copy_from_slice(rk);
     v[0] &= 0xFC;
     if is_int {
-        let v = (read_slice_i32(&v[4..]).next().unwrap() >> 2) as i64;
+        let v = (read_i32(&v[4..8]) >> 2) as i64;
         if d100 && v % 100 != 0 {
             DataType::Float(v as f64 / 100.0)
         } else {
             DataType::Int(if d100 { v / 100 } else { v })
         }
     } else {
-        let v = read_slice_f64(&v).next().unwrap();
+        let v = read_f64(&v);
         DataType::Float(if d100 { v / 100.0 } else { v })
     }
 }
@@ -508,10 +508,7 @@ fn parse_sst(r: &mut Record<'_>, encoding: &mut XlsEncoding) -> Result<Vec<Strin
             found: r.data.len(),
         });
     }
-    let len = read_slice_i32(&r.data[4..])
-        .next()
-        .and_then(|x| usize::try_from(x).ok())
-        .unwrap();
+    let len: usize = read_i32(&r.data[4..8]).try_into().unwrap();
     let mut sst = Vec::with_capacity(len);
     r.data = &r.data[8..];
     for _ in 0..len {
@@ -550,11 +547,9 @@ fn read_rich_extended_string(
         0
     };
     if ext_st != 0 {
-        unused_len += read_slice_i32(r.data)
-            .next()
-            .and_then(|x| usize::try_from(x).ok())
-            .unwrap();
-        r.data = &r.data[4..];
+        let (raw_len, next_data) = r.data.split_at(4);
+        unused_len += usize::try_from(read_i32(raw_len)).unwrap();
+        r.data = next_data;
     };
 
     let s = read_dbcs(encoding, str_len, r)?;
@@ -904,7 +899,7 @@ fn parse_formula(
             }
             0x1F => {
                 stack.push(formula.len());
-                formula.push_str(&format!("{}", read_slice_f64(rgce).next().unwrap()));
+                formula.push_str(&format!("{}", read_f64(rgce)));
                 rgce = &rgce[8..];
             }
             0x20 | 0x40 | 0x60 => {

--- a/src/xlsb.rs
+++ b/src/xlsb.rs
@@ -12,7 +12,7 @@ use quick_xml::Reader as XmlReader;
 use zip::read::{ZipArchive, ZipFile};
 use zip::result::ZipError;
 
-use crate::utils::{push_column, read_slice_f64, read_slice_i32, read_u16, read_u32, read_usize};
+use crate::utils::{push_column, read_f64, read_i32, read_u16, read_u32, read_usize};
 use crate::vba::VbaProject;
 use crate::{Cell, CellErrorType, DataType, Metadata, Range, Reader};
 
@@ -255,7 +255,7 @@ impl<RS: Read + Seek> Xlsb<RS> {
                     let extern_sheets = buf[4..]
                         .chunks(12)
                         .map(|xti| {
-                            match read_slice_i32(&xti[4..8]).next().unwrap() {
+                            match read_i32(&xti[4..8]) {
                                 -2 => "#ThisWorkbook",
                                 -1 => "#InvalidWorkSheet",
                                 p if p >= 0 && (p as usize) < sheets.len() => &sheets[p as usize].0,
@@ -337,7 +337,7 @@ impl<RS: Read + Seek> Xlsb<RS> {
                     let is_int = (buf[8] & 2) != 0;
                     buf[8] &= 0xFC;
                     if is_int {
-                        let v = (read_slice_i32(&buf[8..12]).next().unwrap() >> 2) as i64;
+                        let v = (read_i32(&buf[8..12]) >> 2) as i64;
                         if d100 {
                             DataType::Float((v as f64) / 100.0)
                         } else {
@@ -346,7 +346,7 @@ impl<RS: Read + Seek> Xlsb<RS> {
                     } else {
                         let mut v = [0u8; 8];
                         v[4..].copy_from_slice(&buf[8..12]);
-                        let v = read_slice_f64(&v).next().unwrap();
+                        let v = read_f64(&v);
                         DataType::Float(if d100 { v / 100.0 } else { v })
                     }
                 }
@@ -366,7 +366,7 @@ impl<RS: Read + Seek> Xlsb<RS> {
                     DataType::Error(error)
                 }
                 0x0004 | 0x000A => DataType::Bool(buf[8] != 0), // BrtCellBool or BrtFmlaBool
-                0x0005 | 0x0009 => DataType::Float(read_slice_f64(&buf[8..16]).next().unwrap()), // BrtCellReal or BrtFmlaFloat
+                0x0005 | 0x0009 => DataType::Float(read_f64(&buf[8..16])), // BrtCellReal or BrtFmlaFloat
                 0x0006 | 0x0008 => DataType::String(wide_str(&buf[8..], &mut 0)?.into_owned()), // BrtCellSt or BrtFmlaString
                 0x0007 => {
                     // BrtCellIsst
@@ -809,7 +809,7 @@ fn parse_formula(
             }
             0x1F => {
                 stack.push(formula.len());
-                formula.push_str(&format!("{}", read_slice_f64(rgce).next().unwrap()));
+                formula.push_str(&format!("{}", read_f64(rgce)));
                 rgce = &rgce[8..];
             }
             0x20 | 0x40 | 0x60 => {


### PR DESCRIPTION
This is a follow-up of #201, in order to fix big endian issues (it can be tested with #207) and simplify code.

Changes:
* Use `from_le_bytes` instead of `from_ne_bytes`. The original PR intended to maintain the behavior of the original code, restricting its purpose to remove unsafe and UBs. This PR, instead, is meant to improve support to big endian architectures.
* Changed data-to-primitive abstractions in order to return a single value instead of an iterator. **In theory** previous code should be zero overhead (if the optimizer was able to throw away a bunch of stuff), now it is surely simpler for both coders and optimizer. I do not expect any significant performance difference, but simpler is obviously better in this case.
* Use [`impl<T, const N: usize> TryFrom<&[T]> for [T; N]]`](https://doc.rust-lang.org/std/primitive.array.html#impl-TryFrom%3C%26%27_%20%5BT%5D%3E) to simplify code. I incorrectly remembered this to be introduced in recent versions, but it's available since 1.34, so it is worth using it.

Performance difference from `master` is not significant:
```
 name        master ns/iter  improve-primitive-conversions ns/iter  diff ns/iter  diff %  speedup
 bench_ods   15,187,084      15,553,032                                  365,948   2.41%   x 0.98
 bench_xls   42,718          42,697                                          -21  -0.05%   x 1.00
 bench_xlsb  169,298         169,195                                        -103  -0.06%   x 1.00
 bench_xlsx  246,964         249,108                                       2,144   0.87%   x 0.99
```

Relates to #207 