### PR TITLE
feat: support bools in DataType.as_f64 and DataType.as_i64 variants

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,8 @@
 
 - refactor: rename `DataType` enum to `Data` and `DataTypeRef` to `DataRef`
 - feat: introduce a `DataType` trait implemented by both `Data` and `DataRef`.
+- feat: `Data` and `DataType` now return `Some(0{.0})` and `Some(1{.0})` rather than `None` when `.as_i64` or `.as_f64`
+  is used on a Bool value
 
 ## 0.23.1
 

--- a/src/datatype.rs
+++ b/src/datatype.rs
@@ -152,7 +152,7 @@ impl DataType for Data {
         match self {
             Data::Int(v) => Some(*v as f64),
             Data::Float(v) => Some(*v),
-            Data::Bool(v) => Some((*v).into()),
+            Data::Bool(v) => Some((*v as i32).into()),
             Data::String(v) => v.parse::<f64>().ok(),
             _ => None,
         }
@@ -463,7 +463,7 @@ impl DataType for DataRef<'_> {
         match self {
             DataRef::Int(v) => Some(*v as f64),
             DataRef::Float(v) => Some(*v),
-            DataRef::Bool(v) => Some((*v).into()),
+            DataRef::Bool(v) => Some((*v as i32).into()),
             DataRef::String(v) => v.parse::<f64>().ok(),
             DataRef::SharedString(v) => v.parse::<f64>().ok(),
             _ => None,

--- a/src/datatype.rs
+++ b/src/datatype.rs
@@ -142,6 +142,7 @@ impl DataType for Data {
         match self {
             Data::Int(v) => Some(*v),
             Data::Float(v) => Some(*v as i64),
+            Data::Bool(v) => Some(*v as i64),
             Data::String(v) => v.parse::<i64>().ok(),
             _ => None,
         }
@@ -151,6 +152,7 @@ impl DataType for Data {
         match self {
             Data::Int(v) => Some(*v as f64),
             Data::Float(v) => Some(*v),
+            Data::Bool(v) => Some((*v).into()),
             Data::String(v) => v.parse::<f64>().ok(),
             _ => None,
         }
@@ -450,6 +452,7 @@ impl DataType for DataRef<'_> {
         match self {
             DataRef::Int(v) => Some(*v),
             DataRef::Float(v) => Some(*v as i64),
+            DataRef::Bool(v) => Some(*v as i64),
             DataRef::String(v) => v.parse::<i64>().ok(),
             DataRef::SharedString(v) => v.parse::<i64>().ok(),
             _ => None,
@@ -460,6 +463,7 @@ impl DataType for DataRef<'_> {
         match self {
             DataRef::Int(v) => Some(*v as f64),
             DataRef::Float(v) => Some(*v),
+            DataRef::Bool(v) => Some((*v).into()),
             DataRef::String(v) => v.parse::<f64>().ok(),
             DataRef::SharedString(v) => v.parse::<f64>().ok(),
             _ => None,
@@ -802,5 +806,21 @@ mod tests {
         assert_eq!(Data::Float(100.0), 100.0f64);
         assert_eq!(Data::Bool(true), true);
         assert_eq!(Data::Int(100), 100i64);
+    }
+
+    #[test]
+    fn test_as_i64_with_bools() {
+        assert_eq!(Data::Bool(true).as_i64(), Some(1));
+        assert_eq!(Data::Bool(false).as_i64(), Some(0));
+        assert_eq!(DataRef::Bool(true).as_i64(), Some(1));
+        assert_eq!(DataRef::Bool(false).as_i64(), Some(0));
+    }
+
+    #[test]
+    fn test_as_f64_with_bools() {
+        assert_eq!(Data::Bool(true).as_f64(), Some(1.0));
+        assert_eq!(Data::Bool(false).as_f64(), Some(0.0));
+        assert_eq!(DataRef::Bool(true).as_f64(), Some(1.0));
+        assert_eq!(DataRef::Bool(false).as_f64(), Some(0.0));
     }
 }


### PR DESCRIPTION
Hello @tafia , I figured it would be nice to have an implicit conversion from bool to i64/f64 when using `as_{i64,f64}` , do you believe this makes sense as well ?

I haven't modified `as_string` yet because I thought it'd maybe be unexpected behaviour, but I'd gladly add if as well if you believe it makes sense :slightly_smiling_face: 