### PR TITLE
Patrick dedication/add partial eq string slice to data type

### DIFF
--- a/src/datatype.rs
+++ b/src/datatype.rs
@@ -327,7 +327,7 @@ where
 }
 
 #[cfg(all(test, feature = "dates"))]
-mod tests {
+mod date_tests {
     use super::*;
 
     #[test]
@@ -396,5 +396,18 @@ mod tests {
                 NaiveTime::from_hms(0, 0, 0),
             ))
         );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_partial_eq() {
+        assert_eq!(DataType::String("value".to_string()), "value"[..]);
+        assert_eq!(DataType::Float(100.0), 100.0f64);
+        assert_eq!(DataType::Bool(true), true);
+        assert_eq!(DataType::Int(100), 100i64);
     }
 }

--- a/src/datatype.rs
+++ b/src/datatype.rs
@@ -163,6 +163,15 @@ impl DataType {
     }
 }
 
+impl PartialEq<&str> for DataType {
+    fn eq(&self, other: &&str) -> bool {
+        match *self {
+            DataType::String(ref s) if s == other => true,
+            _ => false,
+        }
+    }
+}
+
 impl PartialEq<str> for DataType {
     fn eq(&self, other: &str) -> bool {
         match *self {
@@ -405,6 +414,7 @@ mod tests {
 
     #[test]
     fn test_partial_eq() {
+        assert_eq!(DataType::String("value".to_string()), "value");
         assert_eq!(DataType::String("value".to_string()), "value"[..]);
         assert_eq!(DataType::Float(100.0), 100.0f64);
         assert_eq!(DataType::Bool(true), true);


### PR DESCRIPTION
When writing test for our use-case we found that we can't do the following
```
let row = vec![DataType::String("value".to_string())];
assert_eq!(row, vec!["value"]);
```