### PR TITLE
Replace `zip` with `zip_next`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ encoding_rs = "0.8"
 log = "0.4"
 serde = "1.0"
 quick-xml = { version = "0.31", features = ["encoding"] }
-zip = { version = "0.6", default-features = false, features = ["deflate"] }
+zip_next = { version = "1.0", default-features = false, features = ["deflate"] }
 chrono = { version = "0.4", features = [
     "serde",
 ], optional = true, default-features = false }

--- a/src/ods.rs
+++ b/src/ods.rs
@@ -12,8 +12,8 @@ use quick_xml::events::attributes::Attributes;
 use quick_xml::events::Event;
 use quick_xml::name::QName;
 use quick_xml::Reader as XmlReader;
-use zip::read::{ZipArchive, ZipFile};
-use zip::result::ZipError;
+use zip_next::read::{ZipArchive, ZipFile};
+use zip_next::result::ZipError;
 
 use crate::vba::VbaProject;
 use crate::{Data, DataType, Metadata, Range, Reader, Sheet, SheetType, SheetVisible};
@@ -29,7 +29,7 @@ pub enum OdsError {
     /// Io error
     Io(std::io::Error),
     /// Zip error
-    Zip(zip::result::ZipError),
+    Zip(zip_next::result::ZipError),
     /// Xml error
     Xml(quick_xml::Error),
     /// Xml attribute error
@@ -63,7 +63,7 @@ pub enum OdsError {
 }
 
 from_err!(std::io::Error, OdsError, Io);
-from_err!(zip::result::ZipError, OdsError, Zip);
+from_err!(zip_next::result::ZipError, OdsError, Zip);
 from_err!(quick_xml::Error, OdsError, Xml);
 from_err!(std::string::ParseError, OdsError, Parse);
 from_err!(std::num::ParseFloatError, OdsError, ParseFloat);

--- a/src/xlsb/mod.rs
+++ b/src/xlsb/mod.rs
@@ -14,8 +14,8 @@ use quick_xml::events::attributes::Attribute;
 use quick_xml::events::Event;
 use quick_xml::name::QName;
 use quick_xml::Reader as XmlReader;
-use zip::read::{ZipArchive, ZipFile};
-use zip::result::ZipError;
+use zip_next::read::{ZipArchive, ZipFile};
+use zip_next::result::ZipError;
 
 use crate::datatype::DataRef;
 use crate::formats::{builtin_format_by_code, detect_custom_number_format, CellFormat};
@@ -29,7 +29,7 @@ pub enum XlsbError {
     /// Io error
     Io(std::io::Error),
     /// Zip error
-    Zip(zip::result::ZipError),
+    Zip(zip_next::result::ZipError),
     /// Xml error
     Xml(quick_xml::Error),
     /// Xml attribute error
@@ -82,7 +82,7 @@ pub enum XlsbError {
 }
 
 from_err!(std::io::Error, XlsbError, Io);
-from_err!(zip::result::ZipError, XlsbError, Zip);
+from_err!(zip_next::result::ZipError, XlsbError, Zip);
 from_err!(quick_xml::Error, XlsbError, Xml);
 
 impl std::fmt::Display for XlsbError {

--- a/src/xlsx/mod.rs
+++ b/src/xlsx/mod.rs
@@ -11,8 +11,8 @@ use quick_xml::events::attributes::{Attribute, Attributes};
 use quick_xml::events::Event;
 use quick_xml::name::QName;
 use quick_xml::Reader as XmlReader;
-use zip::read::{ZipArchive, ZipFile};
-use zip::result::ZipError;
+use zip_next::read::{ZipArchive, ZipFile};
+use zip_next::result::ZipError;
 
 use crate::datatype::DataRef;
 use crate::formats::{builtin_format_by_id, detect_custom_number_format, CellFormat};
@@ -37,7 +37,7 @@ pub enum XlsxError {
     /// Io error
     Io(std::io::Error),
     /// Zip error
-    Zip(zip::result::ZipError),
+    Zip(zip_next::result::ZipError),
     /// Vba error
     Vba(crate::vba::VbaError),
     /// Xml error
@@ -90,7 +90,7 @@ pub enum XlsxError {
 }
 
 from_err!(std::io::Error, XlsxError, Io);
-from_err!(zip::result::ZipError, XlsxError, Zip);
+from_err!(zip_next::result::ZipError, XlsxError, Zip);
 from_err!(crate::vba::VbaError, XlsxError, Vba);
 from_err!(quick_xml::Error, XlsxError, Xml);
 from_err!(std::string::ParseError, XlsxError, Parse);


### PR DESCRIPTION
The `zip` crate hasn't been updated in almost a year, and has a number of bugs that can cause panics when trying to process an invalid zip file. This PR replaces it with `zip_next`, a fork I actively maintain.