### PR TITLE
fix regression on Range::get

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -563,8 +563,7 @@ impl<T: CellType> Range<T> {
     pub fn get(&self, relative_position: (usize, usize)) -> Option<&T> {
         let (row, col) = relative_position;
         let (height, width) = self.get_size();
-        if col >= height {
-            // row is checked implicitly
+        if col >= width || row >= height {
             None
         } else {
             self.inner.get(row * width + col)


### PR DESCRIPTION
Hello @tafia , and thanks a lot for your work on calamine!

It seems like #342 introduced a bug: the column # should be matched against the width, and the row # against  the height. Example of a reproduction case:
```
[src/utils/arrow.rs:10] data = Range {
    start: (
        0,
        0,
    ),
    end: (
        1,
        3,
    ),
    inner: [
        String(
            "date",
        ),
        String(
            "datestr",
        ),
        String(
            "time",
        ),
        String(
            "datetime",
        ),
        DateTimeIso(
            "2023-06-01",
        ),
        String(
            "2023-06-01T02:03:04+02:00",
        ),
        DurationIso(
            "PT01H02M03S",
        ),
        DateTimeIso(
            "2023-06-01T02:03:04",
        ),
    ],
}
[src/utils/arrow.rs:10] data.get((1, 0)) = Some(
    DateTimeIso(
        "2023-06-01",
    ),
)
[src/utils/arrow.rs:10] data.get((1, 1)) = Some(
    String(
        "2023-06-01T02:03:04+02:00",
    ),
)
[src/utils/arrow.rs:10] data.get((1, 2)) = None
```

In case you're interested, we're maintaining a python wrapper around calamine, as pandas and polars 's performance with excel files is disappointing. calamine has been a huge win for us :smile:  We caught the bug in fastexcel's CI : https://github.com/ToucanToco/fastexcel/pull/127