### PR TITLE
update GitHub Actions CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,13 +13,11 @@ jobs:
           - beta
           - nightly
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Install Rust toolchain
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@master
       with:
           toolchain: ${{ matrix.toolchain }}
-          profile: minimal
-          override: true
     - name: Toolchain version
       run: |
         cargo -vV
@@ -31,12 +29,10 @@ jobs:
       run: |
         cargo test --features dates
     - name: Install rustfmt
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@master
       if: ${{ matrix.toolchain == 'stable' }}
       with:
           toolchain: ${{ matrix.toolchain }}
-          profile: minimal
-          override: true
           components: rustfmt
     - name: Format checks
       if: ${{ matrix.toolchain == 'stable' }}


### PR DESCRIPTION
The following updates are performed:
* update [`actions/checkout`](https://github.com/actions/checkout) to v4
* replace [unmaintained](https://github.com/actions-rs/toolchain/issues/216) `actions-rs/toolchain` by [`dtolnay/rust-toolchain`](https://github.com/dtolnay/rust-toolchain)

Still using the outdated / unmaintained actions will generate several warnings in CI runs, for example in https://github.com/tafia/calamine/actions/runs/6153848349:

> The following actions use node12 which is deprecated and will be forced to run on node16: actions/checkout@v2, actions-rs/toolchain@v1. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/

The PR will get rid of those warnings.