### PR TITLE
perf: ensure `fast_float2` used at all float-parsing call sites

### DIFF
--- a/src/ods.rs
+++ b/src/ods.rs
@@ -684,7 +684,10 @@ where
         match a.key {
             QName(b"office:value") if !is_value_set => {
                 let v = reader.decoder().decode(&a.value)?;
-                val = Data::Float(v.parse()?);
+                val = Data::Float(
+                    fast_float2::parse(v.as_bytes())
+                        .map_err(|_| OdsError::ParseFloat(v.parse::<f64>().unwrap_err()))?,
+                );
                 is_value_set = true;
             }
             QName(b"office:string-value" | b"office:date-value" | b"office:time-value")

--- a/src/xlsx/cells_reader.rs
+++ b/src/xlsx/cells_reader.rs
@@ -397,15 +397,15 @@ fn read_v<'s>(
             if v.is_empty() {
                 Ok(DataRef::Empty)
             } else {
-                v.parse()
+                fast_float2::parse::<f64, _>(v.as_bytes())
                     .map(|n| format_excel_f64_ref(n, cell_format, is_1904))
-                    .map_err(XlsxError::ParseFloat)
+                    .map_err(|_| XlsxError::ParseFloat(v.parse::<f64>().unwrap_err()))
             }
         }
         None => {
             // If type is not known, we try to parse as Float for utility, but fall back to
             // String if this fails.
-            v.parse()
+            fast_float2::parse::<f64, _>(v.as_bytes())
                 .map(|n| format_excel_f64_ref(n, cell_format, is_1904))
                 .or(Ok(DataRef::String(v)))
         }


### PR DESCRIPTION
Already a dependency, so no extra crates/deps, I just noticed it wasn't being used everywhere. On a float-heavy sheet (eg: basically ALL floats 😄) this update gets about a ~3% speedup[^1] as `cells_reader` is a hot path.

Applies to `xlsx` and `ods` parsing.

[^1]: Benchmarked on: Apple Silicon M3 Max