### PR TITLE
Fix having row 0 in dimensions

### DIFF
--- a/src/xlsx.rs
+++ b/src/xlsx.rs
@@ -1123,7 +1123,7 @@ fn get_row_column(range: &[u8]) -> Result<(u32, u32), XlsxError> {
             _ => return Err(XlsxError::Alphanumeric(*c)),
         }
     }
-    Ok((row - 1, col - 1))
+    Ok((row.saturating_sub(1), col - 1))
 }
 
 /// attempts to read either a simple or richtext string


### PR DESCRIPTION
I have an XLSX document that was automatically generated by some tool that calamine chokes on. A quick investigation showed that its sheet had the dimension defined as `<dimension ref="A0:AZ48943" />`. This would cause either a panic when calamine was compiled in debug mode, or very odd behavior in calamine in release mode (usually ending with panics).

This is obviously broken, but both Excel and LibreOffice seem to handle it just fine. So I did a sort of quick-and-dirty fix so the XLSX could be parsed by calamine.