### PR TITLE
Issue401

### DIFF
--- a/src/xlsx/mod.rs
+++ b/src/xlsx/mod.rs
@@ -459,6 +459,7 @@ impl<RS: Read + Seek> Xlsx<RS> {
 
     // sheets must be added before this is called!!
     fn read_table_metadata(&mut self) -> Result<(), XlsxError> {
+        let mut new_tables = Vec::new();
         for (sheet_name, sheet_path) in &self.sheets {
             let last_folder_index = sheet_path.rfind('/').expect("should be in a folder");
             let (base_folder, file_name) = sheet_path.split_at(last_folder_index);
@@ -522,7 +523,6 @@ impl<RS: Read + Seek> Xlsx<RS> {
                     }
                 }
             }
-            let mut new_tables = Vec::new();
             for table_file in table_locations {
                 let mut xml = match xml_reader(&mut self.zip, &table_file) {
                     None => continue,
@@ -606,12 +606,8 @@ impl<RS: Read + Seek> Xlsx<RS> {
                     dims,
                 ));
             }
-            if let Some(tables) = &mut self.tables {
-                tables.append(&mut new_tables);
-            } else {
-                self.tables = Some(new_tables);
-            }
         }
+        self.tables = Some(new_tables);
         Ok(())
     }
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1674,3 +1674,14 @@ fn issue_384_multiple_formula() {
     ];
     assert_eq!(formula, expected)
 }
+
+#[test]
+fn issue_401_empty_tables() {
+    setup();
+
+    let path = format!("{}/tests/date.xlsx", env!("CARGO_MANIFEST_DIR"));
+    let mut excel: Xlsx<_> = open_workbook(&path).unwrap();
+    excel.load_tables().unwrap();
+    let tables = excel.table_names();
+    assert!(tables.is_empty());
+}


### PR DESCRIPTION
Some xlsx files do not contain any _rels file and. The tables was thus
never set. Trying to read these tables in turn made it panic.

While the whole table code may need some attention, this commit only
tries to fix this behavior.

Some aspects that may need to be addressed are:
- it should not panic, returning an XlsxError is better
- calling `load_tables` then `table_names`, while more optimal is certain scenario is not very user friendly. At the very least we should provide a function which is doing both of it at once.

Close #401 