### PR TITLE
fix index out of range for slice

### DIFF
--- a/src/xls.rs
+++ b/src/xls.rs
@@ -351,7 +351,7 @@ impl<RS: Read + Seek> Xls<RS> {
                     0x0017 => {
                         // ExternSheet
                         let cxti = read_u16(r.data) as usize;
-                        xtis.extend(r.data[2..].chunks(6).take(cxti).map(|xti| Xti {
+                        xtis.extend(r.data[2..].chunks(6).take(cxti).filter(|e|e.len()>4).map(|xti| Xti {
                             _isup_book: read_u16(&xti[..2]),
                             itab_first: read_i16(&xti[2..4]),
                             _itab_last: read_i16(&xti[4..]),


### PR DESCRIPTION
Open a template excel got this error:
```
thread 'tokio-runtime-worker' panicked at $HOME/.cargo/registry/src/mirrors.ustc.edu.cn-61ef6e0cd06fb9b8/calamine-0.25.0/src/xls.rs:336:54:
range end index 2 out of range for slice of length 1
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

I've fixed skipping the shorter slice.