### PR TITLE
Pin zip crate to 2.5.*

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ fast-float2 = "0.2"
 log = "0.4"
 serde = "1.0"
 quick-xml = { version = "0.37", features = ["encoding"] }
-zip = { version = "2", default-features = false, features = ["deflate"] }
+zip = { version = "~2.5.0", default-features = false, features = ["deflate"] }
 chrono = { version = "0.4", features = [
     "serde",
 ], optional = true, default-features = false }


### PR DESCRIPTION
This fixes the current breaking build due to zip's 2.6 breaking changes.

Here's a screenshot of the build issues due to zip >= 2.6. 

![Screenshot from 2025-04-05 07-10-25](https://github.com/user-attachments/assets/7d8e2352-b58a-4f8e-b6d2-14690fad57bc)
