### PR TITLE
feat: named table data as `DataRef` type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -955,6 +955,11 @@ impl<T> Table<T> {
     pub fn data(&self) -> &Range<T> {
         &self.data
     }
+
+    /// Get an owned range representing the data from the table (excludes column headers)
+    pub fn data_owned(self) -> Range<T> {
+        self.data
+    }
 }
 
 /// A helper function to deserialize cell values as `i64`,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -932,13 +932,13 @@ impl<'a, T: 'a + CellType> DoubleEndedIterator for Rows<'a, T> {
 impl<'a, T: 'a + CellType> ExactSizeIterator for Rows<'a, T> {}
 
 /// Struct with the key elements of a table
-pub struct Table<T: CellType> {
+pub struct Table<T> {
     pub(crate) name: String,
     pub(crate) sheet_name: String,
     pub(crate) columns: Vec<String>,
     pub(crate) data: Range<T>,
 }
-impl<T: CellType> Table<T> {
+impl<T> Table<T> {
     /// Get the name of the table
     pub fn name(&self) -> &str {
         &self.name

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -932,13 +932,13 @@ impl<'a, T: 'a + CellType> DoubleEndedIterator for Rows<'a, T> {
 impl<'a, T: 'a + CellType> ExactSizeIterator for Rows<'a, T> {}
 
 /// Struct with the key elements of a table
-pub struct Table<T> {
+pub struct Table<T: CellType> {
     pub(crate) name: String,
     pub(crate) sheet_name: String,
     pub(crate) columns: Vec<String>,
     pub(crate) data: Range<T>,
 }
-impl<T> Table<T> {
+impl<T: CellType> Table<T> {
     /// Get the name of the table
     pub fn name(&self) -> &str {
         &self.name
@@ -955,10 +955,11 @@ impl<T> Table<T> {
     pub fn data(&self) -> &Range<T> {
         &self.data
     }
+}
 
-    /// Get an owned range representing the data from the table (excludes column headers)
-    pub fn data_owned(self) -> Range<T> {
-        self.data
+impl<T: CellType> From<Table<T>> for Range<T> {
+    fn from(table: Table<T>) -> Range<T> {
+        table.data
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -468,7 +468,7 @@ impl<T: CellType> Range<T> {
             // search bounds
             let row_start = cells.first().unwrap().pos.0;
             let row_end = cells.last().unwrap().pos.0;
-            let mut col_start = std::u32::MAX;
+            let mut col_start = u32::MAX;
             let mut col_end = 0;
             for c in cells.iter().map(|c| c.pos.1) {
                 if c < col_start {

--- a/src/xlsx/mod.rs
+++ b/src/xlsx/mod.rs
@@ -680,6 +680,7 @@ impl<RS: Read + Seek> Xlsx<RS> {
         Ok(())
     }
 
+    #[inline]
     fn get_table_meta(&self, table_name: &str) -> Result<TableMetadata, XlsxError> {
         let match_table_meta = self
             .tables
@@ -692,7 +693,10 @@ impl<RS: Read + Seek> Xlsx<RS> {
         let name = match_table_meta.0.to_owned();
         let sheet_name = match_table_meta.1.clone();
         let columns = match_table_meta.2.clone();
-        let dimensions = (match_table_meta.3.start, match_table_meta.3.end);
+        let dimensions = Dimensions {
+            start: match_table_meta.3.start,
+            end: match_table_meta.3.end,
+        };
 
         Ok(TableMetadata {
             name,
@@ -766,9 +770,9 @@ impl<RS: Read + Seek> Xlsx<RS> {
             columns,
             dimensions,
         } = self.get_table_meta(table_name)?;
-        let (start_dim, end_dim) = dimensions;
+        let Dimensions { start, end } = dimensions;
         let range = self.worksheet_range(&sheet_name)?;
-        let tbl_rng = range.range(start_dim, end_dim);
+        let tbl_rng = range.range(start, end);
 
         Ok(Table {
             name,
@@ -786,9 +790,9 @@ impl<RS: Read + Seek> Xlsx<RS> {
             columns,
             dimensions,
         } = self.get_table_meta(table_name)?;
-        let (start_dim, end_dim) = dimensions;
+        let Dimensions { start, end } = dimensions;
         let range = self.worksheet_range_ref(&sheet_name)?;
-        let tbl_rng = range.range(start_dim, end_dim);
+        let tbl_rng = range.range(start, end);
 
         Ok(Table {
             name,
@@ -848,13 +852,11 @@ impl<RS: Read + Seek> Xlsx<RS> {
     }
 }
 
-type Dimension = (u32, u32);
-
 struct TableMetadata {
     name: String,
     sheet_name: String,
     columns: Vec<String>,
-    dimensions: (Dimension, Dimension),
+    dimensions: Dimensions,
 }
 
 struct InnerTableMetadata {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -584,6 +584,66 @@ fn table() {
     assert_eq!(data.get((0, 1)), Some(&Float(12.5)));
     assert_eq!(data.get((1, 1)), Some(&Float(64.0)));
     xls.worksheet_range_at(0).unwrap().unwrap();
+
+    // Check if owned data works
+    let owned_data = table.data_owned();
+
+    assert_eq!(
+        owned_data.get((0, 0)),
+        Some(&String("something".to_owned()))
+    );
+    assert_eq!(owned_data.get((1, 0)), Some(&String("else".to_owned())));
+    assert_eq!(owned_data.get((0, 1)), Some(&Float(12.5)));
+    assert_eq!(owned_data.get((1, 1)), Some(&Float(64.0)));
+}
+
+#[test]
+fn table_by_ref() {
+    let mut xls: Xlsx<_> = wb("temperature-table.xlsx");
+    xls.load_tables().unwrap();
+    let table_names = xls.table_names();
+    assert_eq!(table_names[0], "Temperature");
+    assert_eq!(table_names[1], "OtherTable");
+    let table = xls
+        .table_by_name_ref("Temperature")
+        .expect("Parsing table's sheet should not error");
+    assert_eq!(table.name(), "Temperature");
+    assert_eq!(table.columns()[0], "label");
+    assert_eq!(table.columns()[1], "value");
+    let data = table.data();
+    assert_eq!(
+        data.get((0, 0))
+            .expect("Could not get data from table ref."),
+        &DataRef::SharedString("celsius")
+    );
+    assert_eq!(
+        data.get((1, 0))
+            .expect("Could not get data from table ref."),
+        &DataRef::SharedString("fahrenheit")
+    );
+    assert_eq!(
+        data.get((0, 1))
+            .expect("Could not get data from table ref."),
+        &DataRef::Float(22.2222)
+    );
+    assert_eq!(
+        data.get((1, 1))
+            .expect("Could not get data from table ref."),
+        &DataRef::Float(72.0)
+    );
+    // Check the second table
+    let table = xls
+        .table_by_name("OtherTable")
+        .expect("Parsing table's sheet should not error");
+    assert_eq!(table.name(), "OtherTable");
+    assert_eq!(table.columns()[0], "label2");
+    assert_eq!(table.columns()[1], "value2");
+    let data = table.data();
+    assert_eq!(data.get((0, 0)), Some(&String("something".to_owned())));
+    assert_eq!(data.get((1, 0)), Some(&String("else".to_owned())));
+    assert_eq!(data.get((0, 1)), Some(&Float(12.5)));
+    assert_eq!(data.get((1, 1)), Some(&Float(64.0)));
+    xls.worksheet_range_at(0).unwrap().unwrap();
 }
 
 #[test]

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -659,7 +659,6 @@ fn table_by_ref() {
             .expect("Could not get data from table ref."),
         &DataRef::Float(64.0)
     );
-    xls.worksheet_range_at(0).unwrap().unwrap();
 
     // Check if owned data works
     let owned_data: Range<DataRef> = table.into();

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -633,16 +633,16 @@ fn table_by_ref() {
     );
     // Check the second table
     let table = xls
-        .table_by_name("OtherTable")
+        .table_by_name_ref("OtherTable")
         .expect("Parsing table's sheet should not error");
     assert_eq!(table.name(), "OtherTable");
     assert_eq!(table.columns()[0], "label2");
     assert_eq!(table.columns()[1], "value2");
     let data = table.data();
-    assert_eq!(data.get((0, 0)), Some(&String("something".to_owned())));
-    assert_eq!(data.get((1, 0)), Some(&String("else".to_owned())));
-    assert_eq!(data.get((0, 1)), Some(&Float(12.5)));
-    assert_eq!(data.get((1, 1)), Some(&Float(64.0)));
+    assert_eq!(data.get((0, 0)).expect("Could not get data from table ref."), &DataRef::SharedString("something"));
+    assert_eq!(data.get((1, 0)).expect("Could not get data from table ref."), &DataRef::SharedString("else"));
+    assert_eq!(data.get((0, 1)).expect("Could not get data from table ref."), &DataRef::Float(12.5));
+    assert_eq!(data.get((1, 1)).expect("Could not get data from table ref."), &DataRef::Float(64.0));
     xls.worksheet_range_at(0).unwrap().unwrap();
 }
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -586,7 +586,7 @@ fn table() {
     xls.worksheet_range_at(0).unwrap().unwrap();
 
     // Check if owned data works
-    let owned_data = table.data_owned();
+    let owned_data: Range<Data> = table.into();
 
     assert_eq!(
         owned_data.get((0, 0)),
@@ -660,6 +660,34 @@ fn table_by_ref() {
         &DataRef::Float(64.0)
     );
     xls.worksheet_range_at(0).unwrap().unwrap();
+
+    // Check if owned data works
+    let owned_data: Range<DataRef> = table.into();
+
+    assert_eq!(
+        owned_data
+            .get((0, 0))
+            .expect("Could not get data from table ref."),
+        &DataRef::SharedString("something")
+    );
+    assert_eq!(
+        owned_data
+            .get((1, 0))
+            .expect("Could not get data from table ref."),
+        &DataRef::SharedString("else")
+    );
+    assert_eq!(
+        owned_data
+            .get((0, 1))
+            .expect("Could not get data from table ref."),
+        &DataRef::Float(12.5)
+    );
+    assert_eq!(
+        owned_data
+            .get((1, 1))
+            .expect("Could not get data from table ref."),
+        &DataRef::Float(64.0)
+    );
 }
 
 #[test]

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -639,10 +639,26 @@ fn table_by_ref() {
     assert_eq!(table.columns()[0], "label2");
     assert_eq!(table.columns()[1], "value2");
     let data = table.data();
-    assert_eq!(data.get((0, 0)).expect("Could not get data from table ref."), &DataRef::SharedString("something"));
-    assert_eq!(data.get((1, 0)).expect("Could not get data from table ref."), &DataRef::SharedString("else"));
-    assert_eq!(data.get((0, 1)).expect("Could not get data from table ref."), &DataRef::Float(12.5));
-    assert_eq!(data.get((1, 1)).expect("Could not get data from table ref."), &DataRef::Float(64.0));
+    assert_eq!(
+        data.get((0, 0))
+            .expect("Could not get data from table ref."),
+        &DataRef::SharedString("something")
+    );
+    assert_eq!(
+        data.get((1, 0))
+            .expect("Could not get data from table ref."),
+        &DataRef::SharedString("else")
+    );
+    assert_eq!(
+        data.get((0, 1))
+            .expect("Could not get data from table ref."),
+        &DataRef::Float(12.5)
+    );
+    assert_eq!(
+        data.get((1, 1))
+            .expect("Could not get data from table ref."),
+        &DataRef::Float(64.0)
+    );
     xls.worksheet_range_at(0).unwrap().unwrap();
 }
 


### PR DESCRIPTION
During some work I was performing on a MR for `fastexcel` (https://github.com/ToucanToco/fastexcel/pull/282) I noticed no method for retrieving `Table`s with `DataRef` as inner type was not possible. This MR should hopefully resolve this issue. 

I also implemented `From<Table<T>>` for `Range<T>` to prevent large clone operations, which I ran into in one method in particular inside `fastexcel`. 

Finally I resolved a small `clippy` warning mentioning that `std::u32::MAX` is deprecated. 

Eager to receive your feedback :) 