### PR TITLE
feat(docs): add benchmarks and plots in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ import (
 )
 
 func main() {
+        // Open workbook
         file, err := excelize.OpenFile(`NYC_311_SR_2010-2020-sample-1M.xlsx`)
 
         if err != nil {
@@ -222,6 +223,7 @@ func main() {
                 }
         }()
 
+        // Select worksheet
         rows, err := file.Rows("NYC_311_SR_2010-2020-sample-1M")
         if err != nil {
                 fmt.Println(err)
@@ -299,7 +301,7 @@ v2.8.0 excelize.exe
   Range (min … max):   236.798 s … 240.167 s    10 runs
 ```
 
-`calamine` comes is 1.75x faster than `excelize`, 7.05x faster than `ClosedXML`, and 9.43x faster than `openpyxl`.
+`calamine` is 1.75x faster than `excelize`, 7.05x faster than `ClosedXML`, and 9.43x faster than `openpyxl`.
 
 The spreadsheet has a range of 1,000,001 rows and 41 columns, for a total of 41,000,041 cells in the range. Of those, 28,056,975 cells had values.
 

--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ The filesize on disk is `186MB`. `calamine` read just that and nothing more. `Cl
 #### Disk Write
 ![bytes_to_disk](https://github.com/RoloEdits/calamine/assets/12489689/1bde4d93-eb50-472d-bd4a-40471f39b2da)
 
-As the programs have no writing involed, I thought this would be a pointless exercize and an empty section, but Excelize is doing something very strange here. I have no clue what its writing. The other two had expected behavior. The programs had no logic for writing and therefore nothing was written.
+As the programs have no writing involved, I thought this would be a pointless exercise and an empty section, but Excelize is doing something very strange here. I have no clue what its writing. The other two had expected behavior. The programs had no logic for writing and therefore nothing was written.
 
 #### Memory
 ![mem_usage](https://github.com/RoloEdits/calamine/assets/12489689/fdc1129e-bc0f-4133-9a2c-9eb09d7c0390)
@@ -295,7 +295,7 @@ As the programs have no writing involed, I thought this would be a pointless exe
 > [!NOTE]
 > `ClosedXML` was reporting a constant `2.5TB` of virtual memory usage, so it was excluded from the chart.
 
-The stepping and falling for `calamine` is from the grows of `Vec`s and the freeing of of memory right after, with the memory usage droping down again. The sudden jump at the end is when the sheet is being read into memory. The other two, being garbage collected, have a more linear climb all the way through.
+The stepping and falling for `calamine` is from the grows of `Vec`s and the freeing of of memory right after, with the memory usage dropping down again. The sudden jump at the end is when the sheet is being read into memory. The other two, being garbage collected, have a more linear climb all the way through.
 
 #### CPU
 ![cpu_usage](https://github.com/RoloEdits/calamine/assets/12489689/3cf046ba-7661-4bc5-8507-24a8960dfdc3)

--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ As the programs have no writing involved, I thought this would be a pointless ex
 > [!NOTE]
 > `ClosedXML` was reporting a constant `2.5TB` of virtual memory usage, so it was excluded from the chart.
 
-The stepping and falling for `calamine` is from the grows of `Vec`s and the freeing of of memory right after, with the memory usage dropping down again. The sudden jump at the end is when the sheet is being read into memory. The other two, being garbage collected, have a more linear climb all the way through.
+The stepping and falling for `calamine` is from the grows of `Vec`s and the freeing of memory right after, with the memory usage dropping down again. The sudden jump at the end is when the sheet is being read into memory. The other two, being garbage collected, have a more linear climb all the way through.
 
 #### CPU
 ![cpu_usage](https://github.com/RoloEdits/calamine/assets/12489689/3cf046ba-7661-4bc5-8507-24a8960dfdc3)

--- a/README.md
+++ b/README.md
@@ -169,9 +169,138 @@ Browse the [examples](https://github.com/tafia/calamine/tree/master/examples) di
 
 ## Performance
 
-While there is no official benchmark yet, my first tests show a significant boost compared to official C# libraries:
-- Reading cell values: at least 3 times faster
-- Reading vba code: calamine does not read all sheets when opening your workbook, this is not fair
+As `calamine` is readonly, the comparisons will only involve reading an excel `xlsx` file and then iterating over the rows. Along with `calamine`, two other libraries were chosen, from two different languages, [`excelize`](https://github.com/qax-os/excelize) written in `go` and [`ClosedXML`](https://github.com/ClosedXML/ClosedXML) written in `C#`. The benchmarks were done using this [dataset](https://raw.githubusercontent.com/wiki/jqnatividad/qsv/files/NYC_311_SR_2010-2020-sample-1M.7z), a `186MB` `xlsx` file. The plotting data was gotten from the [`sysinfo`](https://github.com/GuillaumeGomez/sysinfo) crate, at a sample interval of `200ms`. The program samples the reported values for the running process and records it.
+
+The programs are all structured to follow the same constructs:
+
+`calamine`:
+```rust
+use calamine::{open_workbook, Reader, Xlsx};
+
+fn main() {
+    // Open workbook 
+    let mut excel: Xlsx<_> =
+        open_workbook("NYC_311_SR_2010-2020-sample-1M.xlsx").expect("failed to find file");
+
+    // Get worksheet
+    let sheet = excel
+        .worksheet_range("NYC_311_SR_2010-2020-sample-1M")
+        .unwrap()
+        .unwrap();
+
+    // iterate over rows
+    for _row in sheet.rows() {}
+}
+```
+`excelize`:
+```go
+package main
+
+import (
+        "fmt"
+        "github.com/xuri/excelize/v2"
+)
+
+func main() {
+        // Open workbook
+        file, err := excelize.OpenFile(`NYC_311_SR_2010-2020-sample-1M.xlsx`)
+
+        if err != nil {
+                fmt.Println(err)
+                return
+        }
+
+        defer func() {
+                // Close the spreadsheet.
+                if err := file.Close(); err != nil {
+                        fmt.Println(err)
+                }
+        }()
+
+        // Get worksheet
+        rows, err := file.GetRows("NYC_311_SR_2010-2020-sample-1M")
+        if err != nil {
+                fmt.Println(err)
+                return
+        }
+
+        // Iterate over rows
+        for _, row := range rows {
+                _ = row
+        }
+}
+```
+`ClosedXML`:
+```csharp
+using ClosedXML.Excel;
+
+internal class Program
+{
+        private static void Main(string[] args)
+        {
+                // Open workbook
+                using var workbook = new XLWorkbook("NYC_311_SR_2010-2020-sample-1M.xlsx");
+
+                // Get Worksheet
+                // "NYC_311_SR_2010-2020-sample-1M"
+                var worksheet = workbook.Worksheet(1);
+
+                // Iterate over rows
+                foreach (var row in worksheet.Rows())
+                {
+
+                }
+        }
+}
+```
+
+### Benchmarks
+
+The benchmarking was done using [`hyperfine`](https://github.com/sharkdp/hyperfine) with `--warmup 3` on an `AMD RYZEN 9 5900X @ 4.0GHz` running `Windows 11`. Both `calamine` and `ClosedXML` were built in release mode.
+
+```bash
+0.22.1 calamine.exe
+  Time (mean ± σ):     25.278 s ±  0.424 s    [User: 24.852 s, System: 0.470 s]
+  Range (min … max):   24.980 s … 26.369 s    10 runs
+
+v2.8.0 excelize.exe
+  Time (mean ± σ):     199.709 s ± 11.671 s    [User: 158.678 s, System: 69.350 s]
+  Range (min … max):   193.934 s … 232.725 s    10 runs
+
+0.102.1 closedxml.exe
+  Time (mean ± σ):     178.343 s ±  3.673 s    [User: 177.442 s, System: 2.612 s]
+  Range (min … max):   173.232 s … 185.086 s    10 runs
+```
+
+The spreadsheet has a range of 1,000,001 rows and 41 columns, for a total of 41,000,041 cells in the range. Of those, 28,056,975 cells had values. Going off of that number, `calamine` had a rate of 1,122,279 cells per second. `excelize` had 140,989 cells per second. `ClosedXML` had 157,320 cells per second.
+
+`calamine` comes is 7.9x faster than `excelize`, and 7x faster than `ClosedXML`.
+
+### Plots
+
+#### Disk Read
+![bytes_from_disk](https://github.com/RoloEdits/calamine/assets/12489689/b662c037-f34b-437e-b6b8-331f07e2a15b)
+
+The filesize on disk is `186MB`. `calamine` read just that and nothing more. `ClosedXML` read a little more, `208MB`. `Excelize` on the other hand managed to read `2.12GB` from disk. `calamine` did a 1:1 here, with `ClosedXML` just a little over that. And `excelize` read the file 11x over.
+
+#### Disk Write
+![bytes_to_disk](https://github.com/RoloEdits/calamine/assets/12489689/1bde4d93-eb50-472d-bd4a-40471f39b2da)
+
+As the programs have no writing involed, I thought this would be a pointless exercize and an empty section, but Excelize is doing something very strange here. I have no clue what its writing. The other two had expected behavior. The programs had no logic for writing and therefore nothing was written.
+
+#### Memory
+![mem_usage](https://github.com/RoloEdits/calamine/assets/12489689/fdc1129e-bc0f-4133-9a2c-9eb09d7c0390)
+
+![virt_mem_usage](https://github.com/RoloEdits/calamine/assets/12489689/59009854-3863-4fbc-8c3a-5ba422429f13)
+> [!NOTE]
+> `ClosedXML` was reporting a constant `2.5TB` of virtual memory usage, so it was excluded from the chart.
+
+The stepping and falling for `calamine` is from the grows of `Vec`s and the freeing of of memory right after, with the memory usage droping down again. The sudden jump at the end is when the sheet is being read into memory. The other two, being garbage collected, have a more linear climb all the way through.
+
+#### CPU
+![cpu_usage](https://github.com/RoloEdits/calamine/assets/12489689/3cf046ba-7661-4bc5-8507-24a8960dfdc3)
+
+Very noisy chart, but `calamine` and `ClosedXML` are very close on CPU usage. `excelize`'s spikes must be from the GC?
 
 ## Unsupported
 


### PR DESCRIPTION
Went through and benchmarked some other libraries to see where `calamine` stood compared to other ecosystems. Decided to add it to the docs. As well as, after seeing the results, file an issue for `excelize`.

I wanted to add [`umya-spreadsheet`](https://github.com/MathNya/umya-spreadsheet/tree/master), but it didn't seem to have any way to directly iterate over the rows? At least I couldn't tell from the wording in the docs nor the function signitures. If you manage to figure out a way to do that, and want another rust comparison, I don't mind adding it.

Git history is a bit messy with fixes, squashing might be best.