### PR TITLE
docs: fixes #436

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ use calamine::{open_workbook, Error, Xlsx, Reader, RangeDeserializerBuilder};
 fn example() -> Result<(), Error> {
     let path = format!("{}/tests/temperature.xlsx", env!("CARGO_MANIFEST_DIR"));
     let mut workbook: Xlsx<_> = open_workbook(path)?;
-    let range = workbook.worksheet_range("Sheet1")
-        .ok_or(Error::Msg("Cannot find 'Sheet1'"))??;
+    let range = workbook.worksheet_range("Sheet1")?;
+
 
     let mut iter = RangeDeserializerBuilder::new().from_range(&range)?;
 


### PR DESCRIPTION
Xlsx WorksheetNotFound error is simply propagated rather than using ok or. now passes cargo check