### PR TITLE
fix: do best-effort decoding when codepage is unknown

### DIFF
--- a/src/cfb.rs
+++ b/src/cfb.rs
@@ -10,7 +10,7 @@ use std::io::Read;
 
 use log::debug;
 
-use encoding_rs::{Encoding, UTF_16LE, UTF_8};
+use encoding_rs::{Encoding, UTF_16LE, UTF_8, WINDOWS_1252};
 
 use crate::utils::*;
 
@@ -421,9 +421,12 @@ pub struct XlsEncoding {
 }
 
 impl XlsEncoding {
-    pub fn from_codepage(codepage: u16) -> Result<XlsEncoding, CfbError> {
-        let e = codepage::to_encoding(codepage).ok_or(CfbError::CodePageNotFound(codepage))?;
-        Ok(XlsEncoding { encoding: e })
+    pub fn from_codepage(codepage: u16) -> XlsEncoding {
+        let encoding = codepage::to_encoding(codepage).unwrap_or({
+            log::warn!("{}", CfbError::CodePageNotFound(codepage));
+            WINDOWS_1252
+        });
+        XlsEncoding { encoding }
     }
 
     fn high_byte(&self, high_byte: Option<bool>) -> Option<bool> {

--- a/src/vba.rs
+++ b/src/vba.rs
@@ -335,7 +335,7 @@ fn read_dir_information(stream: &mut &[u8]) -> Result<XlsEncoding, VbaError> {
     *stream = &stream[20..];
 
     // PROJECT Codepage
-    let encoding = XlsEncoding::from_codepage(read_u16(&stream[6..8]))?;
+    let encoding = XlsEncoding::from_codepage(read_u16(&stream[6..8]));
     *stream = &stream[8..];
 
     // PROJECTNAME Record

--- a/src/xls.rs
+++ b/src/xls.rs
@@ -323,7 +323,7 @@ impl<RS: Read + Seek> Xls<RS> {
         let mut xfs = Vec::new();
         let mut biff = Biff::Biff8; // Binary Interchange File Format (BIFF) version
         let codepage = self.options.force_codepage.unwrap_or(1200);
-        let mut encoding = XlsEncoding::from_codepage(codepage)?;
+        let mut encoding = XlsEncoding::from_codepage(codepage);
         #[cfg(feature = "picture")]
         let mut draw_group: Vec<u8> = Vec::new();
         {
@@ -337,7 +337,7 @@ impl<RS: Read + Seek> Xls<RS> {
                     // CodePage
                     0x0042 => {
                         if self.options.force_codepage.is_none() {
-                            encoding = XlsEncoding::from_codepage(read_u16(r.data))?;
+                            encoding = XlsEncoding::from_codepage(read_u16(r.data));
                         }
                     }
                     0x013D => {
@@ -1678,7 +1678,7 @@ mod tests {
 
     #[test]
     fn test_parse_string() {
-        let enc = XlsEncoding::from_codepage(1252).unwrap();
+        let enc = XlsEncoding::from_codepage(1252);
         parse_string(&[0, 1], &enc, Biff::Biff8).unwrap_err();
     }
 }


### PR DESCRIPTION
I've hit an xls file that has an invalid codepage of 0. Decoding reveals it to be ascii compatible, so could be anything.

```text
[2025-10-23T09:42:27Z DEBUG calamine::cfb] decoded as
utf16be: ç´æ‘¯æ±¥,
utf16le: ç‘³æ½¤æ•¬,
win1252: stdole
[2025-10-23T09:42:27Z DEBUG calamine::cfb] decoded as
utf16be: â©œä»ã€°ã€²ã€´ãŒ°â´°ã€°ã€­ã€°ã€°âµƒã€°ã€­ã€°ã€°ã€°ã€°ã€°ã¶ç´£ãˆ®ã€£ã€£äŒºå±—æ¥®æ‘¯ç³å±“ç¥³ååœ¶ã‘œç´æ‘¯æ±¥ãˆ®ç‘¬æˆ£ä½Œä” ä…µç‘¯æµ¡ç‘©æ½®,
utf16le: å°ªç­‡ã€°ãˆ°ã°ã€³ã€­ã€°â´°ã€°ã€°äŒ­ã€°â´°ã€°ã€°ã€°ã€°ã€°ã˜´â½â¸²âŒ°âŒ°ã©ƒåœæ¹©æ½¤ç·åœç¹ä½—ã™—å°´ç‘³æ½¤æ•¬â¸²æ±´â¢ä±â…ç•æ½´æ…­æ¥´æ¹¯,
win1252: *\G{00020430-0000-0000-C000-000000000046}#2.0#0#C:\Windows\SysWOW64\stdole2.tlb#OLE Automation
```

These strings are decoded inside `vba::set_lid`. We could either narrowly attempt to decode the strings inside just this function, since it does some validation on the decoded strings, looking for the presence of a `#` or b) use a global fallback decoding as this PR suggests and log that the codepage was invalid.
