### PR TITLE
perf: cell reader buffer reuse, optimise maps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ atoi_simd = "0.17"
 byteorder = "1.5"
 encoding_rs = "0.8"
 fast-float2 = "0.2"
-hashbrown = "0.16"
 zip = { version = "7.0", default-features = false, features = ["deflate"] }
 quick-xml = { version = "0.38", features = ["encoding"] }
 

--- a/src/ods.rs
+++ b/src/ods.rs
@@ -10,10 +10,9 @@
 ///
 /// [ODF 1.2]: http://docs.oasis-open.org/office/v1.2/OpenDocument-v1.2.pdf
 ///
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::io::{BufReader, Read, Seek};
 
-use hashbrown::HashMap;
 use log::warn;
 use quick_xml::events::attributes::Attributes;
 use quick_xml::events::Event;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -5,9 +5,9 @@
 //! Internal module providing handy functions
 
 use std::borrow::Cow;
+use std::collections::HashMap;
 use std::io::{Read, Seek};
 
-use hashbrown::HashMap;
 use quick_xml::{escape::resolve_xml_entity, events::BytesRef};
 use zip::read::ZipArchive;
 

--- a/src/xlsb/mod.rs
+++ b/src/xlsb/mod.rs
@@ -6,8 +6,8 @@ mod cells_reader;
 
 pub use cells_reader::XlsbCellsReader;
 
-use hashbrown::HashMap;
 use std::borrow::Cow;
+use std::collections::HashMap;
 use std::io::{BufReader, Read, Seek};
 
 use log::debug;


### PR DESCRIPTION
Three optimisations - two (very) small/minor, one medium, no public API changes:

## Optimisations

1) Replaced `s.chunks(4)` with `s.chunks_exact(4)` for the most micro of micro-optimisations.

2) As per @tafia's review suggestion https://github.com/tafia/calamine/pull/606#pullrequestreview-3852047360, replaced use of the standard `HashMap` with `hashbrown::HashMap` (which uses `ahash`). This was already a transitive dependency via `zip`, so doesn't actually expand the current set of deps (though is now explicit in `Cargo.toml`). Also replaced `BTreeMap` with `HashMap` in two places where the map does not actually need to maintain ordering ("read_relationships" and "number_formats") to get `O(n)` instead of `O(log n)`; marginal impact though as these maps are rarely (if ever?) going to be large.

  _**Update:** reverted explicit `hashbrown` integration (benefit was too marginal to reliably measure - maps are likely too small in relation to everything else), but kept the switch from `BTreeMap` to `HashMap` in places where order isn't needed.._

3) Extended the same buffer-reuse optimisation that was part of https://github.com/tafia/calamine/pull/606 to `XlsxCellReader`, but cleaned it up a bit by consolidating the buffers in a new `ValueBufs` struct. No more use of `read_string`, so dropped it (only the variant that takes shared buffers is used now).

## Miscellaneous

`clippy` complained about one of the functions having one too many args, so I also consolidated workbook-related args into a `WorkbookContext` struct; seems tidy?

## Results

~6-7% speedup[^1] when testing on a large (10 million cell) mixed-dtype Workbook.

[^1]: Benchmarked on: Apple Silicon M3 Max