### PR TITLE
 Use `chunks` instead of `chunks_exact`

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -15,7 +15,7 @@ macro_rules! from_err {
 /// Converts a &[u8] into an iterator of `u32`s
 pub fn to_u32(s: &[u8]) -> impl ExactSizeIterator<Item = u32> + '_ {
     assert_eq!(s.len() % 4, 0);
-    s.chunks_exact(4)
+    s.chunks(4)
         .map(|data| u32::from_le_bytes(data.try_into().unwrap()))
 }
 


### PR DESCRIPTION
The `chunks_exact` method returns chunks of exactly 4 bytes, and any leftover bytes at the end of the slice are ignored.

Since we know that the input slice will always be a multiple of 4 bytes per the assert, we can use the `chunks` method instead, which is slightly faster because it doesn't need to redundantly check for leftover bytes.