### PR TITLE
Expose dimensions methods to the public

### DIFF
--- a/src/xlsb/cells_reader.rs
+++ b/src/xlsb/cells_reader.rs
@@ -68,7 +68,7 @@ impl<'a> XlsbCellsReader<'a> {
         })
     }
 
-    pub(crate) fn dimensions(&self) -> Dimensions {
+    pub fn dimensions(&self) -> Dimensions {
         self.dimensions
     }
 

--- a/src/xlsx/cells_reader.rs
+++ b/src/xlsx/cells_reader.rs
@@ -75,7 +75,7 @@ impl<'a> XlsxCellReader<'a> {
         })
     }
 
-    pub(crate) fn dimensions(&self) -> Dimensions {
+    pub fn dimensions(&self) -> Dimensions {
         self.dimensions
     }
 


### PR DESCRIPTION
I ran into a bug in my platform where the `.worksheets()` method would end up allocating an insane amount of memory (500 Gb) for what looked like a normal 10Mb Excel file (user uploaded). Turns out one of its sheets had a very large number of empty cells, and calamine was trying to put the entire thing in memory. I added a check in my code to stop processing sheets that exceed a certain threshold of cells. However, in order to do this, I had to fork your codebase to expose the `dimensions` function. Otherwise, I couldn't find a way to see how big a sheet is without loading the entire thing.

Posting in case it helps somebody else!