### PR TITLE
Add DateFormat to DataType::Datetime

### DIFF
--- a/examples/excel_to_csv.rs
+++ b/examples/excel_to_csv.rs
@@ -36,7 +36,7 @@ fn write_range<W: Write>(dest: &mut W, range: &Range<DataType>) -> std::io::Resu
             match *c {
                 DataType::Empty => Ok(()),
                 DataType::String(ref s) => write!(dest, "{}", s),
-                DataType::Float(ref f) | DataType::DateTime(ref f) => write!(dest, "{}", f),
+                DataType::Float(ref f) | DataType::DateTime(_, ref f) => write!(dest, "{}", f),
                 DataType::Int(ref i) => write!(dest, "{}", i),
                 DataType::Error(ref e) => write!(dest, "{:?}", e),
                 DataType::Bool(ref b) => write!(dest, "{}", b),

--- a/src/de.rs
+++ b/src/de.rs
@@ -571,7 +571,7 @@ impl<'a, 'de> serde::Deserializer<'de> for DataTypeDeserializer<'a> {
             DataType::Bool(v) => visitor.visit_bool(*v),
             DataType::Int(v) => visitor.visit_i64(*v),
             DataType::Empty => visitor.visit_unit(),
-            DataType::DateTime(v) => visitor.visit_f64(*v),
+            DataType::DateTime(_, v) => visitor.visit_f64(*v),
             DataType::Error(ref err) => Err(DeError::CellError {
                 err: err.clone(),
                 pos: self.pos,
@@ -589,7 +589,7 @@ impl<'a, 'de> serde::Deserializer<'de> for DataTypeDeserializer<'a> {
             DataType::Float(v) => visitor.visit_str(&v.to_string()),
             DataType::Int(v) => visitor.visit_str(&v.to_string()),
             DataType::Bool(v) => visitor.visit_str(&v.to_string()),
-            DataType::DateTime(v) => visitor.visit_str(&v.to_string()),
+            DataType::DateTime(_, v) => visitor.visit_str(&v.to_string()),
             DataType::Error(ref err) => Err(DeError::CellError {
                 err: err.clone(),
                 pos: self.pos,
@@ -640,7 +640,7 @@ impl<'a, 'de> serde::Deserializer<'de> for DataTypeDeserializer<'a> {
             DataType::Empty => visitor.visit_bool(false),
             DataType::Float(v) => visitor.visit_bool(*v != 0.),
             DataType::Int(v) => visitor.visit_bool(*v != 0),
-            DataType::DateTime(v) => visitor.visit_bool(*v != 0.),
+            DataType::DateTime(_, v) => visitor.visit_bool(*v != 0.),
             DataType::Error(ref err) => Err(DeError::CellError {
                 err: err.clone(),
                 pos: self.pos,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,7 +83,7 @@ use std::ops::{Index, IndexMut};
 use std::path::Path;
 
 pub use crate::auto::{open_workbook_auto, Sheets};
-pub use crate::datatype::DataType;
+pub use crate::datatype::{DataType, DateFormat};
 pub use crate::de::{DeError, RangeDeserializer, RangeDeserializerBuilder, ToCellDeserializer};
 pub use crate::errors::Error;
 pub use crate::ods::{Ods, OdsError};

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,5 +1,6 @@
 use calamine::CellErrorType::*;
 use calamine::DataType::{Bool, DateTime, Empty, Error, Float, String};
+use calamine::DateFormat;
 use calamine::{open_workbook, open_workbook_auto, Ods, Reader, Xls, Xlsb, Xlsx};
 use std::io::Cursor;
 use std::sync::Once;
@@ -742,7 +743,7 @@ fn date() {
     let mut xls: Xlsx<_> = open_workbook(&path).unwrap();
     let range = xls.worksheet_range_at(0).unwrap().unwrap();
 
-    assert_eq!(range.get_value((0, 0)), Some(&DateTime(44197.0)));
+    assert_eq!(range.get_value((0, 0)), Some(&DateTime(DateFormat::Unknown, 44197.0)));
 
     #[cfg(feature = "dates")]
     {


### PR DESCRIPTION
For my use case, I need to recover the original string as Excel displays it. To do this, I need to know the date format (e.g. "Jan 12 2003" vs "01-12-03"). 

This PR adds a format value to DataType::Datetime and functions to display the date given a date float and a format specifier.

I will add tests for the new stuff after you give the go-ahead to add this feature to the crate.