### PR TITLE
bump v0.27.0

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,7 +4,7 @@ on: [ push, pull_request ]
 
 jobs:
   rust:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         toolchain: 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calamine"
-version = "0.26.1"
+version = "0.27.0"
 authors = ["Johann Tuffe <tafia973@gmail.com>"]
 repository = "https://github.com/tafia/calamine"
 documentation = "https://docs.rs/calamine"

--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,15 @@
 
 ## Unreleased
 
+## 0.27.0 (2025-04-22)
+
+- fix (xls): Invalid formats parsing
+- feat (xls): add one more Error variant related to formatting
+- fix: Always parse string cell as string
+- refactor: bump dependencies
+- fix: pin zip crate to 2.5.*
+- fix (xlsx): check 'closing' tag name with more prefixes
+
 ## 0.26.1 (2024-10-10)
 
 - fix: sparse celle expect 0 index rows, even when using `header_row`

--- a/src/xlsx/mod.rs
+++ b/src/xlsx/mod.rs
@@ -1419,10 +1419,10 @@ pub(crate) fn coordinate_to_name(cell: (u32, u32)) -> Result<Vec<u8>, XlsxError>
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use std::io::Write;
     use zip::write::SimpleFileOptions;
     use zip::ZipWriter;
-    use super::*;
 
     #[test]
     fn test_dimensions() {
@@ -1541,14 +1541,17 @@ mod tests {
 
         let mut buf = [0; 1000];
         let mut zip_writer = ZipWriter::new(std::io::Cursor::new(&mut buf[..]));
-        let options = SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored);
-        zip_writer.start_file("xl/sharedStrings.xml", options).unwrap();
+        let options =
+            SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored);
+        zip_writer
+            .start_file("xl/sharedStrings.xml", options)
+            .unwrap();
         zip_writer.write(shared_strings_data).unwrap();
         let zip_size = zip_writer.finish().unwrap().position() as usize;
 
         let zip = ZipArchive::new(std::io::Cursor::new(&buf[..zip_size])).unwrap();
 
-        let mut xlsx = Xlsx{
+        let mut xlsx = Xlsx {
             zip,
             strings: vec![],
             sheets: vec![],


### PR DESCRIPTION
- fix (xls): Invalid formats parsing
- feat (xls): add one more Error variant related to formatting
- fix: Always parse string cell as string
- refactor: bump dependencies
- fix: pin zip crate to 2.5.*
- fix (xlsx): check 'closing' tag name with more prefixes