### PR TITLE
251 date precision

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,11 @@ byteorder = "1.3.4"
 codepage = "0.1.1"
 encoding_rs = "0.8.24"
 log = "0.4.11"
+once_cell = { version = "1.15", optional = true }
 serde = "1.0.116"
 quick-xml = { version = "0.25", features = ["encoding"] }
 zip = { version = "0.6.2", default-features = false, features = ["deflate"] }
-chrono = { version = "0.4.19", features = ["serde"], optional = true, default-features = false }
+chrono = { version = "0.4.22", features = ["serde"], optional = true, default-features = false }
 
 [dev-dependencies]
 glob = "0.3"
@@ -29,4 +30,4 @@ serde_derive = "1.0.116"
 
 [features]
 default = []
-dates = ["chrono"]
+dates = ["chrono", "once_cell"]

--- a/src/datatype.rs
+++ b/src/datatype.rs
@@ -1,14 +1,14 @@
 use std::fmt;
 
+#[cfg(feature = "dates")]
+use once_cell::sync::OnceCell;
 use serde::de::Visitor;
 use serde::{self, Deserialize};
+
+use super::CellErrorType;
+
 #[cfg(feature = "dates")]
- use once_cell::sync::OnceCell;
-
- use super::CellErrorType;
-
- #[cfg(feature = "dates")]
- static EXCEL_EPOCH: OnceCell<chrono::NaiveDateTime> = OnceCell::new();
+static EXCEL_EPOCH: OnceCell<chrono::NaiveDateTime> = OnceCell::new();
 
 /// An enum to represent all different data types that can appear as
 /// a value in a worksheet cell
@@ -122,8 +122,8 @@ impl DataType {
     /// Try converting data type into a datetime
     #[cfg(feature = "dates")]
     pub fn as_datetime(&self) -> Option<chrono::NaiveDateTime> {
-        const MS_MULTIPLIER:f64 = 24f64 * 60f64 * 60f64 * 1e+3f64;
-        
+        const MS_MULTIPLIER: f64 = 24f64 * 60f64 * 60f64 * 1e+3f64;
+
         match self {
             DataType::Int(x) => {
                 let days = x - 25569;
@@ -132,7 +132,7 @@ impl DataType {
             }
             DataType::Float(f) | DataType::DateTime(f) => {
                 let excel_epoch = EXCEL_EPOCH
-                     .get_or_init(|| chrono::NaiveDate::from_ymd(1899, 12, 30).and_hms(0, 0, 0));
+                    .get_or_init(|| chrono::NaiveDate::from_ymd(1899, 12, 30).and_hms(0, 0, 0));
                 let ms = f * MS_MULTIPLIER;
                 let excel_duration = chrono::Duration::milliseconds(ms as i64);
                 Some(*excel_epoch + excel_duration)

--- a/src/datatype.rs
+++ b/src/datatype.rs
@@ -2,8 +2,13 @@ use std::fmt;
 
 use serde::de::Visitor;
 use serde::{self, Deserialize};
+#[cfg(feature = "dates")]
+ use once_cell::sync::OnceCell;
 
-use super::CellErrorType;
+ use super::CellErrorType;
+
+ #[cfg(feature = "dates")]
+ static EXCEL_EPOCH: OnceCell<chrono::NaiveDateTime> = OnceCell::new();
 
 /// An enum to represent all different data types that can appear as
 /// a value in a worksheet cell
@@ -117,6 +122,8 @@ impl DataType {
     /// Try converting data type into a datetime
     #[cfg(feature = "dates")]
     pub fn as_datetime(&self) -> Option<chrono::NaiveDateTime> {
+        const MS_MULTIPLIER:f64 = 24f64 * 60f64 * 60f64 * 1e+3f64;
+        
         match self {
             DataType::Int(x) => {
                 let days = x - 25569;
@@ -124,11 +131,11 @@ impl DataType {
                 chrono::NaiveDateTime::from_timestamp_opt(secs, 0)
             }
             DataType::Float(f) | DataType::DateTime(f) => {
-                let unix_days = f - 25569.;
-                let unix_secs = unix_days * 86400.;
-                let secs = unix_secs.trunc() as i64;
-                let nsecs = (unix_secs.fract().abs() * 1e9) as u32;
-                chrono::NaiveDateTime::from_timestamp_opt(secs, nsecs)
+                let excel_epoch = EXCEL_EPOCH
+                     .get_or_init(|| chrono::NaiveDate::from_ymd(1899, 12, 30).and_hms(0, 0, 0));
+                let ms = f * MS_MULTIPLIER;
+                let excel_duration = chrono::Duration::milliseconds(ms as i64);
+                Some(*excel_epoch + excel_duration)
             }
             _ => None,
         }
@@ -310,6 +317,16 @@ mod tests {
             Some(NaiveDateTime::new(
                 NaiveDate::from_ymd(1970, 1, 1),
                 NaiveTime::from_hms(0, 0, 0)
+            ))
+        );
+
+        // test for https://github.com/tafia/calamine/issues/251
+        let unix_epoch_precision = DataType::Float(44484.7916666667);
+        assert_eq!(
+            unix_epoch_precision.as_datetime(),
+            Some(NaiveDateTime::new(
+                NaiveDate::from_ymd(2021, 10, 15),
+                NaiveTime::from_hms(19, 0, 0)
             ))
         );
 


### PR DESCRIPTION
Hi @tafia . Here's my attempt to resolve #251 originally reported by @usagi.

I added `once_cell` to get `excel_epoch` more efficiently, and I also bumped `chrono` to the latest release.