### PR TITLE
Add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,98 @@
+name: 🐞 Bug
+
+description: File a bug/issue in calamine
+
+title: "Bug: add a description here"
+
+labels: [bug]
+
+body:
+
+- type: markdown
+  attributes:
+    value: Please fill in the title above and the sections below to submit your bug report.
+
+- type: textarea
+  attributes:
+    label: Current behavior
+    description: A description of what you're experiencing.
+  validations:
+    required: true
+
+- type: textarea
+  attributes:
+    label: Expected behavior
+    description: A description of what you expected to happen.
+  validations:
+    required: true
+
+- type: textarea
+  attributes:
+    label: Sample code to reproduce
+    description: Please add a small, complete, sample program that demonstrates your issue.
+    value: |
+        ```
+        use calamine::{open_workbook, Error, Reader, Xlsx};
+
+        fn main() -> Result<(), Error> {
+            let test_file = "somefile.xlsx";
+
+            let mut workbook: Xlsx<_> = open_workbook(test_file)?;
+
+            let sheet_range = workbook.worksheet_range("Sheet1")?;
+            let mut iter = sheet_range.deserialize()?;
+
+            if let Some(result) = iter.next() {
+                let (label, value): (String, f64) = result?;
+
+                assert_eq!(label, "celsius");
+                assert_eq!(value, 22.2222);
+
+                Ok(())
+            } else {
+                Err(From::from("Expected at least one record but got none"))
+            }
+        }
+        ```
+    render: rust
+  validations:
+    required: true
+
+- type: textarea
+  attributes:
+    label: Test file
+    description: >
+      Please attach the test file that you used in the sample code above. If you
+      are unable to share the original file, please create a minimal test file
+      that reproduces the issue.
+
+
+      Tip: You can attach files by clicking this area to highlight it and then
+      dragging files in.
+  validations:
+    required: true
+
+- type: textarea
+  attributes:
+    label: Environment
+    description: |
+      Add any relevant version or system information:
+    value: |
+        - calamine version:
+        - Cargo.toml dependency line for calamine:
+        - rustc version:
+        - Excel/OpenOffice/LibreOffice version:
+        - OS:
+    render: text
+  validations:
+    required: false
+
+- type: checkboxes
+  attributes:
+    label: Checklist
+    description: >
+      Ensure that the following have been included.
+    options:
+    - label: I have added a complete sample program that compiles in Rust.
+    - label: I have added a test file.
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,27 @@
+name: 🎯 Feature Request
+
+description: Request a new feature in calamine
+
+title: "feature request: add a description here"
+
+labels: [feature request]
+
+body:
+
+- type: markdown
+  attributes:
+    value: |
+      Use the dialog box below to request a new feature in calamine.
+
+- type: textarea
+  attributes:
+    label: Feature Request
+    description: |
+      Describe the new feature that you would like to see in calamine.
+
+      It is important to explain what your personal use case is.
+
+      Consider adding a screenshot or a sample file to help explain the request.
+
+  validations:
+    required: true

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,32 @@
+name: ❓ Question
+
+description: Ask a question about calamine
+
+title: "question: add a description here"
+
+labels: [question]
+
+body:
+
+- type: markdown
+  attributes:
+    value: >
+      General questions on how to do something with the calamine crate should
+      be asked on [StackOverflow](http://stackoverflow.com/questions/tagged/calamine)
+      with a tag of "calamine". This has a better chance of getting several
+      answers and also helps others who might have similar questions in the
+      future. If you don't get an answer on StackOverflow, you can come back
+      here and refer to your question there.
+
+
+      If your question is "Is this a bug" then please file a bug report instead.
+
+
+      Other questions can be asked below.
+
+- type: textarea
+  attributes:
+    label: Question
+    description: Ask a question that doesn't belong on StackOverflow
+  validations:
+    required: true


### PR DESCRIPTION
This PR adds GitHub templates for Bug Report, Feature Request and Questions.

When the user submits a GitHub issue they will get a dialog like this:

![CleanShot 2025-07-05 at 15 11 11](https://github.com/user-attachments/assets/c652d56e-8e58-4f85-ac4b-fe6f7cac3b46)

(Except with `calamine` and not `rust_xlsxwriter`.)

In the past I have found this useful to focus the submitter on what is important, for example a test case and test file in a bug report.

See the following for information on GitHub issue templates:

- https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates
- https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository

@tafia This may (or may not) need to be enabled in the settings by you.