### PR TITLE
ci: add wasm32-unknown-unknown compilation check

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -45,3 +45,16 @@ jobs:
       if: ${{ matrix.toolchain == 'stable' }}
       run: |
         cargo clippy --lib --examples --tests -- -Dwarnings
+
+  wasm:
+    runs-on: ubuntu-24.04
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install Rust toolchain
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        targets: wasm32-unknown-unknown
+    - name: Check wasm32 compilation
+      run: |
+        cargo check --target wasm32-unknown-unknown
+        cargo check --target wasm32-unknown-unknown --all-features


### PR DESCRIPTION
## Summary

Adds a CI job to verify calamine compiles for `wasm32-unknown-unknown` (with and without `--all-features`). calamine already compiles for this target with current dependencies since `atoi_simd v0.17` includes a non-SIMD fallback. This prevents future regressions.

Closes #603