### PR TITLE
docs: enable dates and picture features in docs.rs build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,3 +35,6 @@ sha256 = "1.3"
 default = []
 dates = ["chrono"]
 picture = []
+
+[package.metadata.docs.rs]
+features = ["dates", "picture"]


### PR DESCRIPTION
While looking at the docs through docs.rs I didn't realize `ExcelDateTime` is already able to be converted into `chrono::NaiveDateTime` because the `dates` feature is not enabled in the build.
This PR leverages the [docs.rs metadata feature](https://docs.rs/about/metadata) to enable the `dates` and `picture` features when building docs for docs.rs.