### PR TITLE
README.md: (misc) Fix example

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ function.
 use calamine::{Reader, Xlsx, open_workbook};
 
 let mut excel: Xlsx<_> = open_workbook("file.xlsx").unwrap();
-if let Some(Ok(r)) = excel.worksheet_range("Sheet1") {
+if let Ok(r) = excel.worksheet_range("Sheet1") {
     for row in r.rows() {
         println!("row={:?}, row[0]={:?}", row, row[0]);
     }

--- a/README.md
+++ b/README.md
@@ -106,12 +106,12 @@ if let Ok(r) = excel.worksheet_range("Sheet1") {
 ### Reader: With header row
 
 ```rs
-use calamine::{Reader, Xlsx, open_workbook};
+use calamine::{HeaderRow, Reader, Xlsx, open_workbook};
 
 let mut excel: Xlsx<_> = open_workbook("file.xlsx").unwrap();
 
 let sheet1 = excel
-    .with_header_row(Some(3))
+    .with_header_row(HeaderRow::Row(3))
     .worksheet_range("Sheet1")
     .unwrap();
 ```


### PR DESCRIPTION
Xlsx::worksheet_range() returns Result<T, E> not Option<Result<T, E>>