### PR TITLE
xls: add simple Debug trait for Record struct

### DIFF
--- a/src/xls.rs
+++ b/src/xls.rs
@@ -5,7 +5,7 @@
 use std::borrow::Cow;
 use std::cmp::min;
 use std::collections::BTreeMap;
-use std::fmt::Write;
+use std::fmt::{self, Write};
 use std::io::{Read, Seek, SeekFrom};
 use std::marker::PhantomData;
 
@@ -1066,6 +1066,29 @@ impl<'a> Record<'a> {
             self.data = next;
             len -= l;
         }
+        Ok(())
+    }
+}
+
+// Simple Debug impl to dump record data in hex format.
+impl fmt::Debug for Record<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(
+            f,
+            "\nRecord = 0x{:04X}, Length = 0x{:04X}, {}",
+            self.typ,
+            self.data.len(),
+            self.data.len()
+        )?;
+
+        let mut iter = self.data.chunks(16);
+        for chunk in iter.by_ref() {
+            for byte in chunk {
+                write!(f, "{byte:02X} ")?;
+            }
+            writeln!(f)?;
+        }
+
         Ok(())
     }
 }


### PR DESCRIPTION
Add a `simple fmt::Debug` trait to dump the binary BIFF objects from the Record struct. This is useful when debugging xls files.

The output looks like this:

```
[src/xls.rs:331:17] &r = 
Record = 0x0809, Length = 0x0010, 16
00 06 05 00 54 38 CD 07 C1 00 02 00 06 08 00 00 

[src/xls.rs:331:17] &r = 
Record = 0x00E1, Length = 0x0002, 2
B0 04 

[src/xls.rs:331:17] &r = 
Record = 0x00C1, Length = 0x0002, 2
00 00 

[src/xls.rs:331:17] &r = 
Record = 0x00E2, Length = 0x0000, 0

[src/xls.rs:331:17] &r = 
Record = 0x005C, Length = 0x0070, 112
05 00 01 10 04 3B 04 35 04 3D 04 30 04 20 20 20 
20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 
20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 
20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 
20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 
20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 
20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 

[src/xls.rs:331:17] &r = 
Record = 0x0042, Length = 0x0002, 2
B0 04 

...
```

Ideally I would like to have implemented the output into something like the following. 

```
[BOF] (Record = 0x0809, Length = 0x0010, 16)
    09 08 10 00 00 06 05 00 54 38 CD 07 C1 00 02 00 |........T8......|
    06 08 00 00                                     |....            |


    0   Record                   = 0x0809         2057
    1   Version 1                = 0x08           8   
    2   Length                   = 0x0010         16  
    4   Version 2                = 0x0600         1536
    6   Type: (Workbook globals) = 0x0005         5   
    8   Build                    = 0x3854         14420
    10  Year                     = 0x07CD         1997
    12  History                  = 0x000200C1     131265
    16  Lowest version           = 0x00000806     2054


[INTERFACEHDR] (Record = 0x00E1, Length = 0x0002, 2)
    E1 00 02 00 B0 04                               |......          |


[MMS] (Record = 0x00C1, Length = 0x0002, 2)
    C1 00 02 00 00 00                               |......          |


[INTERFACEEND] (Record = 0x00E2, Length = 0x0000, 0)
    E2 00 00 00                                     |....            |


[WRITEACCESS] (Record = 0x005C, Length = 0x0070, 112)
    5C 00 70 00 05 00 01 10 04 3B 04 35 04 3D 04 30 |\.p......;.5.=.0|
    04 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 |.               |
    20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 |                |
    20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 |                |
    20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 |                |
    20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 |                |
    20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 |                |
    20 20 20 20                                     |                |


[CODEPAGE] (Record = 0x0042, Length = 0x0002, 2)
    42 00 02 00 B0 04                               |B.....          |


    0   Record                   = 0x0042         66  
    2   Length                   = 0x0002         2   
    4   Codepage                 = 0x04B0         1200

```

However, that is probably overkill for a simple `Debug` trait and I may implement that in a separate tool.



