### PR TITLE
deps: remove log.rs dependency

### DIFF
--- a/src/xlsb/mod.rs
+++ b/src/xlsb/mod.rs
@@ -10,8 +10,6 @@ use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::io::{BufReader, Read, Seek};
 
-use log::debug;
-
 use encoding_rs::UTF_16LE;
 use quick_xml::events::attributes::Attribute;
 use quick_xml::events::Event;
@@ -403,7 +401,7 @@ impl<RS: Read + Seek> Xlsb<RS> {
                     self.metadata.names = defined_names;
                     return Ok(());
                 }
-                _ => debug!("Unsupported type {typ:X}"),
+                _ => eprintln!("Unsupported type {typ:X}"),
             }
         }
     }
@@ -779,7 +777,6 @@ fn parse_formula(
             }
             0x01 => {
                 // PtgExp: array/shared formula, ignore
-                debug!("ignoring PtgExp array/shared formula");
                 stack.push(formula.len());
                 rgce = &rgce[4..];
             }

--- a/src/xlsx/mod.rs
+++ b/src/xlsx/mod.rs
@@ -1535,7 +1535,7 @@ impl<RS: Read + Seek> Reader<RS> for Xlsx<RS> {
         let mut cell_reader = match self.worksheet_cells_reader(name) {
             Ok(reader) => reader,
             Err(XlsxError::NotAWorksheet(typ)) => {
-                warn!("'{typ}' not a worksheet");
+                eprintln!("'{typ}' not a worksheet");
                 return Ok(Range::default());
             }
             Err(e) => return Err(e),
@@ -1580,7 +1580,7 @@ impl<RS: Read + Seek> ReaderRef<RS> for Xlsx<RS> {
         let mut cell_reader = match self.worksheet_cells_reader(name) {
             Ok(reader) => reader,
             Err(XlsxError::NotAWorksheet(typ)) => {
-                log::warn!("'{typ}' not a valid worksheet");
+                eprintln!("'{typ}' not a valid worksheet");
                 return Ok(Range::default());
             }
             Err(e) => return Err(e),
@@ -1703,10 +1703,12 @@ pub(crate) fn get_dimension(dimension: &[u8]) -> Result<Dimensions, XlsxError> {
             let rows = parts[1].0 - parts[0].0;
             let columns = parts[1].1 - parts[0].1;
             if rows > MAX_ROWS {
-                warn!("xlsx has more than maximum number of rows ({rows} > {MAX_ROWS})");
+                eprintln!("xlsx has more than maximum number of rows ({rows} > {MAX_ROWS})");
             }
             if columns > MAX_COLUMNS {
-                warn!("xlsx has more than maximum number of columns ({columns} > {MAX_COLUMNS})");
+                eprintln!(
+                    "xlsx has more than maximum number of columns ({columns} > {MAX_COLUMNS})"
+                );
             }
             Ok(Dimensions {
                 start: parts[0],


### PR DESCRIPTION
Removed log.rs dependency and debug statements. Replaced any required `warn!()` or `debug!()` with `eprintln!()`.

This cleans up the code and removed a dependency.

While refactoring/replacing the `cfb` code in #551 I noticed that the was a number of debug statements that weren't required or could be replaced by temporary `dgb!()` statements if needed.