### PR TITLE
Use case-insensitive comparison to find a part file in Xlsx ZIP archive

### DIFF
--- a/src/xlsx/mod.rs
+++ b/src/xlsx/mod.rs
@@ -919,7 +919,11 @@ fn xml_reader<'a, RS: Read + Seek>(
     zip: &'a mut ZipArchive<RS>,
     path: &str,
 ) -> Option<Result<XlReader<'a>, XlsxError>> {
-    match zip.by_name(path) {
+    let actual_path = zip
+        .file_names()
+        .find(|n| n.eq_ignore_ascii_case(path))?
+        .to_owned();
+    match zip.by_name(&actual_path) {
         Ok(f) => {
             let mut r = XmlReader::from_reader(BufReader::new(f));
             r.check_end_names(false)


### PR DESCRIPTION
I have a file which `calamine` fails to open. It crashes with `index out of bounds: the len is 0 but the index is 0` [here](https://github.com/tafia/calamine/blob/master/src/xlsx/cells_reader.rs#L247). It happened that my file contains `/xl/SharedStrings.xml` (while `[Content_Types].xml` mentions `/xl/sharedStrings.xml` :facepalm:) and `calamine` expects `/xl/sharedStrings.xml`.

I did a quick search and it seems ECMA-376 assumes case-insensitive comparison of part names.

> #### 6.2.2.3 Part name equivalence and integrity in an abstract package
> Equivalence of part names shall be determined by ASCII case-insensitive matching.
