### PR TITLE
fix: upgrade zip to v4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ fast-float2 = "0.2"
 log = "0.4"
 serde = "1.0"
 quick-xml = { version = "0.37", features = ["encoding"] }
-zip = { version = "2.6", default-features = false, features = ["deflate"] }
+zip = { version = "4", default-features = false, features = ["deflate"] }
 chrono = { version = "0.4", features = [
     "serde",
 ], optional = true, default-features = false }


### PR DESCRIPTION
zip v2.6 got yanked

```
cargo add calamine

error: failed to select a version for the requirement `zip = "^2.6"`
candidate versions found which didn't match: 4.0.0, 3.0.0, 2.4.2, ...
```

calamine is not effected by changes from v2.6 to v4