### PR TITLE
feat(deps): allow zip>4 to be used

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ atoi_simd = "0.16"
 byteorder = "1.5"
 encoding_rs = "0.8"
 fast-float2 = "0.2"
-zip = { version = "4.2.0", default-features = false, features = ["deflate"] }
+zip = { version = ">=4.2.0", default-features = false, features = ["deflate"] }
 quick-xml = { version = "0.38", features = ["encoding"] }
 
 # Optional dependencies.


### PR DESCRIPTION
This avoids having several versions of the `zip` crate in big projects that have several transitive dependencies on it.

Also, it would allow us to address https://github.com/ToucanToco/fastexcel/issues/413 in fastexcel once https://github.com/zip-rs/zip2/pull/483 is merged