### PR TITLE
include the dates feature in GitHub tests, too

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,7 +25,7 @@ jobs:
         cargo build
     - name: Run tests
       run: |
-        cargo test
+        cargo test --features dates
     - name: Install rustfmt
       uses: actions-rs/toolchain@v1
       if: ${{ matrix.toolchain == 'stable' }}


### PR DESCRIPTION
Some test cases are only run when the dates feature is active. Therefore, the feature should be enabled during tests. This is already the case for tests run on AppVeyor, but not on GitHub - yet.