### PR TITLE
Add functions converting DataType to int/float/str

### DIFF
--- a/src/datatype.rs
+++ b/src/datatype.rs
@@ -111,6 +111,57 @@ impl DataType {
         }
     }
 
+        /// Try converting data type into a string
+    pub fn as_string(&self) -> Option<String> {
+        match self {
+            DataType::Float(v) => {
+                Some(v.to_string())
+            }
+            DataType::Int(v) => {
+                Some(v.to_string())
+            }
+            DataType::String(v) => {
+                Some(v.clone())
+            }
+            _ => {
+                None
+            }
+        }
+    }
+    /// Try converting data type into an int
+    pub fn as_i64(&self) -> Option<i64> {
+        match self {
+            DataType::Int(v) => {
+                Some(*v)
+            }
+            DataType::Float(v) => {
+                Some(*v as i64)
+            }
+            DataType::String(v) => {
+                v.parse::<i64>().ok()
+            }
+            _ => {
+                None
+            }
+        }
+    }
+    /// Try converting data type into a float
+    pub fn as_f64(&self) -> Option<f64> {
+        match self {
+            DataType::Int(v) =>{
+                Some(*v as f64)
+            }
+            DataType::Float(v) => {
+                Some(*v)
+            }
+            DataType::String(v) => {
+                v.parse::<f64>().ok()
+            }
+            _ => {
+                None
+            }
+        }
+    }
     /// Try converting data type into a date
     #[cfg(feature = "dates")]
     pub fn as_date(&self) -> Option<chrono::NaiveDate> {


### PR DESCRIPTION
This pr tries to address two issues.
1. Users might mistakenly store number as text in a workbook, this gives the flexibility to read the data.
2. xlsx reader always return float when dealing with number, but in reality not all the numbers contain decimal spaces. 
https://github.com/tafia/calamine/blob/51116dcba4becb126e29e03b4cf8afcbffb7324d/src/xlsx.rs#L968-L983 