### PR TITLE
refactor(cfb): resolve special case in the caller of fn get_chain

### DIFF
--- a/src/cfb.rs
+++ b/src/cfb.rs
@@ -107,7 +107,8 @@ impl Cfb {
 
         // get the list of directory sectors
         debug!("load directories");
-        let dirs = sectors.get_chain(h.dir_start, &fats, reader, h.dir_len * sector_size)?;
+        // we want to read the full chain, so pass no size restriction
+        let dirs = sectors.get_chain(h.dir_start, &fats, reader, usize::MAX)?;
         let dirs = dirs
             .chunks(128)
             .map(|c| Directory::from_slice(c, h.sector_size))
@@ -168,7 +169,6 @@ impl Cfb {
 struct Header {
     version: u16,
     sector_size: SectorSize,
-    dir_len: usize,
     dir_start: u32,
     fat_len: usize,
     mini_fat_len: usize,
@@ -223,7 +223,6 @@ impl Header {
             });
         }
 
-        let dir_len = read_usize(&buf[40..44]);
         let fat_len = read_usize(&buf[44..48]);
         let dir_start = read_u32(&buf[48..52]);
         let mini_fat_start = read_u32(&buf[60..64]);
@@ -238,7 +237,6 @@ impl Header {
             Header {
                 version,
                 sector_size,
-                dir_len,
                 dir_start,
                 fat_len,
                 mini_fat_len,
@@ -293,19 +291,14 @@ impl Sectors {
         r: &mut R,
         len: usize,
     ) -> Result<Vec<u8>, CfbError> {
-        let mut chain = Vec::with_capacity(len);
-        let read_entire_block = len == 0;
+        let mut chain = Vec::new();
         while sector_id != ENDOFCHAIN {
             let sector = self.get(sector_id, r)?;
-            if read_entire_block {
-                chain.extend_from_slice(sector);
-            } else {
-                let remaining = len - chain.len();
-                let to_copy = sector.len().min(remaining);
-                chain.extend_from_slice(&sector[..to_copy]);
-                if chain.len() >= len {
-                    break;
-                }
+            let remaining = len - chain.len();
+            let to_copy = sector.len().min(remaining);
+            chain.extend_from_slice(&sector[..to_copy]);
+            if chain.len() >= len {
+                break;
             }
             sector_id = fats[sector_id as usize];
         }


### PR DESCRIPTION
Follow up on #609 where the confusion is resolved by `len == 0` being caused by a special case in the spec.

Resolving this special case in the caller streamlines the logic inside `fn get_chain`