### PR TITLE
add GitHub Actions workflow to run tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,40 @@
+name: Rust
+
+on: [ push, pull_request ]
+
+jobs:
+  rust:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        toolchain: [ stable, beta, nightly ]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install Rust toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+          toolchain: ${{ matrix.toolchain }}
+          profile: minimal
+          override: true
+    - name: Toolchain version
+      run: |
+        cargo -vV
+        rustc -vV
+    - name: Build
+      run: |
+        cargo build
+    - name: Run tests
+      run: |
+        cargo test
+    - name: Install rustfmt
+      uses: actions-rs/toolchain@v1
+      if: ${{ matrix.toolchain == 'stable' }}
+      with:
+          toolchain: ${{ matrix.toolchain }}
+          profile: minimal
+          override: true
+          components: rustfmt
+    - name: Format checks
+      if: ${{ matrix.toolchain == 'stable' }}
+      run: |
+        cargo fmt -- --check


### PR DESCRIPTION
Intention of this pull request is to add a workflow that could potentially replace the [Travis CI configuration](https://github.com/tafia/calamine/blob/a72491b4cbf06e7ec094fc25372d4e6fac775438/.travis.yml). Since June 15th, 2021, the building on travis-ci.org is ceased, so this provides a possible alternative to test on Linux.

The tests run on stable, beta and nightly toolchains, just as the Travis builds did, and look like this: https://github.com/striezel/calamine/actions/runs/1504523790