### PR TITLE
bump zip from 2.6 to 3

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         toolchain: 
-          - "1.73"  # MSRV
+          - "1.75"  # MSRV
           - stable
           - beta
           - nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ fast-float2 = "0.2"
 log = "0.4"
 serde = "1.0"
 quick-xml = { version = "0.37", features = ["encoding"] }
-zip = { version = "2.6", default-features = false, features = ["deflate"] }
+zip = { version = "3", default-features = false, features = ["deflate"] }
 chrono = { version = "0.4", features = [
     "serde",
 ], optional = true, default-features = false }


### PR DESCRIPTION
The zip semver issue has been "fixed".

https://github.com/zip-rs/zip2/issues/337