### PR TITLE
feat: Use std::cell::OnceLock instead of the once_cell crate

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         toolchain: 
-          - "1.65"  # MSRV
+          - "1.71"  # MSRV
           - stable
           - beta
           - nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,14 +11,13 @@ keywords = ["excel", "ods", "xls", "xlsx", "xlsb"]
 categories = ["encoding", "parsing", "text-processing"]
 exclude = ["tests/**/*"]
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.71"
 
 [dependencies]
-byteorder = "1.4"
+byteorder = "1.5"
 codepage = "0.1.1"
 encoding_rs = "0.8"
 log = "0.4"
-once_cell = { version = "1.18", optional = true }
 serde = "1.0"
 quick-xml = { version = "0.31", features = ["encoding"] }
 zip = { version = "0.6", default-features = false, features = ["deflate"] }
@@ -28,11 +27,11 @@ chrono = { version = "0.4", features = [
 
 [dev-dependencies]
 glob = "0.3"
-env_logger = "0.10"
+env_logger = "0.11"
 serde_derive = "1.0"
 sha256 = "1.3"
 
 [features]
 default = []
-dates = ["chrono", "once_cell"]
+dates = ["chrono"]
 picture = []

--- a/src/datatype.rs
+++ b/src/datatype.rs
@@ -1,14 +1,14 @@
 use std::fmt;
-
 #[cfg(feature = "dates")]
-use once_cell::sync::OnceCell;
+use std::sync::OnceLock;
+
 use serde::de::Visitor;
 use serde::{self, Deserialize};
 
 use super::CellErrorType;
 
 #[cfg(feature = "dates")]
-static EXCEL_EPOCH: OnceCell<chrono::NaiveDateTime> = OnceCell::new();
+static EXCEL_EPOCH: OnceLock<chrono::NaiveDateTime> = OnceLock::new();
 
 #[cfg(feature = "dates")]
 /// https://learn.microsoft.com/en-us/office/troubleshoot/excel/1900-and-1904-date-system

--- a/src/xls.rs
+++ b/src/xls.rs
@@ -747,10 +747,10 @@ fn parse_label(
     let row = read_u16(r);
     let col = read_u16(&r[2..]);
     let _ixfe = read_u16(&r[4..]);
-    return Ok(Some(Cell::new(
+    Ok(Some(Cell::new(
         (row as u32, col as u32),
         Data::String(parse_string(&r[6..], encoding, biff)?),
-    )));
+    )))
 }
 
 fn parse_label_sst(r: &[u8], strings: &[String]) -> Result<Option<Cell<Data>>, XlsError> {


### PR DESCRIPTION
Use `std::cell::OnceLock` instead of the `once_cell` crate for fewer dependencies.  Requires bumping MSRV to Rust 1.71.