### PR TITLE
feat: use std::cell::OnceCell instead of the once_cell crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,9 +24,6 @@ zip = { version = "0.6", default-features = false, features = ["deflate"] }
 chrono = { version = "0.4", features = [
     "serde",
 ], optional = true, default-features = false }
-time = { version = "0.3", features = [
-    "serde",
-], optional = true, default-features = false }
 
 [dev-dependencies]
 glob = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,35 +4,37 @@ version = "0.24.0"
 authors = ["Johann Tuffe <tafia973@gmail.com>"]
 repository = "https://github.com/tafia/calamine"
 documentation = "https://docs.rs/calamine"
-description = "An Excel/OpenDocument Spreadsheets reader and deserializer in pure rust"
+description = "An Excel/OpenDocument Spreadsheets reader and deserializer in pure Rust"
 license = "MIT"
 readme = "README.md"
 keywords = ["excel", "ods", "xls", "xlsx", "xlsb"]
 categories = ["encoding", "parsing", "text-processing"]
 exclude = ["tests/**/*"]
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.70"
 
 [dependencies]
-byteorder = "1.4"
+byteorder = "1.5"
 codepage = "0.1.1"
 encoding_rs = "0.8"
 log = "0.4"
-once_cell = { version = "1.18", optional = true }
 serde = "1.0"
 quick-xml = { version = "0.31", features = ["encoding"] }
 zip = { version = "0.6", default-features = false, features = ["deflate"] }
 chrono = { version = "0.4", features = [
     "serde",
 ], optional = true, default-features = false }
+time = { version = "0.3", features = [
+    "serde",
+], optional = true, default-features = false }
 
 [dev-dependencies]
 glob = "0.3"
-env_logger = "0.10"
+env_logger = "0.11"
 serde_derive = "1.0"
 sha256 = "1.3"
 
 [features]
 default = []
-dates = ["chrono", "once_cell"]
+dates = ["chrono"]
 picture = []

--- a/src/datatype.rs
+++ b/src/datatype.rs
@@ -1,7 +1,6 @@
+use std::cell::OnceCell;
 use std::fmt;
 
-#[cfg(feature = "dates")]
-use once_cell::sync::OnceCell;
 use serde::de::Visitor;
 use serde::{self, Deserialize};
 


### PR DESCRIPTION
Use `std::cell::OnceCell` instead of the `once_cell` crate to reduce dependencies.  Requires bumping MSRV to Rust 1.70.