### PR TITLE
remove unused import in test case

### DIFF
--- a/src/datatype.rs
+++ b/src/datatype.rs
@@ -324,7 +324,7 @@ mod tests {
 
     #[test]
     fn test_int_dates() {
-        use chrono::{Duration, NaiveDate, NaiveDateTime, NaiveTime};
+        use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
 
         let unix_epoch = DataType::Int(25569);
         assert_eq!(


### PR DESCRIPTION
Removes a warning that occurs when running tests with the `dates` feature enabled. The warning can be seen in the Windows / AppVeyor builds, e.g. here: https://ci.appveyor.com/project/tafia/calamine/builds/41754320

```
warning: unused import: `Duration`
   --> src\datatype.rs:327:22
    |
327 |         use chrono::{Duration, NaiveDate, NaiveDateTime, NaiveTime};
    |                      ^^^^^^^^
    |
    = note: `#[warn(unused_imports)]` on by default
warning: `calamine` (lib test) generated 1 warning
```