### PR TITLE
Add a check that the number format returned isn't an empty string

### DIFF
--- a/src/xlsx.rs
+++ b/src/xlsx.rs
@@ -221,7 +221,9 @@ impl<RS: Read + Seek> Xlsx<RS> {
                                     _ => (),
                                 }
                             }
-                            number_formats.insert(id, format);
+                            if !format.is_empty() {
+                                number_formats.insert(id, format);
+                            }
                         }
                         Ok(Event::End(ref e)) if e.local_name().as_ref() == b"numFmts" => break,
                         Ok(Event::Eof) => return Err(XlsxError::XmlEof("numFmts")),


### PR DESCRIPTION
Fixes #215 

In the custom date detection code `format.bytes().all(|c| b"mdyMDYhsHS-/.: \\".contains(&c))` matches the empty string. The excel files I'm processing might have issues to have an empty number format in them to begin with but I don't think we want those treated as date strings either way. 