### PR TITLE
Add XlsOptions with force_codepage knob

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,7 +87,7 @@ pub use crate::datatype::DataType;
 pub use crate::de::{DeError, RangeDeserializer, RangeDeserializerBuilder, ToCellDeserializer};
 pub use crate::errors::Error;
 pub use crate::ods::{Ods, OdsError};
-pub use crate::xls::{Xls, XlsError};
+pub use crate::xls::{Xls, XlsError, XlsOptions};
 pub use crate::xlsb::{Xlsb, XlsbError};
 pub use crate::xlsx::{Xlsx, XlsxError};
 


### PR DESCRIPTION
Assuming the spreadsheet in #229 was incorrectly authored, this PR adds a knob as a workaround. Usage:

```rust
let mut options = XlsOptions::default();
options.force_codepage = Some(1200);

let mut workbook = Xls::new_with_options(reader, options)?;
```

It's definitely not worth adding a 100 MB spreadsheet to `tests/`, and I don't know how else to make a test case which exercises the issue in #229 to verify the `force_codepage` feature. I settled for adding a doc test which at least ensures this usage _compiles_, but `XlsOptions::force_codepage` itself has no test coverage.