### PR TITLE
Implement handling of merged cells for .xlsx workbooks

### DIFF
--- a/src/xlsx.rs
+++ b/src/xlsx.rs
@@ -1002,7 +1002,6 @@ where
             .clone();
 
         for target in (start.0..=end.0).flat_map(|r| iter::repeat(r).zip(start.1..=end.1)) {
-            // range[target].clone_from(&source_cell);
             range.set_value(target, source_cell.clone());
         }
     }

--- a/src/xlsx.rs
+++ b/src/xlsx.rs
@@ -992,8 +992,7 @@ where
     T: CellType,
 {
     for merge_cell in merge_cells {
-        let start = (merge_cell.start.0, merge_cell.start.1);
-        let end = (merge_cell.end.0, merge_cell.end.1);
+        let Dimensions { start, end } = *merge_cell;
         let source_cell = range
             .get_value(start)
             .ok_or_else(|| {


### PR DESCRIPTION
This PR adds handling for the `mergeCells` tag by parsing it and then editing the created `Range` before returning it. Perhaps there is a better way to go about this, but operating on the `Range` rather than the `Vec` of cells seemed like a better option.