### PR TITLE
bench: change to criterion for benchmark testing

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -44,7 +44,7 @@ jobs:
     - name: Clippy checks
       if: ${{ matrix.toolchain == 'stable' }}
       run: |
-        cargo clippy --lib --examples --tests -- -Dwarnings
+        cargo clippy --all-targets --all-features -- -Dwarnings
 
   wasm:
     runs-on: ubuntu-24.04

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,11 @@ sha2 = "0.10"
 env_logger = "0.11"
 serde_derive = "1.0"
 rstest = { version = "0.26", default-features = false }
+criterion = { version = "0.5", features = ["html_reports"] }
+
+[[bench]]
+name = "basic"
+harness = false
 
 [features]
 default = []

--- a/benches/basic.rs
+++ b/benches/basic.rs
@@ -2,14 +2,15 @@
 //
 // Copyright 2016-2025, Johann Tuffe.
 
-#![feature(test)]
-
-extern crate test;
+// Simple benchmarks to check for performance regressions.
+//
+// Run with: `cargo bench`
+// HTML reports are written to target/criterion/.
 
 use calamine::{open_workbook, Ods, Reader, Xls, Xlsb, Xlsx};
+use criterion::{criterion_group, criterion_main, Criterion};
 use std::fs::File;
 use std::io::BufReader;
-use test::Bencher;
 
 fn count<R: Reader<BufReader<File>>>(path: &str) -> usize {
     let path = format!("{}/{}", env!("CARGO_MANIFEST_DIR"), path);
@@ -28,60 +29,71 @@ fn count<R: Reader<BufReader<File>>>(path: &str) -> usize {
     count
 }
 
-#[bench]
-fn bench_xls(b: &mut Bencher) {
-    b.iter(|| count::<Xls<_>>("tests/issues.xls"));
-}
+fn count_cells_reader_xlsx(path: &str) -> usize {
+    let path = format!("{}/{}", env!("CARGO_MANIFEST_DIR"), path);
+    let mut excel: Xlsx<_> = open_workbook(&path).expect("cannot open excel file");
 
-#[bench]
-fn bench_xlsx(b: &mut Bencher) {
-    b.iter(|| count::<Xlsx<_>>("tests/issues.xlsx"));
-}
-
-#[bench]
-fn bench_xlsb(b: &mut Bencher) {
-    b.iter(|| count::<Xlsb<_>>("tests/issues.xlsb"));
-}
-
-#[bench]
-fn bench_ods(b: &mut Bencher) {
-    b.iter(|| count::<Ods<_>>("tests/issues.ods"));
-}
-
-#[bench]
-fn bench_xlsx_cells_reader(b: &mut Bencher) {
-    fn count<R: Reader<BufReader<File>>>(path: &str) -> usize {
-        let path = format!("{}/{}", env!("CARGO_MANIFEST_DIR"), path);
-        let mut excel: Xlsx<_> = open_workbook(&path).expect("cannot open excel file");
-
-        let sheets = excel.sheet_names();
-        let mut count = 0;
-        for s in sheets {
-            let mut cells_reader = excel.worksheet_cells_reader(&s).unwrap();
-            while cells_reader.next_cell().unwrap().is_some() {
-                count += 1;
-            }
+    let sheets = excel.sheet_names();
+    let mut count = 0;
+    for s in sheets {
+        let mut cells_reader = excel.worksheet_cells_reader(&s).unwrap();
+        while cells_reader.next_cell().unwrap().is_some() {
+            count += 1;
         }
-        count
     }
-    b.iter(|| count::<Xlsx<_>>("tests/issues.xlsx"));
+    count
 }
 
-#[bench]
-fn bench_xlsb_cells_reader(b: &mut Bencher) {
-    fn count<R: Reader<BufReader<File>>>(path: &str) -> usize {
-        let path = format!("{}/{}", env!("CARGO_MANIFEST_DIR"), path);
-        let mut excel: Xlsb<_> = open_workbook(&path).expect("cannot open excel file");
+fn count_cells_reader_xlsb(path: &str) -> usize {
+    let path = format!("{}/{}", env!("CARGO_MANIFEST_DIR"), path);
+    let mut excel: Xlsb<_> = open_workbook(&path).expect("cannot open excel file");
 
-        let sheets = excel.sheet_names();
-        let mut count = 0;
-        for s in sheets {
-            let mut cells_reader = excel.worksheet_cells_reader(&s).unwrap();
-            while cells_reader.next_cell().unwrap().is_some() {
-                count += 1;
-            }
+    let sheets = excel.sheet_names();
+    let mut count = 0;
+    for s in sheets {
+        let mut cells_reader = excel.worksheet_cells_reader(&s).unwrap();
+        while cells_reader.next_cell().unwrap().is_some() {
+            count += 1;
         }
-        count
     }
-    b.iter(|| count::<Xlsx<_>>("tests/issues.xlsb"));
+    count
 }
+
+fn bench_xls(c: &mut Criterion) {
+    c.bench_function("xls", |b| b.iter(|| count::<Xls<_>>("tests/issues.xls")));
+}
+
+fn bench_xlsx(c: &mut Criterion) {
+    c.bench_function("xlsx", |b| b.iter(|| count::<Xlsx<_>>("tests/issues.xlsx")));
+}
+
+fn bench_xlsb(c: &mut Criterion) {
+    c.bench_function("xlsb", |b| b.iter(|| count::<Xlsb<_>>("tests/issues.xlsb")));
+}
+
+fn bench_ods(c: &mut Criterion) {
+    c.bench_function("ods", |b| b.iter(|| count::<Ods<_>>("tests/issues.ods")));
+}
+
+fn bench_xlsx_cells_reader(c: &mut Criterion) {
+    c.bench_function("xlsx_cells_reader", |b| {
+        b.iter(|| count_cells_reader_xlsx("tests/issues.xlsx"))
+    });
+}
+
+fn bench_xlsb_cells_reader(c: &mut Criterion) {
+    c.bench_function("xlsb_cells_reader", |b| {
+        b.iter(|| count_cells_reader_xlsb("tests/issues.xlsb"))
+    });
+}
+
+criterion_group!(
+    benches,
+    bench_xls,
+    bench_xlsx,
+    bench_xlsb,
+    bench_ods,
+    bench_xlsx_cells_reader,
+    bench_xlsb_cells_reader
+);
+criterion_main!(benches);


### PR DESCRIPTION
Change to using the `criterion.rs` crate for `bench` benchmark testing. This avoids the need for `+nightly` to run the benchmarks.

As a side effect it is now possible to run `cargo clippy --all-targets` without `+nightly`.

`criterion.rs` is added as a `dev-dependency`.