### PR TITLE
Pin zip.rs to v4.2.0 (for now)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ fast-float2 = "0.2"
 log = "0.4"
 serde = "1.0"
 quick-xml = { version = "0.37", features = ["encoding"] }
-zip = { version = "4.0", default-features = false, features = ["deflate"] }
+zip = { version = "~4.2.0", default-features = false, features = ["deflate"] }
 chrono = { version = "0.4", features = [
     "serde",
 ], optional = true, default-features = false }


### PR DESCRIPTION
Zip.rs v4.3.0 requires a MSRV of 1.85.0. This change pins zip.rs to v4.2.0 to allow user to maintain a MSRV of 1.73.0.

Once this is release in calamine v0.29.0 it will allow end users to pin calamine to that version and maintain v1.73.0 compatibility. However, it is likely that calamine v0.30.0+ will move back to zip.rs v4.0 and rustc v1.85.0.

Closes #527