### PR TITLE
Do not let chrono pull in time 0.1.44

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ log = "0.4.11"
 serde = "1.0.116"
 quick-xml = { version = "0.19", features = ["encoding"] }
 zip = { version = "0.6.2", default-features = false, features = ["deflate"] }
-chrono = { version = "0.4.17", features = ["serde"], optional = true }
+chrono = { version = "0.4.19", features = ["serde"], optional = true, default-features = false }
 
 [dev-dependencies]
 glob = "0.3"


### PR DESCRIPTION
This solves RUSTSEC-2020-0071 when dates feature is enabled. Calamine
does not use the current time, so it does not need the dependency on the
time crate (and it's security concern).

Bumped the version of chrono to 0.4.19.

This solves: https://github.com/rustsec/advisory-db/blob/main/crates/time/RUSTSEC-2020-0071.md