### PR TITLE
use nested crate to store xlsx shared strings

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         toolchain: 
-          - "1.63"  # MSRV
+          - "1.65"  # MSRV
           - stable
           - beta
           - nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["excel", "ods", "xls", "xlsx", "xlsb"]
 categories = ["encoding", "parsing", "text-processing"]
 exclude = ["tests/**/*"]
 edition = "2021"
-rust-version = "1.63"
+rust-version = "1.65"
 
 [dependencies]
 byteorder = "1.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ zip = { version = "0.6", default-features = false, features = ["deflate"] }
 chrono = { version = "0.4", features = [
     "serde",
 ], optional = true, default-features = false }
+nested = "0.1.1"
 
 [dev-dependencies]
 glob = "0.3"


### PR DESCRIPTION
Use `nested::Nested` to store xlsx shared strings.

My tests show a marginal improvement in terms of speed but memory impact might be noticeable for pathologically large SharedString files.