### PR TITLE
perf: pre-allocate buffers with `with_capacity()`

### DIFF
--- a/src/ods.rs
+++ b/src/ods.rs
@@ -209,7 +209,7 @@ fn parse_content<RS: Read + Seek>(mut zip: ZipArchive<RS>) -> Result<Content, Od
         Err(ZipError::FileNotFound) => return Err(OdsError::FileNotFound("content.xml")),
         Err(e) => return Err(OdsError::Zip(e)),
     };
-    let mut buf = Vec::new();
+    let mut buf = Vec::with_capacity(1024);
     let mut sheets = BTreeMap::new();
     let mut defined_names = Vec::new();
     let mut sheets_metadata = Vec::new();
@@ -292,9 +292,9 @@ fn read_table(reader: &mut OdsReader<'_>) -> Result<(Range<DataType>, Range<Stri
     let mut rows_repeats = Vec::new();
     let mut formulas = Vec::new();
     let mut cols = Vec::new();
-    let mut buf = Vec::new();
-    let mut row_buf = Vec::new();
-    let mut cell_buf = Vec::new();
+    let mut buf = Vec::with_capacity(1024);
+    let mut row_buf = Vec::with_capacity(1024);
+    let mut cell_buf = Vec::with_capacity(1024);
     cols.push(0);
     loop {
         match reader.read_event_into(&mut buf) {
@@ -587,7 +587,7 @@ fn get_datatype(
 
 fn read_named_expressions(reader: &mut OdsReader<'_>) -> Result<Vec<(String, String)>, OdsError> {
     let mut defined_names = Vec::new();
-    let mut buf = Vec::new();
+    let mut buf = Vec::with_capacity(512);
     loop {
         buf.clear();
         match reader.read_event_into(&mut buf) {

--- a/src/xlsb.rs
+++ b/src/xlsb.rs
@@ -146,7 +146,7 @@ impl<RS: Read + Seek> Xlsb<RS> {
                     .trim_text(false)
                     .check_comments(false)
                     .expand_empty_elements(true);
-                let mut buf = Vec::new();
+                let mut buf: Vec<u8> = Vec::with_capacity(64);
 
                 loop {
                     match xml.read_event_into(&mut buf) {

--- a/src/xlsb.rs
+++ b/src/xlsb.rs
@@ -193,7 +193,7 @@ impl<RS: Read + Seek> Xlsb<RS> {
             Ok(iter) => iter,
             Err(_) => return Ok(()), // it is fine if path does not exists
         };
-        let mut buf = vec![0; 1024];
+        let mut buf = Vec::with_capacity(1024);
         let mut number_formats = BTreeMap::new();
 
         loop {
@@ -248,7 +248,7 @@ impl<RS: Read + Seek> Xlsb<RS> {
             Ok(iter) => iter,
             Err(_) => return Ok(()), // it is fine if path does not exists
         };
-        let mut buf = vec![0; 1024];
+        let mut buf = Vec::with_capacity(1024);
 
         let _ = iter.next_skip_blocks(0x009F, &[], &mut buf)?; // BrtBeginSst
         let len = read_usize(&buf[4..8]);
@@ -273,7 +273,7 @@ impl<RS: Read + Seek> Xlsb<RS> {
         relationships: &BTreeMap<Vec<u8>, String>,
     ) -> Result<(), XlsbError> {
         let mut iter = RecordIter::from_zip(&mut self.zip, "xl/workbook.bin")?;
-        let mut buf = vec![0; 1024];
+        let mut buf = Vec::with_capacity(1024);
 
         loop {
             match iter.read_type()? {
@@ -379,7 +379,7 @@ impl<RS: Read + Seek> Xlsb<RS> {
 
     fn worksheet_range_from_path(&mut self, path: &str) -> Result<Range<DataType>, XlsbError> {
         let mut iter = RecordIter::from_zip(&mut self.zip, &path)?;
-        let mut buf = vec![0; 1024];
+        let mut buf = Vec::with_capacity(1024);
         let formats = &self.formats;
         // BrtWsDim
         let _ = iter.next_skip_blocks(
@@ -492,7 +492,7 @@ impl<RS: Read + Seek> Xlsb<RS> {
 
     fn worksheet_formula_from_path(&mut self, path: String) -> Result<Range<String>, XlsbError> {
         let mut iter = RecordIter::from_zip(&mut self.zip, &path)?;
-        let mut buf = vec![0; 1024];
+        let mut buf = Vec::with_capacity(1024);
 
         // BrtWsDim
         let _ = iter.next_skip_blocks(

--- a/src/xlsx.rs
+++ b/src/xlsx.rs
@@ -1222,8 +1222,8 @@ fn read_string(
     xml: &mut XlsReader<'_>,
     QName(closing): QName,
 ) -> Result<Option<String>, XlsxError> {
-    let mut buf = Vec::new();
-    let mut val_buf = Vec::new();
+    let mut buf = Vec::with_capacity(1024);
+    let mut val_buf = Vec::with_capacity(1024);
     let mut rich_buffer: Option<String> = None;
     let mut is_phonetic_text = false;
     loop {

--- a/src/xlsx.rs
+++ b/src/xlsx.rs
@@ -191,7 +191,7 @@ impl<RS: Read + Seek> Xlsx<RS> {
             None => return Ok(()),
             Some(x) => x?,
         };
-        let mut buf = Vec::new();
+        let mut buf = Vec::with_capacity(1024);
         loop {
             buf.clear();
             match xml.read_event_into(&mut buf) {
@@ -217,8 +217,8 @@ impl<RS: Read + Seek> Xlsx<RS> {
 
         let mut number_formats = BTreeMap::new();
 
-        let mut buf = Vec::new();
-        let mut inner_buf = Vec::new();
+        let mut buf = Vec::with_capacity(1024);
+        let mut inner_buf = Vec::with_capacity(1024);
         loop {
             buf.clear();
             match xml.read_event_into(&mut buf) {
@@ -291,8 +291,8 @@ impl<RS: Read + Seek> Xlsx<RS> {
             Some(x) => x?,
         };
         let mut defined_names = Vec::new();
-        let mut buf = Vec::new();
-        let mut val_buf = Vec::new();
+        let mut buf = Vec::with_capacity(1024);
+        let mut val_buf = Vec::with_capacity(1024);
         loop {
             buf.clear();
             match xml.read_event_into(&mut buf) {
@@ -417,7 +417,7 @@ impl<RS: Read + Seek> Xlsx<RS> {
             Some(x) => x?,
         };
         let mut relationships = BTreeMap::new();
-        let mut buf = Vec::new();
+        let mut buf = Vec::with_capacity(64);
         loop {
             buf.clear();
             match xml.read_event_into(&mut buf) {
@@ -456,7 +456,7 @@ impl<RS: Read + Seek> Xlsx<RS> {
             let rel_path = format!("{}/_rels{}.rels", base_folder, file_name);
 
             let mut table_locations = Vec::new();
-            let mut buf = Vec::new();
+            let mut buf = Vec::with_capacity(64);
             // we need another mutable borrow of self.zip later so we enclose this borrow within braces
             {
                 let mut xml = match xml_reader(&mut self.zip, &rel_path) {
@@ -732,8 +732,8 @@ where
         &mut Vec<Cell<T>>,
     ) -> Result<(), XlsxError>,
 {
-    let mut cells = Vec::new();
-    let mut buf = Vec::new();
+    let mut cells = Vec::with_capacity(1024);
+    let mut buf = Vec::with_capacity(1024);
     'xml: loop {
         buf.clear();
         match xml.read_event_into(&mut buf) {
@@ -841,7 +841,7 @@ impl<RS: Read + Seek> Reader<RS> for Xlsx<RS> {
                             xml.read_to_end_into(e.name(), &mut Vec::new())?;
                         }
                         b"f" => {
-                            let mut f_buf = Vec::new();
+                            let mut f_buf = Vec::with_capacity(512);
                             let mut f = String::new();
                             loop {
                                 match xml.read_event_into(&mut f_buf)? {
@@ -937,8 +937,8 @@ where
         &BytesStart<'_>,
     ) -> Result<(), XlsxError>,
 {
-    let mut buf = Vec::new();
-    let mut cell_buf = Vec::new();
+    let mut buf = Vec::with_capacity(1024);
+    let mut cell_buf = Vec::with_capacity(1024);
 
     let mut row_index = 0;
     let mut col_index = 0;


### PR DESCRIPTION
Pre-allocating removes a lot of regrows for the buffers.

## Benchmarks
Quick benchmark opening a 150k row, 17 column `.xlsx` file shows 15% increase in performance.

`master`:
```bash
868,545,530 ns/iter (+/- 7,365,438)
```
`perf/pre_alloc_buf`:
```bash
750,808,050 ns/iter (+/- 6,366,129)
```

## Profiles

Purple highlight is `alloc`.

Current `master`:
![image](https://github.com/tafia/calamine/assets/12489689/318f8af7-3058-4f8b-b94d-df3b96527872)

Change:
![image](https://github.com/tafia/calamine/assets/12489689/bfbcfeca-5838-45be-9dd5-64252e1100ce)

Changed from `vec![]` macro to `with_capacity()` as there was an introduction to a lot of instructions running.

`vec![0;N]`:
![image](https://github.com/tafia/calamine/assets/12489689/7a77d2a9-dc87-42d1-8a10-bfece6be61ac)


`with_capacity(N)`:
![image](https://github.com/tafia/calamine/assets/12489689/559d2dc0-9571-4dfa-b4ab-d5b3f2c9b678)
