### PR TITLE
Add cargo-fuzz fuzzing harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ target
 Cargo.lock
 *.bk
 .vim
+fuzz.xlsx

--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,3 @@
+target
+corpus
+artifacts

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "calamine-fuzz"
+version = "0.0.0"
+authors = ["Automatically generated"]
+publish = false
+edition = "2018"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+
+[dependencies.calamine]
+path = ".."
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[[bin]]
+name = "fuzz_all"
+path = "fuzz_targets/fuzz_all.rs"
+test = false
+doc = false

--- a/fuzz/fuzz_targets/fuzz_all.rs
+++ b/fuzz/fuzz_targets/fuzz_all.rs
@@ -1,0 +1,40 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+use calamine::{Xlsx, open_workbook, Reader};
+use std::io::Write;
+use std::fs::File;
+
+fuzz_target!(|data: &[u8]| {
+    let file_name = "fuzz.xlsx";
+    if let Ok(mut file) = File::create(file_name) {
+        if file.write_all(data).is_err() {
+            return
+        }
+    }
+    let mut workbook: Xlsx<_> = match open_workbook(file_name) {
+        Ok(excel) => excel,
+        Err(_) => return,
+    };
+    for worksheet in workbook.worksheets() {
+        if let Some(Ok(range)) = workbook.worksheet_range(&worksheet.0) {
+           let _ = range.get_size().0 * range.get_size().1;
+           range.used_cells().count();
+        }
+    }
+    if let Some(Ok(mut vba)) = workbook.vba_project() {
+        let vba = vba.to_mut();
+        for module_name in vba.get_module_names() {
+            if vba.get_module(module_name).is_ok() {
+                for r in vba.get_references() {
+                    r.is_missing();
+                }
+            }
+        }
+    }
+    let sheets = workbook.sheet_names().to_owned();
+    for s in sheets {
+        if let Some(Ok(formula)) = workbook.worksheet_formula(&s) {
+            formula.rows().flat_map(|r| r.iter().filter(|f| !f.is_empty())).count();
+        }
+    }
+});


### PR DESCRIPTION
Added a fuzzing harness such that [cargo fuzz](https://github.com/rust-fuzz/cargo-fuzz) can be used to help identify bugs or security issues automatically.

Fuzzing can be ran with `cargo fuzz run fuzz_all`

While not inclusive of all behavior, the current harness tests:
* Opening a workbook
* Opening worksheets and inspecting ranges
* Looking for vba projects, modules, and referernces
* Checking worksheet formulas