### PR TITLE
fix incorrect date parsing caused by excel date bug

### DIFF
--- a/src/datatype.rs
+++ b/src/datatype.rs
@@ -168,6 +168,7 @@ impl DataType {
                         .and_hms_opt(0, 0, 0)
                         .unwrap()
                 });
+                let f = if *f >= 60.0 { *f } else { *f + 1.0 };
                 let ms = f * MS_MULTIPLIER;
                 let excel_duration = chrono::Duration::milliseconds(ms.round() as i64);
                 excel_epoch.checked_add_signed(excel_duration)


### PR DESCRIPTION
Date earlier than `1900-03-01` will be parsed 1 day earlier, 
which is caused by excel incorrectly recognizing 1900 as leap year.

e.g.  `1900-01-05` => `Some(1900-01-04T00:00:00)`  

both `1900-02-28` and `1900-02-29` will be parsed as `Some(1900-02-28T00:00:00)` after fix.