### PR TITLE
remove `[badges]` section from Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,6 @@ categories = ["encoding", "parsing", "text-processing"]
 exclude = ["tests/**/*"]
 edition = "2018"
 
-[badges]
-travis-ci = { repository = "tafia/calamine" }
-appveyor = { repository = "tafia/calamine" }
-
 [dependencies]
 byteorder = "1.3.4"
 codepage = "0.1.1"


### PR DESCRIPTION
[According to the Cargo Book](https://doc.rust-lang.org/cargo/reference/manifest.html#the-badges-section) that feature has been removed:

> crates.io previously displayed badges next to a crate on its website, but that functionality has been removed. Packages should place badges in its README file which will be displayed on crates.io (see the readme field).

By the way: Sorry for sending so much pull requests today. This is the last one for today. I could have sent it all as one single PR, but that way you would not be able to accept or reject a single change so easily but rather would be forced to decide on all or nothing.