### PR TITLE
Bump quick xml from 0.37 to 0.38

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         toolchain:
-          - "1.75"  # MSRV
+          - "1.83"  # MSRV
           - stable
           - beta
           - nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ fast-float2 = "0.2"
 zip = { version = "4.2.0", default-features = false, features = ["deflate"] }
 chrono = { version = "0.4", features = ["serde"], optional = true, default-features = false }
 quick-xml = { version = "0.38", features = ["encoding"] }
+simdutf8 = "0.1"
 
 [dev-dependencies]
 glob = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ encoding_rs = "0.8"
 fast-float2 = "0.2"
 zip = { version = "4.2.0", default-features = false, features = ["deflate"] }
 chrono = { version = "0.4", features = ["serde"], optional = true, default-features = false }
-quick-xml = { version = "0.37", features = ["encoding"] }
+quick-xml = { version = "0.38", features = ["encoding"] }
 
 [dev-dependencies]
 glob = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["excel", "ods", "xls", "xlsx", "xlsb"]
 categories = ["encoding", "parsing", "text-processing"]
 exclude = ["tests/**/*"]
 edition = "2021"
-rust-version = "1.75"
+rust-version = "1.83"
 
 [dependencies]
 log = "0.4"

--- a/src/ods.rs
+++ b/src/ods.rs
@@ -668,7 +668,10 @@ where
             buf.clear();
             match reader.read_event_into(buf) {
                 Ok(Event::Text(ref e)) => {
-                    s.push_str(&e.unescape()?);
+                    s.push_str(&e.decode()?);
+                }
+                Ok(Event::GeneralRef(ref e)) => {
+                    crate::utils::decode_entity_ref_into(e.as_ref(), &mut s);
                 }
                 Ok(Event::End(ref e))
                     if e.name() == QName(b"table:table-cell")

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1054,17 +1054,18 @@ pub const FTAB_ARGC: [u8; FTAB_LEN] = [
     129, // "AVERAGEIFS"
 ];
 
-/// Writes decoded XML entity references directly into the target string
-///
-/// This function handles the standard XML entity references that were
-/// automatically decoded in quick-xml 0.37 but are now reported as
-/// Event::GeneralRef in quick-xml 0.38.
-///
-/// This approach is maximally efficient as it writes directly to the target
-/// string without any intermediate allocations.
-/// For standard XML entities (`amp`, `lt`, `gt`, `quot`, `apos`), decoding is done via direct character matching.
-/// For other entity names, simdutf8 is used insstead of std::str::from_utf8 for faster decoding.
-pub fn decode_entity_ref_into(entity_name: &[u8], target: &mut String) {
+// Writes decoded XML entity references directly into the target string
+//
+// This function handles the standard XML entity references that were
+// automatically decoded in quick-xml 0.37 but are now reported as
+// Event::GeneralRef in quick-xml 0.38.
+//
+// This approach is maximally efficient as it writes directly to the target
+// string without any intermediate allocations.
+// For standard XML entities (`amp`, `lt`, `gt`, `quot`, `apos`), decoding is done via direct character matching.
+// For other entity names, simdutf8 is used insstead of std::str::from_utf8 for faster decoding.
+#[inline]
+pub(crate) fn decode_entity_ref_into(entity_name: &[u8], target: &mut String) {
     match entity_name {
         b"amp" => target.push('&'),
         b"lt" => target.push('<'),

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1110,7 +1110,8 @@ mod tests {
 ///
 /// This approach is maximally efficient as it writes directly to the target
 /// string without any intermediate allocations.
-/// It also uses simdutf8 to decode the entity name for faster decoding.
+/// For standard XML entities (`amp`, `lt`, `gt`, `quot`, `apos`), decoding is done via direct character matching.
+/// For other entity names, simdutf8 is used to decode the entity name for faster decoding.
 pub fn decode_entity_ref_into(entity_name: &[u8], target: &mut String) {
     match entity_name {
         b"amp" => target.push('&'),

--- a/src/xlsx/cells_reader.rs
+++ b/src/xlsx/cells_reader.rs
@@ -318,7 +318,10 @@ where
             loop {
                 v_buf.clear();
                 match xml.read_event_into(&mut v_buf)? {
-                    Event::Text(t) => v.push_str(&t.unescape()?),
+                    Event::Text(t) => v.push_str(&t.decode()?),
+                    Event::GeneralRef(ref e) => {
+                        crate::utils::decode_entity_ref_into(e.as_ref(), &mut v);
+                    }
                     Event::End(end) if end.name() == e.name() => break,
                     Event::Eof => return Err(XlsxError::XmlEof("v")),
                     _ => (),
@@ -416,7 +419,10 @@ where
             let mut f = String::new();
             loop {
                 match xml.read_event_into(&mut f_buf)? {
-                    Event::Text(t) => f.push_str(&t.unescape()?),
+                    Event::Text(t) => f.push_str(&t.decode()?),
+                    Event::GeneralRef(ref e) => {
+                        crate::utils::decode_entity_ref_into(e.as_ref(), &mut f);
+                    }
                     Event::End(end) if end.name() == e.name() => break,
                     Event::Eof => return Err(XlsxError::XmlEof("f")),
                     _ => (),

--- a/src/xlsx/mod.rs
+++ b/src/xlsx/mod.rs
@@ -471,7 +471,10 @@ impl<RS: Read + Seek> Xlsx<RS> {
                         let mut value = String::new();
                         loop {
                             match xml.read_event_into(&mut val_buf)? {
-                                Event::Text(t) => value.push_str(&t.unescape()?),
+                                Event::Text(t) => value.push_str(&t.decode()?),
+                                Event::GeneralRef(ref e) => {
+                                    crate::utils::decode_entity_ref_into(e.as_ref(), &mut value);
+                                }
                                 Event::End(end) if end.name() == e.name() => break,
                                 Event::Eof => return Err(XlsxError::XmlEof("workbook")),
                                 _ => (),
@@ -1815,7 +1818,10 @@ where
                 let mut value = String::new();
                 loop {
                     match xml.read_event_into(&mut val_buf)? {
-                        Event::Text(t) => value.push_str(&t.unescape()?),
+                        Event::Text(t) => value.push_str(&t.decode()?),
+                        Event::GeneralRef(ref e) => {
+                            crate::utils::decode_entity_ref_into(e.as_ref(), &mut value);
+                        }
                         Event::End(end) if end.name() == e.name() => break,
                         Event::Eof => return Err(XlsxError::XmlEof("t")),
                         _ => (),


### PR DESCRIPTION
Folks,
Bumped quick-xml to 0.38 which has breaking API changes that replaced `unescape()` with `decode()`.

`decode()`, however, returns standard XML entity references that were automatically decoded in quick-xml 0.37 `unescape()`as `Event::GeneralRef`, so I added the `decode_entity_ref_into()` helper.

Added simdutf8 as well to make sure the utf8 decoding as fast as possible.

Didn't get around to benchmarking it though...