### PR TITLE
Fix small docs typo

### DIFF
--- a/src/datatype.rs
+++ b/src/datatype.rs
@@ -9,7 +9,7 @@ use super::CellErrorType;
 /// a value in a worksheet cell
 #[derive(Debug, Clone, PartialEq)]
 pub enum DataType {
-    /// Unsigned integer
+    /// Signed integer
     Int(i64),
     /// Float
     Float(f64),


### PR DESCRIPTION
I may be misunderstanding, but shouldn't this be 'signed integer'?