### PR TITLE
perf: accelerated datatype conversion

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,11 @@ edition = "2021"
 rust-version = "1.73"
 
 [dependencies]
+atoi_simd = "0.16"
 byteorder = "1.5"
 codepage = "0.1.1"
 encoding_rs = "0.8"
+fast-float2 = "0.2"
 log = "0.4"
 serde = "1.0"
 quick-xml = { version = "0.36", features = ["encoding"] }

--- a/src/datatype.rs
+++ b/src/datatype.rs
@@ -154,7 +154,7 @@ impl DataType for Data {
             Data::Int(v) => Some(*v),
             Data::Float(v) => Some(*v as i64),
             Data::Bool(v) => Some(*v as i64),
-            Data::String(v) => v.parse::<i64>().ok(),
+            Data::String(v) => atoi_simd::parse::<i64>(v.as_bytes()).ok(),
             _ => None,
         }
     }
@@ -164,7 +164,7 @@ impl DataType for Data {
             Data::Int(v) => Some(*v as f64),
             Data::Float(v) => Some(*v),
             Data::Bool(v) => Some((*v as i32).into()),
-            Data::String(v) => v.parse::<f64>().ok(),
+            Data::String(v) => fast_float2::parse(v).ok(),
             _ => None,
         }
     }
@@ -472,8 +472,8 @@ impl DataType for DataRef<'_> {
             DataRef::Int(v) => Some(*v),
             DataRef::Float(v) => Some(*v as i64),
             DataRef::Bool(v) => Some(*v as i64),
-            DataRef::String(v) => v.parse::<i64>().ok(),
-            DataRef::SharedString(v) => v.parse::<i64>().ok(),
+            DataRef::String(v) => atoi_simd::parse::<i64>(v.as_bytes()).ok(),
+            DataRef::SharedString(v) => atoi_simd::parse::<i64>(v.as_bytes()).ok(),
             _ => None,
         }
     }
@@ -483,8 +483,8 @@ impl DataType for DataRef<'_> {
             DataRef::Int(v) => Some(*v as f64),
             DataRef::Float(v) => Some(*v),
             DataRef::Bool(v) => Some((*v as i32).into()),
-            DataRef::String(v) => v.parse::<f64>().ok(),
-            DataRef::SharedString(v) => v.parse::<f64>().ok(),
+            DataRef::String(v) => fast_float2::parse(v).ok(),
+            DataRef::SharedString(v) => fast_float2::parse(v).ok(),
             _ => None,
         }
     }

--- a/src/xlsx/cells_reader.rs
+++ b/src/xlsx/cells_reader.rs
@@ -195,13 +195,8 @@ impl<'a> XlsxCellReader<'a> {
                                     // shared index
                                     let shared_index =
                                         match get_attribute(e.attributes(), QName(b"si"))? {
-                                            Some(res) => match std::str::from_utf8(res) {
-                                                Ok(res) => match res.parse::<usize>() {
-                                                    Ok(res) => res,
-                                                    Err(e) => {
-                                                        return Err(XlsxError::ParseInt(e));
-                                                    }
-                                                },
+                                            Some(res) => match atoi_simd::parse::<usize>(res) {
+                                                Ok(res) => res,
                                                 Err(_) => {
                                                     return Err(XlsxError::Unexpected(
                                                         "si attribute must be a number",

--- a/src/xlsx/cells_reader.rs
+++ b/src/xlsx/cells_reader.rs
@@ -327,10 +327,7 @@ fn read_v<'s>(
 ) -> Result<DataRef<'s>, XlsxError> {
     let cell_format = match get_attribute(c_element.attributes(), QName(b"s")) {
         Ok(Some(style)) => {
-            let id: usize = std::str::from_utf8(style)
-                .unwrap_or("0")
-                .parse()
-                .unwrap_or(0);
+            let id = atoi_simd::parse::<usize>(style).unwrap_or(0);
             formats.get(id)
         }
         _ => Some(&CellFormat::Other),
@@ -338,7 +335,7 @@ fn read_v<'s>(
     match get_attribute(c_element.attributes(), QName(b"t"))? {
         Some(b"s") => {
             // shared string
-            let idx: usize = v.parse()?;
+            let idx = atoi_simd::parse::<usize>(v.as_bytes()).unwrap_or(0);
             Ok(DataRef::SharedString(&strings[idx]))
         }
         Some(b"b") => {


### PR DESCRIPTION
implements #378

Apart from `atoi_simd` for integer conversion, also used `fast-float2` for float conversion.

Both crates are heavily used by the Polars project.