### PR TITLE
perf: custom zero-overhead attribute extraction

### DIFF
--- a/src/attrs.rs
+++ b/src/attrs.rs
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright 2016-2025, Johann Tuffe.
+
+//! Zero-allocation XML attribute extraction utilities.
+//!
+//! These replace quick_xml's own `Attributes` iterator,
+//! avoiding per-item overhead from `Result` wrapping,
+//! `Cow`/`QName` newtypes, quote-type tracking, etc.
+
+use quick_xml::escape::unescape;
+use quick_xml::events::BytesStart;
+use quick_xml::Decoder;
+
+/// Zero-allocation iterator over raw XML attribute
+/// bytes, yielding `(key, value)` byte-slice pairs.
+pub(crate) struct RawAttrIter<'a> {
+    raw: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> RawAttrIter<'a> {
+    #[inline]
+    fn new(raw: &'a [u8]) -> Self {
+        Self { raw, pos: 0 }
+    }
+}
+
+impl<'a> Iterator for RawAttrIter<'a> {
+    type Item = (&'a [u8], &'a [u8]);
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        let raw = self.raw;
+        let len = raw.len();
+
+        // skip whitespace
+        while self.pos < len && raw[self.pos].is_ascii_whitespace() {
+            self.pos += 1;
+        }
+        if self.pos >= len {
+            return None;
+        }
+
+        // key
+        let key_start = self.pos;
+        while self.pos < len && raw[self.pos] != b'=' {
+            self.pos += 1;
+        }
+        if self.pos >= len {
+            return None;
+        }
+        let key = &raw[key_start..self.pos];
+        self.pos += 1; // skip '='
+        if self.pos >= len {
+            return None;
+        }
+
+        // quoted value
+        let quote = raw[self.pos];
+        if quote != b'"' && quote != b'\'' {
+            return None;
+        }
+        self.pos += 1; // skip opening quote
+        let val_start = self.pos;
+        while self.pos < len && raw[self.pos] != quote {
+            self.pos += 1;
+        }
+        let val = &raw[val_start..self.pos];
+        if self.pos < len {
+            self.pos += 1; // skip closing quote
+        }
+        Some((key, val))
+    }
+}
+
+/// Extension trait for fast/raw attribute access on XML elements.
+pub(crate) trait RawAttributes {
+    /// Iterate over all attributes as `(key, value)` byte-slice pairs.
+    fn iter_raw_attrs(&self) -> RawAttrIter<'_>;
+
+    /// Get a single attribute by name.
+    #[inline]
+    fn raw_attr(&self, name: &[u8]) -> Option<&[u8]> {
+        self.iter_raw_attrs()
+            .find_map(|(k, v)| (k == name).then_some(v))
+    }
+}
+
+impl RawAttributes for BytesStart<'_> {
+    #[inline]
+    fn iter_raw_attrs(&self) -> RawAttrIter<'_> {
+        RawAttrIter::new(self.attributes_raw())
+    }
+}
+
+/// Get a set of named attributes from an element in a single
+/// pass, with early exit as soon as all items are found.
+macro_rules! get_attrs {
+    ($e:expr, $($key:expr => $var:ident),+ $(,)?) => {{
+        $(let mut $var = None;)+
+        let mut found = 0u8;
+        let total = get_attrs!(@count $($key),+);
+        for (k, v) in $e.iter_raw_attrs() {
+            match k {
+                $($key => { $var = Some(v); found += 1; })+
+                _ => {}
+            }
+            if found == total {
+                break;
+            }
+        }
+        ($($var),+)
+    }};
+    (@count $first:expr $(, $rest:expr)*) => {
+        1u8 $(+ get_attrs!(@count_one $rest))*
+    };
+    (@count_one $e:expr) => { 1u8 };
+}
+
+/// Decode raw attribute bytes into a `String`, with XML entity unescaping.
+/// Only needed for values that can contain entities (eg: sheet names, table names, etc).
+pub(crate) fn decode_attr(decoder: &Decoder, val: &[u8]) -> Result<String, quick_xml::Error> {
+    let decoded = decoder.decode(val)?;
+    let unescaped = unescape(&decoded).map_err(quick_xml::Error::from)?;
+    Ok(unescaped.into_owned())
+}

--- a/src/attrs.rs
+++ b/src/attrs.rs
@@ -1,0 +1,322 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright 2016-2025, Johann Tuffe.
+
+//! Zero-allocation XML attribute extraction utilities.
+//!
+//! These replace quick_xml's own `Attributes` iterator, avoiding its per-item
+//! `Cow`/`QName` newtypes, quote-type tracking, namespace bookkeeping, entity
+//! decoding, and UTF8 validation. We can do this as we have a constrained
+//! set of keys that we access internally (all of them are simple ASCII).
+//!
+//! Like quick_xml, malformed attributes are reported as [`AttrError`] items rather
+//! than being skipped; a key with no `=` yields [`AttrError::ExpectedEq`] and an
+//! unquoted values yield [`AttrError::UnquotedValue`]. (Unclosed quotes never
+//! reach here as quick_xml's tokenizer rejects them at `read_event` time).
+
+use quick_xml::escape::unescape;
+use quick_xml::events::attributes::AttrError;
+use quick_xml::events::BytesStart;
+use quick_xml::Decoder;
+
+/// Zero-allocation iterator over raw XML attribute bytes, yielding
+/// `(key, value)` byte-slice pairs or an [`AttrError`] for malformed input.
+pub(crate) struct RawAttrIter<'a> {
+    raw: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> RawAttrIter<'a> {
+    #[inline]
+    fn new(raw: &'a [u8]) -> Self {
+        Self { raw, pos: 0 }
+    }
+}
+
+impl<'a> Iterator for RawAttrIter<'a> {
+    type Item = Result<(&'a [u8], &'a [u8]), AttrError>;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        let raw = self.raw;
+        let len = raw.len();
+
+        // note: make "pos" local to ensure the compiler keeps it in
+        // a register across the scan loops (struct field otherwise)
+        let mut pos = self.pos;
+
+        // skip whitespace before the key
+        while pos < len && raw[pos].is_ascii_whitespace() {
+            pos += 1;
+        }
+        if pos >= len {
+            self.pos = pos;
+            return None;
+        }
+
+        // key: scan to '=' with a single comparison
+        // per byte (handling whitespace around '=')
+        let key_start = pos;
+        while pos < len && raw[pos] != b'=' {
+            pos += 1;
+        }
+        if pos >= len {
+            // a key with no '=' is malformed; park the cursor at the end so the
+            // next call returns None rather than re-reporting the same error
+            self.pos = len;
+            return Some(Err(AttrError::ExpectedEq(key_start)));
+        }
+        let key = raw[key_start..pos].trim_ascii_end();
+        pos += 1; // skip '='
+
+        // skip whitespace after '=' (normally none: loop exits immediately)
+        while pos < len && raw[pos].is_ascii_whitespace() {
+            pos += 1;
+        }
+
+        // quoted value (XML mandates quotes; anything else, including a missing
+        // value at end-of-input, is malformed)
+        let quote = raw.get(pos).copied();
+        if quote != Some(b'"') && quote != Some(b'\'') {
+            self.pos = len;
+            return Some(Err(AttrError::UnquotedValue(pos)));
+        }
+        let quote = quote.unwrap();
+        pos += 1; // skip opening quote
+        let val_start = pos;
+        while pos < len && raw[pos] != quote {
+            pos += 1;
+        }
+        let val = &raw[val_start..pos];
+        if pos < len {
+            pos += 1; // skip closing quote
+        }
+        self.pos = pos;
+        Some(Ok((key, val)))
+    }
+}
+
+/// Extension trait for fast/raw attribute access on XML elements.
+pub(crate) trait RawAttributes {
+    /// Iterate over attributes, yielding `(key, value)` byte-slice
+    /// pairs (or an [`AttrError`] for malformed input).
+    fn iter_raw_attrs(&self) -> RawAttrIter<'_>;
+
+    /// Get a single attribute by name, returning `Ok(None)` if absent and
+    /// an `Err` if a malformed attribute is encountered while scanning.
+    #[inline]
+    fn raw_attr(&self, name: &[u8]) -> Result<Option<&[u8]>, AttrError> {
+        for item in self.iter_raw_attrs() {
+            let (k, v) = item?;
+            if k == name {
+                return Ok(Some(v));
+            }
+        }
+        Ok(None)
+    }
+}
+
+impl RawAttributes for BytesStart<'_> {
+    #[inline]
+    fn iter_raw_attrs(&self) -> RawAttrIter<'_> {
+        RawAttrIter::new(self.attributes_raw())
+    }
+}
+
+/// Get a set of named attributes from an element in a single
+/// pass, with early exit as soon as all items are found.
+macro_rules! get_attrs {
+    ($e:expr, $($key:expr => $var:ident),+ $(,)?) => {{
+        $(let mut $var = None;)+
+        let mut found = 0u8;
+        let total = get_attrs!(@count $($key),+);
+        let mut result = Ok(());
+        for item in $e.iter_raw_attrs() {
+            match item {
+                Ok((k, v)) => {
+                    match k {
+                        $($key => { $var = Some(v); found += 1; })+
+                        _ => {}
+                    }
+                    if found == total {
+                        break;
+                    }
+                }
+                Err(e) => {
+                    result = Err(e);
+                    break;
+                }
+            }
+        }
+        result.map(|()| ($($var),+))
+    }};
+    (@count $first:expr $(, $rest:expr)*) => {
+        1u8 $(+ get_attrs!(@count_one $rest))*
+    };
+    (@count_one $e:expr) => { 1u8 };
+}
+
+/// Decode raw attribute bytes into a `String`, with XML entity unescaping.
+/// Only needed for values that can contain entities (eg: sheet names, table names, etc).
+pub(crate) fn decode_attr(decoder: &Decoder, val: &[u8]) -> Result<String, quick_xml::Error> {
+    let decoded = decoder.decode(val)?;
+    let unescaped = unescape(&decoded).map_err(quick_xml::Error::from)?;
+    Ok(unescaped.into_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Collect well-formed attributes, panicking on any malformed item.
+    fn collect(raw: &[u8]) -> Vec<(&[u8], &[u8])> {
+        RawAttrIter::new(raw)
+            .map(|r| r.expect("unexpected malformed attribute"))
+            .collect()
+    }
+
+    #[test]
+    fn test_basic_attrs() {
+        let bytes = b"key1=\"val1\" key2='val2'";
+        let mut iter = RawAttrIter::new(bytes);
+        assert_eq!(iter.next(), Some(Ok((&b"key1"[..], &b"val1"[..]))));
+        assert_eq!(iter.next(), Some(Ok((&b"key2"[..], &b"val2"[..]))));
+        assert_eq!(iter.next(), None);
+    }
+
+    #[test]
+    fn test_whitespace_around_equals() {
+        let bytes = b"key = \"value\"";
+        let mut iter = RawAttrIter::new(bytes);
+        assert_eq!(iter.next(), Some(Ok((&b"key"[..], &b"value"[..]))));
+        assert_eq!(iter.next(), None);
+    }
+
+    #[test]
+    fn test_empty_value() {
+        let bytes = b"key=\"\"";
+        let mut iter = RawAttrIter::new(bytes);
+        assert_eq!(iter.next(), Some(Ok((&b"key"[..], &b""[..]))));
+        assert_eq!(iter.next(), None);
+    }
+
+    #[test]
+    fn test_no_trailing_space() {
+        let bytes = b"key=\"value\"";
+        let mut iter = RawAttrIter::new(bytes);
+        assert_eq!(iter.next(), Some(Ok((&b"key"[..], &b"value"[..]))));
+        assert_eq!(iter.next(), None);
+    }
+
+    #[test]
+    fn test_no_attributes() {
+        assert_eq!(collect(b""), vec![]);
+        assert_eq!(collect(b"   "), vec![]);
+    }
+
+    #[test]
+    fn test_leading_and_trailing_whitespace() {
+        // `attributes_raw()` yields a leading space; a self-closing tag can
+        // leave a trailing one (e.g. `<c r="A1" />` -> ` r="A1" `).
+        assert_eq!(collect(b" r=\"A1\" "), vec![(&b"r"[..], &b"A1"[..])]);
+    }
+
+    #[test]
+    fn test_mixed_whitespace_and_quotes() {
+        // Whitespace around `=` combined with both quote styles, as a real
+        // (if unusual) tag like `<row r = "50" spans = '1:4'>` would produce.
+        let bytes = b" r = \"50\" spans = '1:4'";
+        assert_eq!(
+            collect(bytes),
+            vec![(&b"r"[..], &b"50"[..]), (&b"spans"[..], &b"1:4"[..])]
+        );
+    }
+
+    #[test]
+    fn test_value_containing_other_quote() {
+        // A single-quoted value may contain double quotes and vice versa.
+        assert_eq!(collect(b"k='a\"b'"), vec![(&b"k"[..], &b"a\"b"[..])]);
+        assert_eq!(collect(b"k=\"a'b\""), vec![(&b"k"[..], &b"a'b"[..])]);
+    }
+
+    #[test]
+    fn test_namespaced_attributes() {
+        // Namespace declarations and prefixed names are yielded verbatim with
+        // their prefix; call sites match the full raw key (see issue #632).
+        let bytes = b" xmlns:foo=\"bar\" foo:id=\"x\" r:id=\"rId1\"";
+        assert_eq!(
+            collect(bytes),
+            vec![
+                (&b"xmlns:foo"[..], &b"bar"[..]),
+                (&b"foo:id"[..], &b"x"[..]),
+                (&b"r:id"[..], &b"rId1"[..]),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_malformed_unquoted_value_reports_error() {
+        // Unquoted values are malformed: yield the valid attr,
+        // then the UnquotedValue error, then stop.
+        let mut iter = RawAttrIter::new(b"good=\"1\" bad=2");
+        assert_eq!(iter.next(), Some(Ok((&b"good"[..], &b"1"[..]))));
+        assert!(matches!(
+            iter.next(),
+            Some(Err(AttrError::UnquotedValue(_)))
+        ));
+        assert_eq!(iter.next(), None);
+    }
+
+    #[test]
+    fn test_no_equals_reports_error() {
+        // A bare name with no '=' is reported as ExpectedEq, then iteration ends.
+        let mut iter = RawAttrIter::new(b"disabled");
+        assert!(matches!(iter.next(), Some(Err(AttrError::ExpectedEq(_)))));
+        assert_eq!(iter.next(), None);
+
+        // Leading whitespace then a bare name behaves the same.
+        let mut iter = RawAttrIter::new(b"  spans  ");
+        assert!(matches!(iter.next(), Some(Err(AttrError::ExpectedEq(_)))));
+        assert_eq!(iter.next(), None);
+    }
+
+    #[test]
+    fn test_tabs_and_newlines_as_separators() {
+        // Attributes may be split by tabs/newlines, not just spaces.
+        assert_eq!(
+            collect(b"\tr=\"A1\"\n\ts=\"3\""),
+            vec![(&b"r"[..], &b"A1"[..]), (&b"s"[..], &b"3"[..])]
+        );
+    }
+
+    #[test]
+    fn test_raw_attr_lookup() {
+        use quick_xml::events::Event;
+        use quick_xml::Reader;
+
+        let mut reader = Reader::from_str(r#"<c r="A1" s="3" t="s"/>"#);
+        let Event::Empty(e) = reader.read_event().unwrap() else {
+            panic!("expected empty element");
+        };
+        assert_eq!(e.raw_attr(b"r"), Ok(Some(&b"A1"[..])));
+        assert_eq!(e.raw_attr(b"s"), Ok(Some(&b"3"[..])));
+        assert_eq!(e.raw_attr(b"t"), Ok(Some(&b"s"[..])));
+        assert_eq!(e.raw_attr(b"missing"), Ok(None));
+    }
+
+    #[test]
+    fn test_get_attrs_macro() {
+        use quick_xml::events::Event;
+        use quick_xml::Reader;
+
+        // Test with/without whitespace around `=`
+        let mut reader = Reader::from_str(r#"<c r = "A1" t="s"/>"#);
+        let Event::Empty(e) = reader.read_event().unwrap() else {
+            panic!("expected empty element");
+        };
+        let (r, s, t) = get_attrs!(e, b"r" => r, b"s" => s, b"t" => t).unwrap();
+        assert_eq!(r, Some(&b"A1"[..]));
+        assert_eq!(s, None);
+        assert_eq!(t, Some(&b"s"[..]));
+    }
+}

--- a/src/attrs.rs
+++ b/src/attrs.rs
@@ -96,19 +96,44 @@ impl<'a> Iterator for RawAttrIter<'a> {
     }
 }
 
+/// Compare an attribute key against a local name, ignoring any namespace
+/// prefix, eg: both `id` and `r:id` would match a `local_name` of `b"id"`.
+#[inline]
+pub(crate) fn local_name_matches(key: &[u8], local_name: &[u8]) -> bool {
+    // exact match, or `<prefix>:<local>`
+    key == local_name
+        || key
+            .strip_suffix(local_name) // compare on subslice to avoid allocation
+            .is_some_and(|prefix| prefix.last() == Some(&b':'))
+}
+
 /// Extension trait for fast/raw attribute access on XML elements.
 pub(crate) trait RawAttributes {
     /// Iterate over attributes, yielding `(key, value)` byte-slice
     /// pairs (or an [`AttrError`] for malformed input).
     fn iter_raw_attrs(&self) -> RawAttrIter<'_>;
 
-    /// Get a single attribute by name, returning `Ok(None)` if absent and
+    /// Get a single attribute by exact key, returning `Ok(None)` if absent and
     /// an `Err` if a malformed attribute is encountered while scanning.
     #[inline]
     fn raw_attr(&self, name: &[u8]) -> Result<Option<&[u8]>, AttrError> {
         for item in self.iter_raw_attrs() {
             let (k, v) = item?;
             if k == name {
+                return Ok(Some(v));
+            }
+        }
+        Ok(None)
+    }
+
+    /// Like `raw_attr`, but matches on the attribute's *local* name, ignoring
+    /// any namespace prefix (so both `id` and `r:id` would match `b"id"`).
+    #[allow(dead_code)] // note: currently only reached from `picture`-gated code
+    #[inline] // but the function is general-purpose and will be useful elsewhere
+    fn raw_attr_local(&self, local_name: &[u8]) -> Result<Option<&[u8]>, AttrError> {
+        for item in self.iter_raw_attrs() {
+            let (k, v) = item?;
+            if local_name_matches(k, local_name) {
                 return Ok(Some(v));
             }
         }
@@ -302,6 +327,35 @@ mod tests {
         assert_eq!(e.raw_attr(b"s"), Ok(Some(&b"3"[..])));
         assert_eq!(e.raw_attr(b"t"), Ok(Some(&b"s"[..])));
         assert_eq!(e.raw_attr(b"missing"), Ok(None));
+    }
+
+    #[test]
+    fn test_local_name_matches() {
+        // match
+        assert!(local_name_matches(b"id", b"id"));
+        assert!(local_name_matches(b"r:id", b"id"));
+        assert!(local_name_matches(b"x:embed", b"embed"));
+        assert!(local_name_matches(b":id", b"id"));
+
+        // don't match
+        assert!(!local_name_matches(b"xmlid", b"id"));
+        assert!(!local_name_matches(b"rid", b"id"));
+        assert!(!local_name_matches(b"name", b"id"));
+    }
+
+    #[test]
+    fn test_raw_attr_local_lookup() {
+        use quick_xml::events::Event;
+        use quick_xml::Reader;
+
+        let mut reader = Reader::from_str(r#"<blip cstate="print" r:embed="rId1"/>"#);
+        let Event::Empty(e) = reader.read_event().unwrap() else {
+            panic!("expected empty element");
+        };
+        // namespaced key matched on local name, exact key still works
+        assert_eq!(e.raw_attr_local(b"embed"), Ok(Some(&b"rId1"[..])));
+        assert_eq!(e.raw_attr_local(b"cstate"), Ok(Some(&b"print"[..])));
+        assert_eq!(e.raw_attr_local(b"missing"), Ok(None));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,6 +79,8 @@
 #[macro_use]
 mod utils;
 
+#[macro_use]
+mod attrs;
 mod auto;
 mod cfb;
 mod datatype;

--- a/src/ods.rs
+++ b/src/ods.rs
@@ -14,13 +14,13 @@ use std::collections::{BTreeMap, HashMap};
 use std::io::{BufReader, Read, Seek};
 
 use log::warn;
-use quick_xml::events::attributes::Attributes;
-use quick_xml::events::Event;
+use quick_xml::events::{BytesStart, Event};
 use quick_xml::name::QName;
 use quick_xml::Reader as XmlReader;
 use zip::read::{ZipArchive, ZipFile};
 use zip::result::ZipError;
 
+use crate::attrs::{decode_attr, RawAttributes};
 use crate::utils::unescape_entity_to_buffer;
 use crate::vba::VbaProject;
 use crate::{Data, DataType, HeaderRow, Metadata, Range, Reader, Sheet, SheetType, SheetVisible};
@@ -350,17 +350,16 @@ fn parse_content<RS: Read + Seek>(mut zip: ZipArchive<RS>) -> Result<Content, Od
         match reader.read_event_into(&mut buf) {
             Ok(Event::Start(e)) if e.name() == QName(b"style:style") => {
                 style_name = e
-                    .try_get_attribute(b"style:name")?
-                    .map(|a| a.decode_and_unescape_value(reader.decoder()))
-                    .transpose()?
-                    .map(|x| x.to_string());
+                    .raw_attr(b"style:name")?
+                    .map(|v| decode_attr(&reader.decoder(), v))
+                    .transpose()?;
             }
             Ok(Event::Start(e))
                 if style_name.is_some() && e.name() == QName(b"style:table-properties") =>
             {
-                let visible = match e.try_get_attribute(b"table:display")? {
-                    Some(a) => {
-                        if a.decode_and_unescape_value(reader.decoder())?.parse()? {
+                let visible = match e.raw_attr(b"table:display")? {
+                    Some(v) => {
+                        if decode_attr(&reader.decoder(), v)?.parse()? {
                             SheetVisible::Visible
                         } else {
                             SheetVisible::Hidden
@@ -373,19 +372,14 @@ fn parse_content<RS: Read + Seek>(mut zip: ZipArchive<RS>) -> Result<Content, Od
             Ok(Event::Start(e)) if e.name() == QName(b"table:table") => {
                 let visible = styles
                     .get(
-                        &e.try_get_attribute(b"table:style-name")?
-                            .map(|a| a.decode_and_unescape_value(reader.decoder()))
-                            .transpose()?
-                            .map(|x| x.to_string()),
+                        &e.raw_attr(b"table:style-name")?
+                            .map(|v| decode_attr(&reader.decoder(), v))
+                            .transpose()?,
                     )
                     .cloned()
                     .unwrap_or(SheetVisible::Visible);
-                if let Some(a) = e
-                    .attributes()
-                    .filter_map(|a| a.ok())
-                    .find(|a| a.key == QName(b"table:name"))
-                {
-                    let name = a.decode_and_unescape_value(reader.decoder())?.to_string();
+                if let Some(v) = e.raw_attr(b"table:name")? {
+                    let name = decode_attr(&reader.decoder(), v)?;
                     let (range, formulas) = read_table(&mut reader)?;
                     sheets_metadata.push(Sheet {
                         name: name.clone(),
@@ -427,8 +421,8 @@ where
     loop {
         match reader.read_event_into(&mut buf) {
             Ok(Event::Start(e)) if e.name() == QName(b"table:table-row") => {
-                let row_repeats = match e.try_get_attribute(b"table:number-rows-repeated")? {
-                    Some(c) => c.decode_and_unescape_value(reader.decoder())?.parse()?,
+                let row_repeats = match e.raw_attr(b"table:number-rows-repeated")? {
+                    Some(v) => decode_attr(&reader.decoder(), v)?.parse()?,
                     None => 1,
                 };
 
@@ -602,16 +596,12 @@ where
                 if e.name() == QName(b"table:table-cell")
                     || e.name() == QName(b"table:covered-table-cell") =>
             {
-                let mut repeats = 1;
-                for a in e.attributes() {
-                    let a = a?;
-                    if a.key == QName(b"table:number-columns-repeated") {
-                        repeats = reader.decoder().decode(&a.value)?.parse()?;
-                        break;
-                    }
-                }
+                let repeats = match e.raw_attr(b"table:number-columns-repeated")? {
+                    Some(v) => reader.decoder().decode(v)?.parse()?,
+                    None => 1,
+                };
 
-                let (value, formula, is_closed) = get_datatype(reader, e.attributes(), cell_buf)?;
+                let (value, formula, is_closed) = get_datatype(reader, &e, cell_buf)?;
 
                 // Cap empty_col_repeats to not exceed MAX_COLUMNS
                 let current_cols = cells.len() - row_start;
@@ -669,7 +659,7 @@ where
 /// ODF 1.2-19.385
 fn get_datatype<RS>(
     reader: &mut OdsReader<'_, RS>,
-    atts: Attributes<'_>,
+    e: &BytesStart<'_>,
     buf: &mut Vec<u8>,
 ) -> Result<(Data, String, bool), OdsError>
 where
@@ -679,36 +669,36 @@ where
     let mut is_value_set = false;
     let mut val = Data::Empty;
     let mut formula = String::new();
-    for a in atts {
-        let a = a?;
-        match a.key {
-            QName(b"office:value") if !is_value_set => {
-                let v = reader.decoder().decode(&a.value)?;
+    for attr in e.iter_raw_attrs() {
+        let (key, value) = attr?;
+        match key {
+            b"office:value" if !is_value_set => {
+                let v = reader.decoder().decode(value)?;
                 val = Data::Float(
                     fast_float2::parse(v.as_bytes())
                         .map_err(|_| OdsError::ParseFloat(v.parse::<f64>().unwrap_err()))?,
                 );
                 is_value_set = true;
             }
-            QName(b"office:string-value" | b"office:date-value" | b"office:time-value")
+            b"office:string-value" | b"office:date-value" | b"office:time-value"
                 if !is_value_set =>
             {
-                let attr = a.decode_and_unescape_value(reader.decoder())?.to_string();
-                val = match a.key {
-                    QName(b"office:date-value") => Data::DateTimeIso(attr),
-                    QName(b"office:time-value") => Data::DurationIso(attr),
+                let attr = decode_attr(&reader.decoder(), value)?;
+                val = match key {
+                    b"office:date-value" => Data::DateTimeIso(attr),
+                    b"office:time-value" => Data::DurationIso(attr),
                     _ => Data::String(attr),
                 };
                 is_value_set = true;
             }
-            QName(b"office:boolean-value") if !is_value_set => {
-                let b = &*a.value == b"TRUE" || &*a.value == b"true";
+            b"office:boolean-value" if !is_value_set => {
+                let b = value == b"TRUE" || value == b"true";
                 val = Data::Bool(b);
                 is_value_set = true;
             }
-            QName(b"office:value-type") if !is_value_set => is_string = &*a.value == b"string",
-            QName(b"table:formula") => {
-                formula = a.decode_and_unescape_value(reader.decoder())?.to_string();
+            b"office:value-type" if !is_value_set => is_string = value == b"string",
+            b"table:formula" => {
+                formula = decode_attr(&reader.decoder(), value)?;
             }
             _ => (),
         }
@@ -750,8 +740,8 @@ where
                     }
                 }
                 Ok(Event::Start(e)) if e.name() == QName(b"text:s") => {
-                    let count = match e.try_get_attribute("text:c")? {
-                        Some(c) => c.decode_and_unescape_value(reader.decoder())?.parse()?,
+                    let count = match e.raw_attr(b"text:c")? {
+                        Some(v) => decode_attr(&reader.decoder(), v)?.parse()?,
                         None => 1,
                     };
                     for _ in 0..count {
@@ -785,14 +775,14 @@ where
             {
                 let mut name = String::new();
                 let mut formula = String::new();
-                for a in e.attributes() {
-                    let a = a?;
-                    match a.key {
-                        QName(b"table:name") => {
-                            name = a.decode_and_unescape_value(reader.decoder())?.to_string();
+                for attr in e.iter_raw_attrs() {
+                    let (key, value) = attr?;
+                    match key {
+                        b"table:name" => {
+                            name = decode_attr(&reader.decoder(), value)?;
                         }
-                        QName(b"table:cell-range-address" | b"table:expression") => {
-                            formula = a.decode_and_unescape_value(reader.decoder())?.to_string();
+                        b"table:cell-range-address" | b"table:expression" => {
+                            formula = decode_attr(&reader.decoder(), value)?;
                         }
                         _ => (),
                     }

--- a/src/xlsb/mod.rs
+++ b/src/xlsb/mod.rs
@@ -13,13 +13,13 @@ use std::io::{BufReader, Read, Seek};
 use log::debug;
 
 use encoding_rs::UTF_16LE;
-use quick_xml::events::attributes::Attribute;
 use quick_xml::events::Event;
 use quick_xml::name::QName;
 use quick_xml::Reader as XmlReader;
 use zip::read::{ZipArchive, ZipFile};
 use zip::result::ZipError;
 
+use crate::attrs::{decode_attr, RawAttributes};
 use crate::datatype::DataRef;
 use crate::formats::{builtin_format_by_code, detect_custom_number_format, CellFormat};
 use crate::utils::{
@@ -183,32 +183,10 @@ impl<RS: Read + Seek> Xlsb<RS> {
                 loop {
                     match xml.read_event_into(&mut buf) {
                         Ok(Event::Start(e)) if e.name() == QName(b"Relationship") => {
-                            let mut id = None;
-                            let mut target = None;
-                            for a in e.attributes() {
-                                match a? {
-                                    Attribute {
-                                        key: QName(b"Id"),
-                                        value: v,
-                                    } => {
-                                        id = Some(v.to_vec());
-                                    }
-                                    Attribute {
-                                        key: QName(b"Target"),
-                                        value: v,
-                                    } => {
-                                        target = Some(
-                                            xml.decoder()
-                                                .decode(&v)
-                                                .map_err(XlsbError::Encoding)?
-                                                .into_owned(),
-                                        );
-                                    }
-                                    _ => (),
-                                }
-                            }
+                            let (id, target) = get_attrs!(e, b"Id" => id, b"Target" => target);
                             if let (Some(id), Some(target)) = (id, target) {
-                                relationships.insert(id, target);
+                                relationships
+                                    .insert(id.to_vec(), decode_attr(&xml.decoder(), target)?);
                             }
                         }
                         Ok(Event::Eof) => break,

--- a/src/xlsb/mod.rs
+++ b/src/xlsb/mod.rs
@@ -13,13 +13,13 @@ use std::io::{BufReader, Read, Seek};
 use log::debug;
 
 use encoding_rs::UTF_16LE;
-use quick_xml::events::attributes::Attribute;
 use quick_xml::events::Event;
 use quick_xml::name::QName;
 use quick_xml::Reader as XmlReader;
 use zip::read::{ZipArchive, ZipFile};
 use zip::result::ZipError;
 
+use crate::attrs::{decode_attr, RawAttributes};
 use crate::datatype::DataRef;
 use crate::formats::{builtin_format_by_code, detect_custom_number_format, CellFormat};
 use crate::utils::{
@@ -183,32 +183,10 @@ impl<RS: Read + Seek> Xlsb<RS> {
                 loop {
                     match xml.read_event_into(&mut buf) {
                         Ok(Event::Start(e)) if e.name() == QName(b"Relationship") => {
-                            let mut id = None;
-                            let mut target = None;
-                            for a in e.attributes() {
-                                match a? {
-                                    Attribute {
-                                        key: QName(b"Id"),
-                                        value: v,
-                                    } => {
-                                        id = Some(v.to_vec());
-                                    }
-                                    Attribute {
-                                        key: QName(b"Target"),
-                                        value: v,
-                                    } => {
-                                        target = Some(
-                                            xml.decoder()
-                                                .decode(&v)
-                                                .map_err(XlsbError::Encoding)?
-                                                .into_owned(),
-                                        );
-                                    }
-                                    _ => (),
-                                }
-                            }
+                            let (id, target) = get_attrs!(e, b"Id" => id, b"Target" => target)?;
                             if let (Some(id), Some(target)) = (id, target) {
-                                relationships.insert(id, target);
+                                relationships
+                                    .insert(id.to_vec(), decode_attr(&xml.decoder(), target)?);
                             }
                         }
                         Ok(Event::Eof) => break,

--- a/src/xlsx/cells_reader.rs
+++ b/src/xlsx/cells_reader.rs
@@ -2,20 +2,18 @@
 //
 // Copyright 2016-2025, Johann Tuffe.
 
-use quick_xml::{
-    events::{attributes::Attribute, BytesStart, Event},
-    name::QName,
-};
+use quick_xml::events::{BytesStart, Event};
 use std::{
-    borrow::{Borrow, Cow},
+    borrow::Borrow,
     collections::HashMap,
     io::{Read, Seek},
 };
 
 use super::{
-    get_attribute, get_dimension, get_row, get_row_column, read_string_with_bufs,
-    replace_cell_names, Dimensions, XlReader,
+    get_dimension, get_row, get_row_column, read_string_with_bufs, replace_cell_names, Dimensions,
+    XlReader,
 };
+use crate::attrs::RawAttributes;
 use crate::{
     datatype::DataRef,
     formats::{format_excel_f64_ref, CellFormat},
@@ -85,15 +83,9 @@ where
             match xml.read_event_into(&mut buf).map_err(XlsxError::Xml)? {
                 Event::Start(e) => match e.local_name().as_ref() {
                     b"dimension" => {
-                        for a in e.attributes() {
-                            if let Attribute {
-                                key: QName(b"ref"),
-                                value: rdim,
-                            } = a?
-                            {
-                                dimensions = get_dimension(&rdim)?;
-                                continue 'xml;
-                            }
+                        if let Some(rdim) = e.raw_attr(b"ref") {
+                            dimensions = get_dimension(rdim)?;
+                            continue 'xml;
                         }
                         return Err(XlsxError::UnexpectedNode("dimension"));
                     }
@@ -138,10 +130,8 @@ where
             self.buf.clear();
             match self.xml.read_event_into(&mut self.buf) {
                 Ok(Event::Start(row_element)) if row_element.local_name().as_ref() == b"row" => {
-                    let attribute = get_attribute(row_element.attributes(), QName(b"r"))?;
-                    if let Some(range) = attribute {
-                        let row = get_row(range)?;
-                        self.row_index = row;
+                    if let Some(r) = row_element.raw_attr(b"r") {
+                        self.row_index = get_row(r)?;
                     }
                 }
                 Ok(Event::End(row_element)) if row_element.local_name().as_ref() == b"row" => {
@@ -149,23 +139,8 @@ where
                     self.col_index = 0;
                 }
                 Ok(Event::Start(c_element)) if c_element.local_name().as_ref() == b"c" => {
-                    // Extract all needed attributes in one pass (avoids calling
-                    // `get_attribute` multiple times as each re-iterates).
-                    let mut pos_attr = None;
-                    let mut style_attr = None;
-                    let mut type_attr = None;
-                    for a in c_element.attributes() {
-                        let a = a.map_err(XlsxError::XmlAttr)?;
-                        let Cow::Borrowed(val) = a.value else {
-                            continue;
-                        };
-                        match a.key {
-                            QName(b"r") => pos_attr = Some(val),
-                            QName(b"s") => style_attr = Some(val),
-                            QName(b"t") => type_attr = Some(val),
-                            _ => {}
-                        }
-                    }
+                    let (pos_attr, style_attr, type_attr) =
+                        get_attrs!(c_element, b"r" => r, b"s" => s, b"t" => t);
                     let pos = if let Some(range) = pos_attr {
                         let (row, col) = get_row_column(range)?;
                         self.col_index = col;
@@ -216,10 +191,8 @@ where
             self.buf.clear();
             match self.xml.read_event_into(&mut self.buf) {
                 Ok(Event::Start(row_element)) if row_element.local_name().as_ref() == b"row" => {
-                    let attribute = get_attribute(row_element.attributes(), QName(b"r"))?;
-                    if let Some(range) = attribute {
-                        let row = get_row(range)?;
-                        self.row_index = row;
+                    if let Some(r) = row_element.raw_attr(b"r") {
+                        self.row_index = get_row(r)?;
                     }
                 }
                 Ok(Event::End(row_element)) if row_element.local_name().as_ref() == b"row" => {
@@ -227,9 +200,8 @@ where
                     self.col_index = 0;
                 }
                 Ok(Event::Start(c_element)) if c_element.local_name().as_ref() == b"c" => {
-                    let attribute = get_attribute(c_element.attributes(), QName(b"r"))?;
-                    let pos = if let Some(range) = attribute {
-                        let (row, col) = get_row_column(range)?;
+                    let pos = if let Some(r) = c_element.raw_attr(b"r") {
+                        let (row, col) = get_row_column(r)?;
                         self.col_index = col;
                         (row, col)
                     } else {
@@ -244,31 +216,30 @@ where
                                 if let Some(f) = formula.borrow() {
                                     value = Some(f.clone());
                                 }
-                                if let Ok(Some(b"shared")) =
-                                    get_attribute(e.attributes(), QName(b"t"))
-                                {
+                                let (t_attr, si_attr, ref_attr) =
+                                    get_attrs!(e, b"t" => t, b"si" => si, b"ref" => ref_);
+                                if t_attr == Some(b"shared".as_slice()) {
                                     // shared formula
                                     let mut offset_map: HashMap<(u32, u32), (i64, i64)> =
                                         HashMap::new();
                                     // shared index
-                                    let shared_index =
-                                        match get_attribute(e.attributes(), QName(b"si"))? {
-                                            Some(res) => match atoi_simd::parse::<usize>(res) {
-                                                Ok(res) => res,
-                                                Err(_) => {
-                                                    return Err(XlsxError::Unexpected(
-                                                        "si attribute must be a number",
-                                                    ));
-                                                }
-                                            },
-                                            None => {
+                                    let shared_index = match si_attr {
+                                        Some(res) => match atoi_simd::parse::<usize>(res) {
+                                            Ok(res) => res,
+                                            Err(_) => {
                                                 return Err(XlsxError::Unexpected(
-                                                    "si attribute is mandatory if it is shared",
+                                                    "si attribute must be a number",
                                                 ));
                                             }
-                                        };
+                                        },
+                                        None => {
+                                            return Err(XlsxError::Unexpected(
+                                                "si attribute is mandatory if it is shared",
+                                            ));
+                                        }
+                                    };
                                     // shared reference
-                                    match get_attribute(e.attributes(), QName(b"ref"))? {
+                                    match ref_attr {
                                         Some(res) => {
                                             // original reference formula
                                             let reference = get_dimension(res)?;

--- a/src/xlsx/cells_reader.rs
+++ b/src/xlsx/cells_reader.rs
@@ -2,19 +2,14 @@
 //
 // Copyright 2016-2026, Johann Tuffe.
 
-use quick_xml::{
-    events::{attributes::Attribute, BytesStart, Event},
-    name::QName,
-};
-use std::{
-    borrow::Cow,
-    io::{Read, Seek},
-};
+use quick_xml::events::{BytesStart, Event};
+use std::io::{Read, Seek};
 
 use super::{
-    expand_shared_formula, get_attribute, get_dimension, get_row, get_row_column,
-    read_string_with_bufs, Dimensions, XlReader,
+    expand_shared_formula, get_dimension, get_row, get_row_column, read_string_with_bufs,
+    Dimensions, XlReader,
 };
+use crate::attrs::RawAttributes;
 use crate::{
     datatype::DataRef,
     formats::{format_excel_f64_ref, CellFormat},
@@ -214,15 +209,9 @@ where
             match xml.read_event_into(&mut buf).map_err(XlsxError::Xml)? {
                 Event::Start(e) => match e.local_name().as_ref() {
                     b"dimension" => {
-                        for a in e.attributes() {
-                            if let Attribute {
-                                key: QName(b"ref"),
-                                value: rdim,
-                            } = a?
-                            {
-                                dimensions = get_dimension(&rdim)?;
-                                continue 'xml;
-                            }
+                        if let Some(rdim) = e.raw_attr(b"ref")? {
+                            dimensions = get_dimension(rdim)?;
+                            continue 'xml;
                         }
                         return Err(XlsxError::UnexpectedNode("dimension"));
                     }
@@ -269,10 +258,8 @@ where
             self.buf.clear();
             match self.xml.read_event_into(&mut self.buf) {
                 Ok(Event::Start(row_element)) if row_element.local_name().as_ref() == b"row" => {
-                    let attribute = get_attribute(row_element.attributes(), QName(b"r"))?;
-                    if let Some(range) = attribute {
-                        let row = get_row(range)?;
-                        self.row_index = row;
+                    if let Some(r) = row_element.raw_attr(b"r")? {
+                        self.row_index = get_row(r)?;
                     }
                 }
                 Ok(Event::End(row_element)) if row_element.local_name().as_ref() == b"row" => {
@@ -280,23 +267,8 @@ where
                     self.col_index = 0;
                 }
                 Ok(Event::Start(c_element)) if c_element.local_name().as_ref() == b"c" => {
-                    // Extract all needed attributes in one pass (avoids calling
-                    // `get_attribute` multiple times as each re-iterates).
-                    let mut pos_attr = None;
-                    let mut style_attr = None;
-                    let mut type_attr = None;
-                    for a in c_element.attributes() {
-                        let a = a.map_err(XlsxError::XmlAttr)?;
-                        let Cow::Borrowed(val) = a.value else {
-                            continue;
-                        };
-                        match a.key {
-                            QName(b"r") => pos_attr = Some(val),
-                            QName(b"s") => style_attr = Some(val),
-                            QName(b"t") => type_attr = Some(val),
-                            _ => {}
-                        }
-                    }
+                    let (pos_attr, style_attr, type_attr) =
+                        get_attrs!(c_element, b"r" => r, b"s" => s, b"t" => t)?;
                     let pos = if let Some(range) = pos_attr {
                         let (row, col) = get_row_column(range)?;
                         self.col_index = col;
@@ -351,8 +323,9 @@ where
     ) -> Result<Option<FormulaMetadata>, XlsxError> {
         let formula = read_formula(xml, e)?;
 
-        if let Ok(Some(b"shared")) = get_attribute(e.attributes(), QName(b"t")) {
-            let shared_index = match get_attribute(e.attributes(), QName(b"si"))? {
+        let (t_attr, si_attr, ref_attr) = get_attrs!(e, b"t" => t, b"si" => si, b"ref" => ref_)?;
+        if t_attr == Some(b"shared".as_slice()) {
+            let shared_index = match si_attr {
                 Some(res) => match atoi_simd::parse::<usize>(res) {
                     Ok(res) => res,
                     Err(_) => return Err(XlsxError::Unexpected("si attribute must be a number")),
@@ -364,7 +337,7 @@ where
                 }
             };
 
-            return match get_attribute(e.attributes(), QName(b"ref"))? {
+            return match ref_attr {
                 Some(res) => {
                     let range = get_dimension(res)?;
                     let formula = formula.unwrap_or_default();
@@ -446,10 +419,8 @@ where
             self.buf.clear();
             match self.xml.read_event_into(&mut self.buf) {
                 Ok(Event::Start(row_element)) if row_element.local_name().as_ref() == b"row" => {
-                    let attribute = get_attribute(row_element.attributes(), QName(b"r"))?;
-                    if let Some(range) = attribute {
-                        let row = get_row(range)?;
-                        self.row_index = row;
+                    if let Some(r) = row_element.raw_attr(b"r")? {
+                        self.row_index = get_row(r)?;
                     }
                 }
                 Ok(Event::End(row_element)) if row_element.local_name().as_ref() == b"row" => {
@@ -457,21 +428,8 @@ where
                     self.col_index = 0;
                 }
                 Ok(Event::Start(c_element)) if c_element.local_name().as_ref() == b"c" => {
-                    let mut pos_attr = None;
-                    let mut style_attr = None;
-                    let mut type_attr = None;
-                    for a in c_element.attributes() {
-                        let a = a.map_err(XlsxError::XmlAttr)?;
-                        let Cow::Borrowed(val) = a.value else {
-                            continue;
-                        };
-                        match a.key {
-                            QName(b"r") => pos_attr = Some(val),
-                            QName(b"s") => style_attr = Some(val),
-                            QName(b"t") => type_attr = Some(val),
-                            _ => {}
-                        }
-                    }
+                    let (pos_attr, style_attr, type_attr) =
+                        get_attrs!(c_element, b"r" => r, b"s" => s, b"t" => t)?;
                     let pos = if let Some(range) = pos_attr {
                         let (row, col) = get_row_column(range)?;
                         self.col_index = col;
@@ -537,10 +495,8 @@ where
             self.buf.clear();
             match self.xml.read_event_into(&mut self.buf) {
                 Ok(Event::Start(row_element)) if row_element.local_name().as_ref() == b"row" => {
-                    let attribute = get_attribute(row_element.attributes(), QName(b"r"))?;
-                    if let Some(range) = attribute {
-                        let row = get_row(range)?;
-                        self.row_index = row;
+                    if let Some(r) = row_element.raw_attr(b"r")? {
+                        self.row_index = get_row(r)?;
                     }
                 }
                 Ok(Event::End(row_element)) if row_element.local_name().as_ref() == b"row" => {
@@ -548,9 +504,8 @@ where
                     self.col_index = 0;
                 }
                 Ok(Event::Start(c_element)) if c_element.local_name().as_ref() == b"c" => {
-                    let attribute = get_attribute(c_element.attributes(), QName(b"r"))?;
-                    let pos = if let Some(range) = attribute {
-                        let (row, col) = get_row_column(range)?;
+                    let pos = if let Some(r) = c_element.raw_attr(b"r")? {
+                        let (row, col) = get_row_column(r)?;
                         self.col_index = col;
                         (row, col)
                     } else {

--- a/src/xlsx/mod.rs
+++ b/src/xlsx/mod.rs
@@ -6,22 +6,20 @@
 
 mod cells_reader;
 
-use std::borrow::Cow;
 use std::collections::HashMap;
 use std::io::BufReader;
 use std::io::{Read, Seek};
 use std::str::FromStr;
 
 use log::warn;
-use quick_xml::events::attributes::{AttrError, Attribute, Attributes};
-use quick_xml::events::BytesStart;
-use quick_xml::events::Event;
+use quick_xml::events::{BytesStart, Event};
 use quick_xml::name::QName;
 use quick_xml::Decoder;
 use quick_xml::Reader as XmlReader;
 use zip::read::{ZipArchive, ZipFile};
 use zip::result::ZipError;
 
+use crate::attrs::{decode_attr, RawAttributes};
 use crate::datatype::DataRef;
 use crate::formats::{builtin_format_by_id, detect_custom_number_format, CellFormat};
 use crate::utils::{
@@ -290,7 +288,7 @@ impl<RS: Read + Seek> Xlsx<RS> {
             buf.clear();
             match xml.read_event_into(&mut buf) {
                 Ok(Event::Start(e)) if e.local_name().as_ref() == b"sst" => {
-                    if let Ok(Some(count)) = get_attribute(e.attributes(), QName(b"uniqueCount")) {
+                    if let Some(count) = e.raw_attr(b"uniqueCount") {
                         if let Ok(n) = atoi_simd::parse::<usize>(count) {
                             self.strings.reserve(n);
                         }
@@ -341,23 +339,11 @@ impl<RS: Read + Seek> Xlsx<RS> {
                     inner_buf.clear();
                     match xml.read_event_into(&mut inner_buf) {
                         Ok(Event::Start(e)) if e.local_name().as_ref() == b"numFmt" => {
-                            let mut id = Vec::new();
-                            let mut format = String::new();
-                            for a in e.attributes() {
-                                match a? {
-                                    Attribute {
-                                        key: QName(b"numFmtId"),
-                                        value: v,
-                                    } => id.extend_from_slice(&v),
-                                    Attribute {
-                                        key: QName(b"formatCode"),
-                                        value: v,
-                                    } => format = xml.decoder().decode(&v)?.into_owned(),
-                                    _ => (),
-                                }
-                            }
-                            if !format.is_empty() {
-                                number_formats.insert(id, format);
+                            let (id, format_code) =
+                                get_attrs!(e, b"numFmtId" => id, b"formatCode" => fmt);
+                            if let (Some(id), Some(fc)) = (id, format_code) {
+                                let format = decode_attr(&xml.decoder(), fc)?;
+                                number_formats.insert(id.to_vec(), format);
                             }
                         }
                         Ok(Event::End(e)) if e.local_name().as_ref() == b"numFmts" => break,
@@ -370,17 +356,13 @@ impl<RS: Read + Seek> Xlsx<RS> {
                     inner_buf.clear();
                     match xml.read_event_into(&mut inner_buf) {
                         Ok(Event::Start(e)) if e.local_name().as_ref() == b"xf" => {
-                            self.formats.push(
-                                e.attributes()
-                                    .filter_map(|a| a.ok())
-                                    .find(|a| a.key == QName(b"numFmtId"))
-                                    .map_or(CellFormat::Other, |a| {
-                                        match number_formats.get(&*a.value) {
-                                            Some(fmt) => detect_custom_number_format(fmt),
-                                            None => builtin_format_by_id(&a.value),
-                                        }
-                                    }),
-                            );
+                            self.formats.push(e.raw_attr(b"numFmtId").map_or(
+                                CellFormat::Other,
+                                |val| match number_formats.get(val) {
+                                    Some(fmt) => detect_custom_number_format(fmt),
+                                    None => builtin_format_by_id(val),
+                                },
+                            ));
                         }
                         Ok(Event::End(e)) if e.local_name().as_ref() == b"cellXfs" => break,
                         Ok(Event::Eof) => return Err(XlsxError::XmlEof("cellXfs")),
@@ -412,38 +394,28 @@ impl<RS: Read + Seek> Xlsx<RS> {
                     let mut name = String::new();
                     let mut path = String::new();
                     let mut visible = SheetVisible::Visible;
-                    for a in e.attributes() {
-                        let a = a?;
-                        match a {
-                            Attribute {
-                                key: QName(b"name"),
-                                ..
-                            } => {
-                                name = a.decode_and_unescape_value(xml.decoder())?.to_string();
+                    for (key, val) in e.iter_raw_attrs() {
+                        match key {
+                            b"name" => {
+                                name = decode_attr(&xml.decoder(), val)?;
                             }
-                            Attribute {
-                                key: QName(b"state"),
-                                ..
-                            } => {
-                                visible = match a.decode_and_unescape_value(xml.decoder())?.as_ref()
-                                {
-                                    "visible" => SheetVisible::Visible,
-                                    "hidden" => SheetVisible::Hidden,
-                                    "veryHidden" => SheetVisible::VeryHidden,
+                            b"state" => {
+                                visible = match val {
+                                    b"visible" => SheetVisible::Visible,
+                                    b"hidden" => SheetVisible::Hidden,
+                                    b"veryHidden" => SheetVisible::VeryHidden,
                                     v => {
+                                        let v = xml.decoder().decode(v)?;
                                         return Err(XlsxError::Unrecognized {
                                             typ: "sheet:state",
-                                            val: v.to_string(),
-                                        })
+                                            val: v.into_owned(),
+                                        });
                                     }
                                 }
                             }
-                            Attribute {
-                                key: QName(b"r:id" | b"relationships:id"),
-                                value: v,
-                            } => {
+                            b"r:id" | b"relationships:id" => {
                                 let r = &relationships
-                                    .get(&*v)
+                                    .get(val)
                                     .ok_or(XlsxError::RelationshipNotFound)?[..];
                                 // target may have prepended "/xl/" or "xl/" path;
                                 // strip if present
@@ -455,7 +427,7 @@ impl<RS: Read + Seek> Xlsx<RS> {
                                     format!("xl/{r}")
                                 };
                             }
-                            _ => (),
+                            _ => {}
                         }
                     }
                     let typ = match path.split('/').nth(1) {
@@ -476,23 +448,15 @@ impl<RS: Read + Seek> Xlsx<RS> {
                     });
                     self.sheets.push((name, path));
                 }
-                Ok(Event::Start(e)) if e.name().as_ref() == b"workbookPr" => {
-                    self.is_1904 = match e.try_get_attribute("date1904")? {
-                        Some(c) => ["1", "true"].contains(
-                            &c.decode_and_unescape_value(xml.decoder())
-                                .map_err(XlsxError::Xml)?
-                                .as_ref(),
-                        ),
+                Ok(Event::Start(e)) if e.local_name().as_ref() == b"workbookPr" => {
+                    self.is_1904 = match e.raw_attr(b"date1904") {
+                        Some(v) => v == b"1" || v == b"true",
                         None => false,
                     };
                 }
                 Ok(Event::Start(e)) if e.local_name().as_ref() == b"definedName" => {
-                    if let Some(a) = e
-                        .attributes()
-                        .filter_map(std::result::Result::ok)
-                        .find(|a| a.key == QName(b"name"))
-                    {
-                        let name = a.decode_and_unescape_value(xml.decoder())?.to_string();
+                    if let Some(val) = e.raw_attr(b"name") {
+                        let name = decode_attr(&xml.decoder(), val)?;
                         val_buf.clear();
                         let mut value = String::new();
                         loop {
@@ -536,22 +500,10 @@ impl<RS: Read + Seek> Xlsx<RS> {
             buf.clear();
             match xml.read_event_into(&mut buf) {
                 Ok(Event::Start(e)) if e.local_name().as_ref() == b"Relationship" => {
-                    let mut id = Vec::new();
-                    let mut target = String::new();
-                    for a in e.attributes() {
-                        match a? {
-                            Attribute {
-                                key: QName(b"Id"),
-                                value: v,
-                            } => id.extend_from_slice(&v),
-                            Attribute {
-                                key: QName(b"Target"),
-                                value: v,
-                            } => target = xml.decoder().decode(&v)?.into_owned(),
-                            _ => (),
-                        }
+                    let (id, target) = get_attrs!(e, b"Id" => id, b"Target" => target);
+                    if let (Some(id), Some(target)) = (id, target) {
+                        relationships.insert(id.to_vec(), decode_attr(&xml.decoder(), target)?);
                     }
-                    relationships.insert(id, target);
                 }
                 Ok(Event::End(e)) if e.local_name().as_ref() == b"Relationships" => break,
                 Ok(Event::Eof) => return Err(XlsxError::XmlEof("Relationships")),
@@ -582,27 +534,14 @@ impl<RS: Read + Seek> Xlsx<RS> {
                     buf.clear();
                     match xml.read_event_into(&mut buf) {
                         Ok(Event::Start(e)) if e.local_name().as_ref() == b"Relationship" => {
-                            let mut id = Vec::new();
-                            let mut target = String::new();
-                            let mut table_type = false;
-                            for a in e.attributes() {
-                                match a? {
-                                    Attribute {
-                                        key: QName(b"Id"),
-                                        value: v,
-                                    } => id.extend_from_slice(&v),
-                                    Attribute {
-                                        key: QName(b"Target"),
-                                        value: v,
-                                    } => target = xml.decoder().decode(&v)?.into_owned(),
-                                    Attribute {
-                                        key: QName(b"Type"),
-                                        value: v,
-                                    } => table_type = *v == b"http://schemas.openxmlformats.org/officeDocument/2006/relationships/table"[..],
-                                    _ => (),
-                                }
-                            }
+                            let (_, target, typ) =
+                                get_attrs!(e, b"Id" => id, b"Target" => target, b"Type" => typ);
+                            let table_type = typ == Some(b"http://schemas.openxmlformats.org/officeDocument/2006/relationships/table" as &[u8]);
                             if table_type {
+                                let target = match target {
+                                    Some(t) => decode_attr(&xml.decoder(), t)?,
+                                    None => String::new(),
+                                };
                                 if target.starts_with("../") {
                                     // Relative path.
                                     let new_index =
@@ -637,49 +576,30 @@ impl<RS: Read + Seek> Xlsx<RS> {
                     buf.clear();
                     match xml.read_event_into(&mut buf) {
                         Ok(Event::Start(e)) if e.local_name().as_ref() == b"table" => {
-                            for a in e.attributes() {
-                                match a? {
-                                    Attribute {
-                                        key: QName(b"displayName"),
-                                        value: v,
-                                    } => {
-                                        table_meta.display_name =
-                                            xml.decoder().decode(&v)?.into_owned();
+                            for (key, val) in e.iter_raw_attrs() {
+                                match key {
+                                    b"displayName" => {
+                                        table_meta.display_name = decode_attr(&xml.decoder(), val)?;
                                     }
-                                    Attribute {
-                                        key: QName(b"ref"),
-                                        value: v,
-                                    } => {
+                                    b"ref" => {
                                         table_meta.ref_cells =
-                                            xml.decoder().decode(&v)?.into_owned();
+                                            xml.decoder().decode(val)?.into_owned();
                                     }
-                                    Attribute {
-                                        key: QName(b"headerRowCount"),
-                                        value: v,
-                                    } => {
+                                    b"headerRowCount" => {
                                         table_meta.header_row_count =
-                                            xml.decoder().decode(&v)?.parse()?;
+                                            xml.decoder().decode(val)?.parse()?;
                                     }
-                                    Attribute {
-                                        key: QName(b"totalsRowCount"),
-                                        value: v,
-                                    } => {
+                                    b"totalsRowCount" => {
                                         table_meta.totals_row_count =
-                                            xml.decoder().decode(&v)?.parse()?;
+                                            xml.decoder().decode(val)?.parse()?;
                                     }
-                                    _ => (),
+                                    _ => {}
                                 }
                             }
                         }
                         Ok(Event::Start(e)) if e.local_name().as_ref() == b"tableColumn" => {
-                            for a in e.attributes().flatten() {
-                                if let Attribute {
-                                    key: QName(b"name"),
-                                    value: v,
-                                } = a
-                                {
-                                    column_names.push(xml.decoder().decode(&v)?.into_owned());
-                                }
+                            if let Some(val) = e.raw_attr(b"name") {
+                                column_names.push(decode_attr(&xml.decoder(), val)?);
                             }
                         }
                         Ok(Event::End(e)) if e.local_name().as_ref() == b"table" => break,
@@ -838,8 +758,8 @@ impl<RS: Read + Seek> Xlsx<RS> {
                     buf.clear();
                     match xml.read_event_into(&mut buf) {
                         Ok(Event::Start(e)) if e.local_name() == QName(b"mergeCell").into() => {
-                            if let Some(attr) = get_attribute(e.attributes(), QName(b"ref"))? {
-                                let dimension = get_dimension(attr)?;
+                            if let Some(val) = e.raw_attr(b"ref") {
+                                let dimension = get_dimension(val)?;
                                 regions.push((
                                     sheet_name.to_string(),
                                     sheet_path.to_string(),
@@ -1779,24 +1699,6 @@ fn xml_reader<'a, RS: Read + Seek>(
     }
 }
 
-/// search through an Element's attributes for the named one
-pub(crate) fn get_attribute<'a>(
-    atts: Attributes<'a>,
-    n: QName,
-) -> Result<Option<&'a [u8]>, XlsxError> {
-    for a in atts {
-        match a {
-            Ok(Attribute {
-                key,
-                value: Cow::Borrowed(value),
-            }) if key == n => return Ok(Some(value)),
-            Err(e) => return Err(XlsxError::XmlAttr(e)),
-            _ => {} // ignore other attributes
-        }
-    }
-    Ok(None)
-}
-
 /// converts a text representation (e.g. "A6:G67") of a dimension into integers
 /// - top left (row, column),
 /// - bottom right (row, column)
@@ -1980,15 +1882,8 @@ where
 
         match xml.read_event_into(&mut buffer) {
             Ok(Event::Start(event)) if event.local_name().as_ref() == b"mergeCell" => {
-                for attribute in event.attributes() {
-                    let attribute = attribute?;
-
-                    if attribute.key == QName(b"ref") {
-                        let dimensions = get_dimension(&attribute.value)?;
-                        merge_cells.push(dimensions);
-
-                        break;
-                    }
+                if let Some(val) = event.raw_attr(b"ref") {
+                    merge_cells.push(get_dimension(val)?);
                 }
             }
             Ok(Event::End(event)) if event.local_name().as_ref() == b"mergeCells" => {
@@ -2335,17 +2230,9 @@ fn item_tag(e: &BytesStart) -> Option<Tag> {
         _ => None,
     }
 }
-fn item_value(e: &BytesStart) -> Result<Value, AttrError> {
-    for a in e.attributes() {
-        if let Attribute {
-            key: QName(b"v"),
-            value,
-        } = a?
-        {
-            return Ok(Some(Box::from(value)));
-        }
-    }
-    Ok(None)
+
+fn item_value(e: &BytesStart) -> Value {
+    e.raw_attr(b"v").map(Box::from)
 }
 
 // Get the target location of the pivot table's pivot cache definitions.
@@ -2369,21 +2256,12 @@ where
         buf.clear();
         match xml.read_event_into(&mut buf) {
             Ok(Event::Start(e)) if e.local_name().as_ref() == b"Relationship" => {
-                let mut target = String::new();
-                let mut is_pivot_cache_definitions_type = false;
-                for a in e.attributes() {
-                    match a? {
-                            Attribute {
-                                key: QName(b"Target"),
-                                value: v,
-                            } => target = xml.decoder().decode(&v)?.into_owned(),
-                            Attribute {
-                                key: QName(b"Type"),
-                                value: v,
-                            } => is_pivot_cache_definitions_type = *v == b"http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotCacheDefinition"[..],
-                            _ => (),
-                        }
-                }
+                let (target, typ) = get_attrs!(e, b"Target" => target, b"Type" => typ);
+                let is_pivot_cache_definitions_type = typ == Some(b"http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotCacheDefinition" as &[u8]);
+                let target = match target {
+                    Some(t) => decode_attr(&xml.decoder(), t)?,
+                    None => String::new(),
+                };
                 match (is_pivot_cache_definitions_type, definitions_path.is_some()) {
                     (true, false) => {
                         if let Some(target) = target.strip_prefix("../") {
@@ -2437,21 +2315,12 @@ where
         buf.clear();
         match xml.read_event_into(&mut buf) {
             Ok(Event::Start(e)) if e.local_name().as_ref() == b"Relationship" => {
-                let mut target = String::new();
-                let mut is_pivot_cache_record_type = false;
-                for a in e.attributes() {
-                    match a? {
-                            Attribute {
-                                key: QName(b"Target"),
-                                value: v,
-                            } => target = xml.decoder().decode(&v)?.into_owned(),
-                            Attribute {
-                                key: QName(b"Type"),
-                                value: v,
-                            } => is_pivot_cache_record_type = *v == b"http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotCacheRecords"[..],
-                            _ => (),
-                        }
-                }
+                let (target, typ) = get_attrs!(e, b"Target" => target, b"Type" => typ);
+                let is_pivot_cache_record_type = typ == Some(b"http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotCacheRecords" as &[u8]);
+                let target = match target {
+                    Some(t) => decode_attr(&xml.decoder(), t)?,
+                    None => String::new(),
+                };
                 match (is_pivot_cache_record_type, record_path.is_some()) {
                     (true, false) => {
                         if target.starts_with("xl/pivotCache") {
@@ -2507,22 +2376,13 @@ where
         buf.clear();
         match xml.read_event_into(&mut buf) {
             Ok(Event::Start(e)) if e.local_name().as_ref() == b"Relationship" => {
-                let mut target = String::new();
-                let mut is_pivot_table_type = false;
-                for a in e.attributes() {
-                    match a? {
-                            Attribute {
-                                key: QName(b"Target"),
-                                value: v,
-                            } => target = xml.decoder().decode(&v)?.into_owned(),
-                            Attribute {
-                                key: QName(b"Type"),
-                                value: v,
-                            } => is_pivot_table_type = *v == b"http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotTable"[..],
-                            _ => (),
-                        }
-                }
+                let (target, typ) = get_attrs!(e, b"Target" => target, b"Type" => typ);
+                let is_pivot_table_type = typ == Some(b"http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotTable" as &[u8]);
                 if is_pivot_table_type {
+                    let target = match target {
+                        Some(t) => decode_attr(&xml.decoder(), t)?,
+                        None => String::new(),
+                    };
                     if let Some(target) = target.strip_prefix("../") {
                         // this is an incomplete implementation, but should be good enough for excel
                         let (parent, _) = base_folder
@@ -2563,20 +2423,13 @@ where
         buf.clear();
         match xml.read_event_into(&mut buf) {
             Ok(Event::Start(e)) if e.local_name().as_ref() == b"pivotTableDefinition" => {
-                for a in e.attributes() {
-                    if let Attribute {
-                        key: QName(b"name"),
-                        value: v,
-                    } = a?
-                    {
-                        if name.is_some() {
-                            return Err(XlsxError::Unexpected(
-                                "multiple name entries for one pivot table path",
-                            ));
-                        } else {
-                            name.replace(xml.decoder().decode(&v)?.into_owned());
-                        }
+                if let Some(val) = e.raw_attr(b"name") {
+                    if name.is_some() {
+                        return Err(XlsxError::Unexpected(
+                            "multiple name entries for one pivot table path",
+                        ));
                     }
+                    name.replace(decode_attr(&xml.decoder(), val)?);
                 }
             }
             Ok(Event::End(e)) if e.local_name().as_ref() == b"pivotTableDefinition" => break,
@@ -2835,26 +2688,14 @@ fn get_pivot_cache_iter<'a, RS: Read + Seek + 'a>(
 
             match xml.read_event_into(&mut buf) {
                 Ok(Event::Start(e)) if e.local_name().as_ref() == b"cacheField" => {
-                    for a in e.attributes() {
-                        match a? {
-                            Attribute {
-                                key: QName(b"name"),
-                                value,
-                            } => {
-                                field_names.push(xml.decoder().decode(value.as_ref())?.to_string());
-                                fields.push(vec![]);
-                            }
-                            Attribute {
-                                key: QName(b"formula"),
-                                value: _value,
-                            } => {
-                                field_names.pop();
-                                fields.pop();
-                            }
-                            _ => {
-                                // do nothing
-                            }
-                        }
+                    let (name, formula) = get_attrs!(e, b"name" => name, b"formula" => formula);
+                    if let Some(name) = name {
+                        field_names.push(decode_attr(&xml.decoder(), name)?);
+                        fields.push(vec![]);
+                    }
+                    if formula.is_some() {
+                        field_names.pop();
+                        fields.pop();
                     }
                 }
                 // Exclude grouped fields from results.
@@ -2870,7 +2711,7 @@ fn get_pivot_cache_iter<'a, RS: Read + Seek + 'a>(
                 Ok(Event::Start(e)) => {
                     if let Some(tag) = item_tag(&e) {
                         if let Some(field) = fields.last_mut() {
-                            field.push((tag, item_value(&e)?));
+                            field.push((tag, item_value(&e)));
                         }
                     }
                 }
@@ -2929,30 +2770,21 @@ impl<'a, RS: Read + Seek + 'a> Iterator for PivotCacheIter<'a, RS> {
             buf.clear();
             match self.reader.read_event_into(&mut buf) {
                 Ok(Event::Start(e)) if e.local_name().as_ref() == b"x" => {
-                    for a in e.attributes() {
-                        if let Ok(Attribute {
-                            key: QName(b"v"),
-                            value,
-                        }) = a
-                        {
-                            let value_position = match self.reader.decoder().decode(value.as_ref())
-                            {
-                                Ok(val) => match val.parse::<usize>() {
-                                    Ok(val) => val,
-                                    Err(e) => {
-                                        return Some(Err(XlsxError::ParseInt(e)));
-                                    }
-                                },
-                                Err(e) => return Some(Err(XlsxError::Encoding(e))),
-                            };
+                    if let Some(val) = e.raw_attr(b"v") {
+                        let value_position = match atoi_simd::parse::<usize>(val) {
+                            Ok(val) => val,
+                            Err(_) => {
+                                return Some(Err(XlsxError::Unexpected(
+                                    "pivot cache x:v attribute must be a number",
+                                )));
+                            }
+                        };
 
-                            let column_name = &self.field_names[col_number];
-                            row.push(parse_item(
-                                &self.definitions[column_name][value_position],
-                                &self.reader.decoder(),
-                            ));
-                            break;
-                        }
+                        let column_name = &self.field_names[col_number];
+                        row.push(parse_item(
+                            &self.definitions[column_name][value_position],
+                            &self.reader.decoder(),
+                        ));
                     }
 
                     col_number += 1;
@@ -2969,7 +2801,8 @@ impl<'a, RS: Read + Seek + 'a> Iterator for PivotCacheIter<'a, RS> {
                 Err(e) => return Some(Err(XlsxError::Xml(e))),
                 Ok(Event::Start(e)) => {
                     if let Some(tag) = item_tag(&e) {
-                        if let Ok(value) = item_value(&e) {
+                        {
+                            let value = item_value(&e);
                             row.push(parse_item(&(tag, value), &self.reader.decoder()));
                             col_number += 1;
                         }

--- a/src/xlsx/mod.rs
+++ b/src/xlsx/mod.rs
@@ -21,7 +21,7 @@ use quick_xml::Reader as XmlReader;
 use zip::read::{ZipArchive, ZipFile};
 use zip::result::ZipError;
 
-use crate::attrs::{decode_attr, RawAttributes};
+use crate::attrs::{decode_attr, local_name_matches, RawAttributes};
 use crate::datatype::DataRef;
 use crate::formats::{builtin_format_by_id, detect_custom_number_format, CellFormat};
 use crate::utils::{
@@ -478,7 +478,7 @@ impl<RS: Read + Seek> Xlsx<RS> {
                                 }
                             }
                             // Ignore the "r:id" attribute namespace and match on the "id" name.
-                            key if key == b"id" || key.ends_with(b":id") => {
+                            key if local_name_matches(key, b"id") => {
                                 rel_id = val.to_vec();
                             }
                             _ => {}
@@ -754,27 +754,16 @@ impl<RS: Read + Seek> Xlsx<RS> {
                     buf.clear();
                     match xml.read_event_into(&mut buf) {
                         Ok(Event::Start(e)) if e.local_name().as_ref() == b"Relationship" => {
-                            let mut is_drawing = false;
-                            let mut target = String::new();
-                            for a in e.attributes() {
-                                match a? {
-                                    Attribute {
-                                        key: QName(b"Type"),
-                                        value: v,
-                                    } => {
-                                        is_drawing = v.ends_with(b"/drawing");
+                            let (rel_type, target) =
+                                get_attrs!(e, b"Type" => typ, b"Target" => target)?;
+                            let is_drawing = rel_type.is_some_and(|t| t.ends_with(b"/drawing"));
+                            if is_drawing {
+                                if let Some(target) = target {
+                                    let target = decode_attr(&xml.decoder(), target)?;
+                                    if !target.is_empty() {
+                                        drawing_paths.push(resolve_path(base_folder, &target));
                                     }
-                                    Attribute {
-                                        key: QName(b"Target"),
-                                        value: v,
-                                    } => {
-                                        target = xml.decoder().decode(&v)?.into_owned();
-                                    }
-                                    _ => (),
                                 }
-                            }
-                            if is_drawing && !target.is_empty() {
-                                drawing_paths.push(resolve_path(base_folder, &target));
                             }
                         }
                         Ok(Event::End(e)) if e.local_name().as_ref() == b"Relationships" => break,
@@ -803,36 +792,21 @@ impl<RS: Read + Seek> Xlsx<RS> {
                         buf.clear();
                         match xml.read_event_into(&mut buf) {
                             Ok(Event::Start(e)) if e.local_name().as_ref() == b"Relationship" => {
-                                let mut id = String::new();
-                                let mut target = String::new();
-                                let mut is_image = false;
-                                for a in e.attributes() {
-                                    match a? {
-                                        Attribute {
-                                            key: QName(b"Id"),
-                                            value: v,
-                                        } => {
-                                            id = xml.decoder().decode(&v)?.into_owned();
+                                let (id, target, rel_type) = get_attrs!(e, b"Id" => id, b"Target" => target, b"Type" => typ)?;
+                                let is_image = rel_type.is_some_and(|t| t.ends_with(b"/image"));
+                                if is_image {
+                                    if let Some(id) = id {
+                                        let id = decode_attr(&xml.decoder(), id)?;
+                                        if !id.is_empty() {
+                                            let target = match target {
+                                                Some(t) => decode_attr(&xml.decoder(), t)?,
+                                                None => String::new(),
+                                            };
+                                            let norm = resolve_path(draw_base, &target)
+                                                .to_ascii_lowercase();
+                                            rid_to_media.insert(id, norm);
                                         }
-                                        Attribute {
-                                            key: QName(b"Target"),
-                                            value: v,
-                                        } => {
-                                            target = xml.decoder().decode(&v)?.into_owned();
-                                        }
-                                        Attribute {
-                                            key: QName(b"Type"),
-                                            value: v,
-                                        } => {
-                                            is_image = v.ends_with(b"/image");
-                                        }
-                                        _ => (),
                                     }
-                                }
-                                if is_image && !id.is_empty() {
-                                    let norm =
-                                        resolve_path(draw_base, &target).to_ascii_lowercase();
-                                    rid_to_media.insert(id, norm);
                                 }
                             }
                             Ok(Event::End(e)) if e.local_name().as_ref() == b"Relationships" => {
@@ -880,23 +854,14 @@ impl<RS: Read + Seek> Xlsx<RS> {
                                     b"col" if in_from => in_col = true,
                                     b"row" if in_from => in_row = true,
                                     b"blip" if in_anchor => {
-                                        for a in e.attributes().flatten() {
-                                            if a.key.local_name().as_ref() == b"embed" {
-                                                current_rid =
-                                                    xml.decoder().decode(&a.value)?.into_owned();
-                                            }
+                                        // The embed rId is namespaced (`r:embed`).
+                                        if let Some(val) = e.raw_attr_local(b"embed")? {
+                                            current_rid = decode_attr(&xml.decoder(), val)?;
                                         }
                                     }
                                     b"cNvPr" if in_anchor => {
-                                        for a in e.attributes() {
-                                            if let Attribute {
-                                                key: QName(b"name"),
-                                                value: v,
-                                            } = a?
-                                            {
-                                                current_name =
-                                                    xml.decoder().decode(&v)?.into_owned();
-                                            }
+                                        if let Some(val) = e.raw_attr(b"name")? {
+                                            current_name = decode_attr(&xml.decoder(), val)?;
                                         }
                                     }
                                     _ => (),
@@ -988,35 +953,22 @@ impl<RS: Read + Seek> Xlsx<RS> {
                 buf.clear();
                 match xml.read_event_into(&mut buf) {
                     Ok(Event::Start(e)) if e.local_name().as_ref() == b"Relationship" => {
-                        let mut id = String::new();
-                        let mut target = String::new();
-                        let mut is_image = false;
-                        for a in e.attributes() {
-                            match a? {
-                                Attribute {
-                                    key: QName(b"Id"),
-                                    value: v,
-                                } => {
-                                    id = xml.decoder().decode(&v)?.into_owned();
+                        let (id, target, rel_type) =
+                            get_attrs!(e, b"Id" => id, b"Target" => target, b"Type" => typ)?;
+                        let is_image = rel_type.is_some_and(|t| t.ends_with(b"/image"));
+                        if is_image {
+                            if let Some(id) = id {
+                                let id = decode_attr(&xml.decoder(), id)?;
+                                if !id.is_empty() {
+                                    let target = match target {
+                                        Some(t) => decode_attr(&xml.decoder(), t)?,
+                                        None => String::new(),
+                                    };
+                                    let norm =
+                                        resolve_path("xl/richData", &target).to_ascii_lowercase();
+                                    rid_to_media.insert(id, norm);
                                 }
-                                Attribute {
-                                    key: QName(b"Target"),
-                                    value: v,
-                                } => {
-                                    target = xml.decoder().decode(&v)?.into_owned();
-                                }
-                                Attribute {
-                                    key: QName(b"Type"),
-                                    value: v,
-                                } => {
-                                    is_image = v.ends_with(b"/image");
-                                }
-                                _ => (),
                             }
-                        }
-                        if is_image && !id.is_empty() {
-                            let norm = resolve_path("xl/richData", &target).to_ascii_lowercase();
-                            rid_to_media.insert(id, norm);
                         }
                     }
                     Ok(Event::End(e)) if e.local_name().as_ref() == b"Relationships" => break,
@@ -1043,13 +995,11 @@ impl<RS: Read + Seek> Xlsx<RS> {
                 buf.clear();
                 match xml.read_event_into(&mut buf) {
                     Ok(Event::Start(e)) if e.local_name().as_ref() == b"rel" => {
-                        let mut rid = String::new();
-                        for a in e.attributes().flatten() {
-                            if a.key.local_name().as_ref() == b"id" {
-                                rid = xml.decoder().decode(&a.value)?.into_owned();
-                                break;
-                            }
-                        }
+                        // The rId is namespaced (`r:id`).
+                        let rid = match e.raw_attr_local(b"id")? {
+                            Some(val) => decode_attr(&xml.decoder(), val)?,
+                            None => String::new(),
+                        };
                         let media_path = rid_to_media.get(&rid).cloned().unwrap_or_default();
                         idx_to_media.push(media_path);
                     }
@@ -1128,45 +1078,20 @@ impl<RS: Read + Seek> Xlsx<RS> {
                 buf.clear();
                 match xml.read_event_into(&mut buf) {
                     Ok(Event::Start(e)) if e.local_name().as_ref() == b"row" => {
-                        for a in e.attributes() {
-                            if let Attribute {
-                                key: QName(b"r"),
-                                value: v,
-                            } = a?
-                            {
-                                let s = xml.decoder().decode(&v)?.into_owned();
-                                current_row = s.parse::<u32>().unwrap_or(1) - 1;
-                            }
+                        if let Some(r) = e.raw_attr(b"r")? {
+                            current_row = atoi_simd::parse::<u32>(r).unwrap_or(1) - 1;
                         }
                     }
                     Ok(Event::Start(e)) if e.local_name().as_ref() == b"c" => {
-                        let mut vm: Option<usize> = None;
-                        let mut cell_ref = String::new();
-                        for a in e.attributes() {
-                            match a? {
-                                Attribute {
-                                    key: QName(b"vm"),
-                                    value: v,
-                                } => {
-                                    let s = xml.decoder().decode(&v)?.into_owned();
-                                    vm = s.parse().ok();
-                                }
-                                Attribute {
-                                    key: QName(b"r"),
-                                    value: v,
-                                } => {
-                                    cell_ref = xml.decoder().decode(&v)?.into_owned();
-                                }
-                                _ => (),
-                            }
-                        }
+                        let (vm, r) = get_attrs!(e, b"vm" => vm, b"r" => r)?;
+                        let vm = vm.and_then(|v| atoi_simd::parse::<usize>(v).ok());
                         if let Some(vm_val) = vm {
                             let rv_idx = vm_val.saturating_sub(1);
                             if let Some(&img_idx) = rv_to_img_idx.get(&rv_idx) {
                                 if let Some(media_path) = idx_to_media.get(img_idx) {
                                     if !media_path.is_empty() {
                                         if let Some((ext, data)) = media.get(media_path) {
-                                            let col = col_from_cell_ref(&cell_ref);
+                                            let col = r.map_or(0, col_from_cell_ref);
                                             seen.insert(media_path.clone());
                                             pics.push(Picture {
                                                 extension: ext.clone(),
@@ -2534,7 +2459,7 @@ where
                         // for the relationships namespace is conventionally
                         // "r" but OOXML allows any prefix bound to the
                         // relationships namespace URI.
-                        key if key == b"id" || key.ends_with(b":id") => {
+                        key if local_name_matches(key, b"id") => {
                             rid = Some(xml.decoder().decode(val)?.into_owned());
                         }
                         _ => (),
@@ -2808,11 +2733,12 @@ fn resolve_path(base: &str, target: &str) -> String {
     }
 }
 
-// Parse the 0-based column index from an A1-style cell reference like "B2".
+// Parse the 0-based column index from the raw bytes of an A1-style cell
+// reference like `B2`.
 #[cfg(feature = "picture")]
-fn col_from_cell_ref(cell_ref: &str) -> u32 {
+fn col_from_cell_ref(cell_ref: &[u8]) -> u32 {
     let mut col: u32 = 0;
-    for b in cell_ref.bytes() {
+    for &b in cell_ref {
         if b.is_ascii_alphabetic() {
             col = col * 26 + (b.to_ascii_uppercase() - b'A') as u32 + 1;
         } else {

--- a/src/xlsx/mod.rs
+++ b/src/xlsx/mod.rs
@@ -6,7 +6,6 @@
 
 mod cells_reader;
 
-use std::borrow::Cow;
 use std::collections::HashMap;
 #[cfg(feature = "picture")]
 use std::collections::HashSet;
@@ -15,15 +14,14 @@ use std::io::{Read, Seek};
 use std::str::FromStr;
 
 use log::warn;
-use quick_xml::events::attributes::{AttrError, Attribute, Attributes};
-use quick_xml::events::BytesStart;
-use quick_xml::events::Event;
+use quick_xml::events::{BytesStart, Event};
 use quick_xml::name::QName;
 use quick_xml::Decoder;
 use quick_xml::Reader as XmlReader;
 use zip::read::{ZipArchive, ZipFile};
 use zip::result::ZipError;
 
+use crate::attrs::{decode_attr, RawAttributes};
 use crate::datatype::DataRef;
 use crate::formats::{builtin_format_by_id, detect_custom_number_format, CellFormat};
 use crate::utils::{
@@ -308,22 +306,12 @@ impl<RS: Read + Seek> Xlsx<RS> {
             buf.clear();
             match xml.read_event_into(&mut buf) {
                 Ok(Event::Start(e)) if e.local_name().as_ref() == b"Relationship" => {
-                    let mut rel_type = String::new();
-                    let mut target = String::new();
-                    for a in e.attributes() {
-                        let a = a?;
-                        match a.key {
-                            QName(b"Type") => {
-                                rel_type = a.decode_and_unescape_value(xml.decoder())?.to_string();
-                            }
-                            QName(b"Target") => {
-                                target = a.decode_and_unescape_value(xml.decoder())?.to_string();
-                            }
-                            _ => (),
+                    let (rel_type, target) =
+                        get_attrs!(e, b"Type" => rel_type, b"Target" => target)?;
+                    if rel_type == Some(b"http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument".as_slice()) {
+                        if let Some(target) = target {
+                            document_target = Some(decode_attr(&xml.decoder(), target)?);
                         }
-                    }
-                    if rel_type == "http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" {
-                        document_target = Some(target);
                     }
                 }
                 Ok(Event::End(e)) if e.local_name().as_ref() == b"Relationships" => break,
@@ -358,7 +346,7 @@ impl<RS: Read + Seek> Xlsx<RS> {
             buf.clear();
             match xml.read_event_into(&mut buf) {
                 Ok(Event::Start(e)) if e.local_name().as_ref() == b"sst" => {
-                    if let Ok(Some(count)) = get_attribute(e.attributes(), QName(b"uniqueCount")) {
+                    if let Some(count) = e.raw_attr(b"uniqueCount")? {
                         if let Ok(n) = atoi_simd::parse::<usize>(count) {
                             self.strings.reserve(n);
                         }
@@ -410,23 +398,11 @@ impl<RS: Read + Seek> Xlsx<RS> {
                     inner_buf.clear();
                     match xml.read_event_into(&mut inner_buf) {
                         Ok(Event::Start(e)) if e.local_name().as_ref() == b"numFmt" => {
-                            let mut id = Vec::new();
-                            let mut format = String::new();
-                            for a in e.attributes() {
-                                match a? {
-                                    Attribute {
-                                        key: QName(b"numFmtId"),
-                                        value: v,
-                                    } => id.extend_from_slice(&v),
-                                    Attribute {
-                                        key: QName(b"formatCode"),
-                                        value: v,
-                                    } => format = xml.decoder().decode(&v)?.into_owned(),
-                                    _ => (),
-                                }
-                            }
-                            if !format.is_empty() {
-                                number_formats.insert(id, format);
+                            let (id, format_code) =
+                                get_attrs!(e, b"numFmtId" => id, b"formatCode" => fmt)?;
+                            if let (Some(id), Some(fc)) = (id, format_code) {
+                                let format = decode_attr(&xml.decoder(), fc)?;
+                                number_formats.insert(id.to_vec(), format);
                             }
                         }
                         Ok(Event::End(e)) if e.local_name().as_ref() == b"numFmts" => break,
@@ -439,17 +415,13 @@ impl<RS: Read + Seek> Xlsx<RS> {
                     inner_buf.clear();
                     match xml.read_event_into(&mut inner_buf) {
                         Ok(Event::Start(e)) if e.local_name().as_ref() == b"xf" => {
-                            self.formats.push(
-                                e.attributes()
-                                    .filter_map(|a| a.ok())
-                                    .find(|a| a.key == QName(b"numFmtId"))
-                                    .map_or(CellFormat::Other, |a| {
-                                        match number_formats.get(&*a.value) {
-                                            Some(fmt) => detect_custom_number_format(fmt),
-                                            None => builtin_format_by_id(&a.value),
-                                        }
-                                    }),
-                            );
+                            self.formats.push(e.raw_attr(b"numFmtId")?.map_or(
+                                CellFormat::Other,
+                                |val| match number_formats.get(val) {
+                                    Some(fmt) => detect_custom_number_format(fmt),
+                                    None => builtin_format_by_id(val),
+                                },
+                            ));
                         }
                         Ok(Event::End(e)) if e.local_name().as_ref() == b"cellXfs" => break,
                         Ok(Event::Eof) => return Err(XlsxError::XmlEof("cellXfs")),
@@ -485,37 +457,31 @@ impl<RS: Read + Seek> Xlsx<RS> {
                     let mut name = String::new();
                     let mut rel_id = Vec::new();
                     let mut visible = SheetVisible::Visible;
-                    for a in e.attributes() {
-                        let a = a?;
-                        match a {
-                            Attribute {
-                                key: QName(b"name"),
-                                ..
-                            } => {
-                                name = a.decode_and_unescape_value(xml.decoder())?.to_string();
+                    for attr in e.iter_raw_attrs() {
+                        let (key, val) = attr?;
+                        match key {
+                            b"name" => {
+                                name = decode_attr(&xml.decoder(), val)?;
                             }
-                            Attribute {
-                                key: QName(b"state"),
-                                ..
-                            } => {
-                                visible = match a.decode_and_unescape_value(xml.decoder())?.as_ref()
-                                {
-                                    "visible" => SheetVisible::Visible,
-                                    "hidden" => SheetVisible::Hidden,
-                                    "veryHidden" => SheetVisible::VeryHidden,
+                            b"state" => {
+                                visible = match val {
+                                    b"visible" => SheetVisible::Visible,
+                                    b"hidden" => SheetVisible::Hidden,
+                                    b"veryHidden" => SheetVisible::VeryHidden,
                                     v => {
+                                        let v = xml.decoder().decode(v)?;
                                         return Err(XlsxError::Unrecognized {
                                             typ: "sheet:state",
-                                            val: v.to_string(),
-                                        })
+                                            val: v.into_owned(),
+                                        });
                                     }
                                 }
                             }
                             // Ignore the "r:id" attribute namespace and match on the "id" name.
-                            Attribute { key, value: v } if key.local_name().as_ref() == b"id" => {
-                                rel_id = (*v).to_vec();
+                            key if key == b"id" || key.ends_with(b":id") => {
+                                rel_id = val.to_vec();
                             }
-                            _ => (),
+                            _ => {}
                         }
                     }
                     let (r, rel_type) = relationships
@@ -545,23 +511,15 @@ impl<RS: Read + Seek> Xlsx<RS> {
                     });
                     self.sheets.push((name, path));
                 }
-                Ok(Event::Start(e)) if e.name().as_ref() == b"workbookPr" => {
-                    self.is_1904 = match e.try_get_attribute("date1904")? {
-                        Some(c) => ["1", "true"].contains(
-                            &c.decode_and_unescape_value(xml.decoder())
-                                .map_err(XlsxError::Xml)?
-                                .as_ref(),
-                        ),
+                Ok(Event::Start(e)) if e.local_name().as_ref() == b"workbookPr" => {
+                    self.is_1904 = match e.raw_attr(b"date1904")? {
+                        Some(v) => v == b"1" || v == b"true",
                         None => false,
                     };
                 }
                 Ok(Event::Start(e)) if e.local_name().as_ref() == b"definedName" => {
-                    if let Some(a) = e
-                        .attributes()
-                        .filter_map(std::result::Result::ok)
-                        .find(|a| a.key == QName(b"name"))
-                    {
-                        let name = a.decode_and_unescape_value(xml.decoder())?.to_string();
+                    if let Some(val) = e.raw_attr(b"name")? {
+                        let name = decode_attr(&xml.decoder(), val)?;
                         val_buf.clear();
                         let mut value = String::new();
                         loop {
@@ -600,27 +558,20 @@ impl<RS: Read + Seek> Xlsx<RS> {
             buf.clear();
             match xml.read_event_into(&mut buf) {
                 Ok(Event::Start(e)) if e.local_name().as_ref() == b"Relationship" => {
-                    let mut id = Vec::new();
-                    let mut rel_type = String::new();
-                    let mut target = String::new();
-                    for a in e.attributes() {
-                        match a? {
-                            Attribute {
-                                key: QName(b"Id"),
-                                value: v,
-                            } => id.extend_from_slice(&v),
-                            Attribute {
-                                key: QName(b"Type"),
-                                value: v,
-                            } => rel_type = xml.decoder().decode(&v)?.into_owned(),
-                            Attribute {
-                                key: QName(b"Target"),
-                                value: v,
-                            } => target = xml.decoder().decode(&v)?.into_owned(),
-                            _ => (),
-                        }
+                    let (id, rel_type, target) =
+                        get_attrs!(e, b"Id" => id, b"Type" => rel_type, b"Target" => target)?;
+                    if let Some(id) = id {
+                        let decoder = xml.decoder();
+                        let rel_type = rel_type
+                            .map(|v| decoder.decode(v).map(|s| s.into_owned()))
+                            .transpose()?
+                            .unwrap_or_default();
+                        let target = target
+                            .map(|v| decoder.decode(v).map(|s| s.into_owned()))
+                            .transpose()?
+                            .unwrap_or_default();
+                        relationships.insert(id.to_vec(), (target, rel_type));
                     }
-                    relationships.insert(id, (target, rel_type));
                 }
                 Ok(Event::End(e)) if e.local_name().as_ref() == b"Relationships" => break,
                 Ok(Event::Eof) => return Err(XlsxError::XmlEof("Relationships")),
@@ -651,27 +602,14 @@ impl<RS: Read + Seek> Xlsx<RS> {
                     buf.clear();
                     match xml.read_event_into(&mut buf) {
                         Ok(Event::Start(e)) if e.local_name().as_ref() == b"Relationship" => {
-                            let mut id = Vec::new();
-                            let mut target = String::new();
-                            let mut table_type = false;
-                            for a in e.attributes() {
-                                match a? {
-                                    Attribute {
-                                        key: QName(b"Id"),
-                                        value: v,
-                                    } => id.extend_from_slice(&v),
-                                    Attribute {
-                                        key: QName(b"Target"),
-                                        value: v,
-                                    } => target = xml.decoder().decode(&v)?.into_owned(),
-                                    Attribute {
-                                        key: QName(b"Type"),
-                                        value: v,
-                                    } => table_type = *v == b"http://schemas.openxmlformats.org/officeDocument/2006/relationships/table"[..],
-                                    _ => (),
-                                }
-                            }
+                            let (_, target, typ) =
+                                get_attrs!(e, b"Id" => id, b"Target" => target, b"Type" => typ)?;
+                            let table_type = typ == Some(b"http://schemas.openxmlformats.org/officeDocument/2006/relationships/table" as &[u8]);
                             if table_type {
+                                let target = match target {
+                                    Some(t) => decode_attr(&xml.decoder(), t)?,
+                                    None => String::new(),
+                                };
                                 if target.starts_with("../") {
                                     // Relative path.
                                     let new_index =
@@ -706,49 +644,31 @@ impl<RS: Read + Seek> Xlsx<RS> {
                     buf.clear();
                     match xml.read_event_into(&mut buf) {
                         Ok(Event::Start(e)) if e.local_name().as_ref() == b"table" => {
-                            for a in e.attributes() {
-                                match a? {
-                                    Attribute {
-                                        key: QName(b"displayName"),
-                                        value: v,
-                                    } => {
-                                        table_meta.display_name =
-                                            xml.decoder().decode(&v)?.into_owned();
+                            for attr in e.iter_raw_attrs() {
+                                let (key, val) = attr?;
+                                match key {
+                                    b"displayName" => {
+                                        table_meta.display_name = decode_attr(&xml.decoder(), val)?;
                                     }
-                                    Attribute {
-                                        key: QName(b"ref"),
-                                        value: v,
-                                    } => {
+                                    b"ref" => {
                                         table_meta.ref_cells =
-                                            xml.decoder().decode(&v)?.into_owned();
+                                            xml.decoder().decode(val)?.into_owned();
                                     }
-                                    Attribute {
-                                        key: QName(b"headerRowCount"),
-                                        value: v,
-                                    } => {
+                                    b"headerRowCount" => {
                                         table_meta.header_row_count =
-                                            xml.decoder().decode(&v)?.parse()?;
+                                            xml.decoder().decode(val)?.parse()?;
                                     }
-                                    Attribute {
-                                        key: QName(b"totalsRowCount"),
-                                        value: v,
-                                    } => {
+                                    b"totalsRowCount" => {
                                         table_meta.totals_row_count =
-                                            xml.decoder().decode(&v)?.parse()?;
+                                            xml.decoder().decode(val)?.parse()?;
                                     }
-                                    _ => (),
+                                    _ => {}
                                 }
                             }
                         }
                         Ok(Event::Start(e)) if e.local_name().as_ref() == b"tableColumn" => {
-                            for a in e.attributes().flatten() {
-                                if let Attribute {
-                                    key: QName(b"name"),
-                                    value: v,
-                                } = a
-                                {
-                                    column_names.push(xml.decoder().decode(&v)?.into_owned());
-                                }
+                            if let Some(val) = e.raw_attr(b"name")? {
+                                column_names.push(decode_attr(&xml.decoder(), val)?);
                             }
                         }
                         Ok(Event::End(e)) if e.local_name().as_ref() == b"table" => break,
@@ -1395,8 +1315,8 @@ impl<RS: Read + Seek> Xlsx<RS> {
                     buf.clear();
                     match xml.read_event_into(&mut buf) {
                         Ok(Event::Start(e)) if e.local_name() == QName(b"mergeCell").into() => {
-                            if let Some(attr) = get_attribute(e.attributes(), QName(b"ref"))? {
-                                let dimension = get_dimension(attr)?;
+                            if let Some(val) = e.raw_attr(b"ref")? {
+                                let dimension = get_dimension(val)?;
                                 regions.push((
                                     sheet_name.to_string(),
                                     sheet_path.to_string(),
@@ -2539,30 +2459,22 @@ where
             Ok(Event::Start(e)) | Ok(Event::Empty(e))
                 if e.local_name().as_ref() == b"Relationship" =>
             {
-                let mut id = String::new();
-                let mut target = String::new();
-                let mut is_hyperlink = false;
-                for a in e.attributes() {
-                    match a? {
-                        Attribute {
-                            key: QName(b"Id"),
-                            value: v,
-                        } => id = xml.decoder().decode(&v)?.into_owned(),
-                        Attribute {
-                            key: QName(b"Target"),
-                            value: v,
-                        } => target = unescape_xml(&xml.decoder().decode(&v)?).into_owned(),
-                        Attribute {
-                            key: QName(b"Type"),
-                            value: v,
-                        } => {
-                            is_hyperlink = v.ends_with(b"/relationships/hyperlink");
-                        }
-                        _ => (),
+                let (id, target, typ) =
+                    get_attrs!(e, b"Id" => id, b"Target" => target, b"Type" => typ)?;
+                let is_hyperlink = typ.is_some_and(|t| t.ends_with(b"/relationships/hyperlink"));
+                if is_hyperlink {
+                    if let Some(id) = id.filter(|id| !id.is_empty()) {
+                        let id = xml.decoder().decode(id)?.into_owned();
+                        let target = target
+                            .map(|t| {
+                                xml.decoder()
+                                    .decode(t)
+                                    .map(|t| unescape_xml(&t).into_owned())
+                            })
+                            .transpose()?
+                            .unwrap_or_default();
+                        rels.insert(id, target);
                     }
-                }
-                if is_hyperlink && !id.is_empty() {
-                    rels.insert(id, target);
                 }
             }
             Ok(Event::End(e)) if e.local_name().as_ref() == b"Relationships" => break,
@@ -2602,34 +2514,28 @@ where
                 let mut displayed_text: Option<String> = None;
                 let mut tooltip: Option<String> = None;
 
-                for attribute in event.attributes() {
-                    let attribute = attribute?;
-                    let local = attribute.key.local_name();
-                    match local.as_ref() {
+                for attr in event.iter_raw_attrs() {
+                    let (key, val) = attr?;
+                    match key {
                         b"ref" => {
-                            range = Some(get_dimension(&attribute.value)?);
+                            range = Some(get_dimension(val)?);
+                        }
+                        b"location" => {
+                            location = Some(unescape_xml(&xml.decoder().decode(val)?).into_owned());
+                        }
+                        b"display" => {
+                            displayed_text =
+                                Some(unescape_xml(&xml.decoder().decode(val)?).into_owned());
+                        }
+                        b"tooltip" => {
+                            tooltip = Some(unescape_xml(&xml.decoder().decode(val)?).into_owned());
                         }
                         // Match on the local name; the namespace prefix
                         // for the relationships namespace is conventionally
                         // "r" but OOXML allows any prefix bound to the
                         // relationships namespace URI.
-                        b"id" => {
-                            rid = Some(xml.decoder().decode(&attribute.value)?.into_owned());
-                        }
-                        b"location" => {
-                            location = Some(
-                                unescape_xml(&xml.decoder().decode(&attribute.value)?).into_owned(),
-                            );
-                        }
-                        b"display" => {
-                            displayed_text = Some(
-                                unescape_xml(&xml.decoder().decode(&attribute.value)?).into_owned(),
-                            );
-                        }
-                        b"tooltip" => {
-                            tooltip = Some(
-                                unescape_xml(&xml.decoder().decode(&attribute.value)?).into_owned(),
-                            );
+                        key if key == b"id" || key.ends_with(b":id") => {
+                            rid = Some(xml.decoder().decode(val)?.into_owned());
                         }
                         _ => (),
                     }
@@ -2938,24 +2844,6 @@ fn xml_reader<'a, RS: Read + Seek>(
     }
 }
 
-/// search through an Element's attributes for the named one
-pub(crate) fn get_attribute<'a>(
-    atts: Attributes<'a>,
-    n: QName,
-) -> Result<Option<&'a [u8]>, XlsxError> {
-    for a in atts {
-        match a {
-            Ok(Attribute {
-                key,
-                value: Cow::Borrowed(value),
-            }) if key == n => return Ok(Some(value)),
-            Err(e) => return Err(XlsxError::XmlAttr(e)),
-            _ => {} // ignore other attributes
-        }
-    }
-    Ok(None)
-}
-
 /// converts a text representation (e.g. "A6:G67") of a dimension into integers
 /// - top left (row, column),
 /// - bottom right (row, column)
@@ -3130,15 +3018,8 @@ where
 
         match xml.read_event_into(&mut buffer) {
             Ok(Event::Start(event)) if event.local_name().as_ref() == b"mergeCell" => {
-                for attribute in event.attributes() {
-                    let attribute = attribute?;
-
-                    if attribute.key == QName(b"ref") {
-                        let dimensions = get_dimension(&attribute.value)?;
-                        merge_cells.push(dimensions);
-
-                        break;
-                    }
+                if let Some(val) = event.raw_attr(b"ref")? {
+                    merge_cells.push(get_dimension(val)?);
                 }
             }
             Ok(Event::End(event)) if event.local_name().as_ref() == b"mergeCells" => {
@@ -3555,17 +3436,9 @@ fn item_tag(e: &BytesStart) -> Option<Tag> {
         _ => None,
     }
 }
-fn item_value(e: &BytesStart) -> Result<Value, AttrError> {
-    for a in e.attributes() {
-        if let Attribute {
-            key: QName(b"v"),
-            value,
-        } = a?
-        {
-            return Ok(Some(Box::from(value)));
-        }
-    }
-    Ok(None)
+
+fn item_value(e: &BytesStart) -> Result<Value, quick_xml::events::attributes::AttrError> {
+    Ok(e.raw_attr(b"v")?.map(Box::from))
 }
 
 // Get the target location of the pivot table's pivot cache definitions.
@@ -3589,21 +3462,12 @@ where
         buf.clear();
         match xml.read_event_into(&mut buf) {
             Ok(Event::Start(e)) if e.local_name().as_ref() == b"Relationship" => {
-                let mut target = String::new();
-                let mut is_pivot_cache_definitions_type = false;
-                for a in e.attributes() {
-                    match a? {
-                            Attribute {
-                                key: QName(b"Target"),
-                                value: v,
-                            } => target = xml.decoder().decode(&v)?.into_owned(),
-                            Attribute {
-                                key: QName(b"Type"),
-                                value: v,
-                            } => is_pivot_cache_definitions_type = *v == b"http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotCacheDefinition"[..],
-                            _ => (),
-                        }
-                }
+                let (target, typ) = get_attrs!(e, b"Target" => target, b"Type" => typ)?;
+                let is_pivot_cache_definitions_type = typ == Some(b"http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotCacheDefinition" as &[u8]);
+                let target = match target {
+                    Some(t) => decode_attr(&xml.decoder(), t)?,
+                    None => String::new(),
+                };
                 match (is_pivot_cache_definitions_type, definitions_path.is_some()) {
                     (true, false) => {
                         if let Some(target) = target.strip_prefix("../") {
@@ -3658,21 +3522,12 @@ where
         buf.clear();
         match xml.read_event_into(&mut buf) {
             Ok(Event::Start(e)) if e.local_name().as_ref() == b"Relationship" => {
-                let mut target = String::new();
-                let mut is_pivot_cache_record_type = false;
-                for a in e.attributes() {
-                    match a? {
-                            Attribute {
-                                key: QName(b"Target"),
-                                value: v,
-                            } => target = xml.decoder().decode(&v)?.into_owned(),
-                            Attribute {
-                                key: QName(b"Type"),
-                                value: v,
-                            } => is_pivot_cache_record_type = *v == b"http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotCacheRecords"[..],
-                            _ => (),
-                        }
-                }
+                let (target, typ) = get_attrs!(e, b"Target" => target, b"Type" => typ)?;
+                let is_pivot_cache_record_type = typ == Some(b"http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotCacheRecords" as &[u8]);
+                let target = match target {
+                    Some(t) => decode_attr(&xml.decoder(), t)?,
+                    None => String::new(),
+                };
                 match (is_pivot_cache_record_type, record_path.is_some()) {
                     (true, false) => {
                         if target.starts_with(cache_path) {
@@ -3728,22 +3583,13 @@ where
         buf.clear();
         match xml.read_event_into(&mut buf) {
             Ok(Event::Start(e)) if e.local_name().as_ref() == b"Relationship" => {
-                let mut target = String::new();
-                let mut is_pivot_table_type = false;
-                for a in e.attributes() {
-                    match a? {
-                            Attribute {
-                                key: QName(b"Target"),
-                                value: v,
-                            } => target = xml.decoder().decode(&v)?.into_owned(),
-                            Attribute {
-                                key: QName(b"Type"),
-                                value: v,
-                            } => is_pivot_table_type = *v == b"http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotTable"[..],
-                            _ => (),
-                        }
-                }
+                let (target, typ) = get_attrs!(e, b"Target" => target, b"Type" => typ)?;
+                let is_pivot_table_type = typ == Some(b"http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotTable" as &[u8]);
                 if is_pivot_table_type {
+                    let target = match target {
+                        Some(t) => decode_attr(&xml.decoder(), t)?,
+                        None => String::new(),
+                    };
                     if let Some(target) = target.strip_prefix("../") {
                         // this is an incomplete implementation, but should be good enough for excel
                         let (parent, _) = base_folder
@@ -3784,20 +3630,13 @@ where
         buf.clear();
         match xml.read_event_into(&mut buf) {
             Ok(Event::Start(e)) if e.local_name().as_ref() == b"pivotTableDefinition" => {
-                for a in e.attributes() {
-                    if let Attribute {
-                        key: QName(b"name"),
-                        value: v,
-                    } = a?
-                    {
-                        if name.is_some() {
-                            return Err(XlsxError::Unexpected(
-                                "multiple name entries for one pivot table path",
-                            ));
-                        } else {
-                            name.replace(xml.decoder().decode(&v)?.into_owned());
-                        }
+                if let Some(val) = e.raw_attr(b"name")? {
+                    if name.is_some() {
+                        return Err(XlsxError::Unexpected(
+                            "multiple name entries for one pivot table path",
+                        ));
                     }
+                    name.replace(decode_attr(&xml.decoder(), val)?);
                 }
             }
             Ok(Event::End(e)) if e.local_name().as_ref() == b"pivotTableDefinition" => break,
@@ -4056,26 +3895,14 @@ fn get_pivot_cache_iter<'a, RS: Read + Seek + 'a>(
 
             match xml.read_event_into(&mut buf) {
                 Ok(Event::Start(e)) if e.local_name().as_ref() == b"cacheField" => {
-                    for a in e.attributes() {
-                        match a? {
-                            Attribute {
-                                key: QName(b"name"),
-                                value,
-                            } => {
-                                field_names.push(xml.decoder().decode(value.as_ref())?.to_string());
-                                fields.push(vec![]);
-                            }
-                            Attribute {
-                                key: QName(b"formula"),
-                                value: _value,
-                            } => {
-                                field_names.pop();
-                                fields.pop();
-                            }
-                            _ => {
-                                // do nothing
-                            }
-                        }
+                    let (name, formula) = get_attrs!(e, b"name" => name, b"formula" => formula)?;
+                    if let Some(name) = name {
+                        field_names.push(decode_attr(&xml.decoder(), name)?);
+                        fields.push(vec![]);
+                    }
+                    if formula.is_some() {
+                        field_names.pop();
+                        fields.pop();
                     }
                 }
                 // Exclude grouped fields from results.
@@ -4150,30 +3977,25 @@ impl<'a, RS: Read + Seek + 'a> Iterator for PivotCacheIter<'a, RS> {
             buf.clear();
             match self.reader.read_event_into(&mut buf) {
                 Ok(Event::Start(e)) if e.local_name().as_ref() == b"x" => {
-                    for a in e.attributes() {
-                        if let Ok(Attribute {
-                            key: QName(b"v"),
-                            value,
-                        }) = a
-                        {
-                            let value_position = match self.reader.decoder().decode(value.as_ref())
-                            {
-                                Ok(val) => match val.parse::<usize>() {
-                                    Ok(val) => val,
-                                    Err(e) => {
-                                        return Some(Err(XlsxError::ParseInt(e)));
-                                    }
-                                },
-                                Err(e) => return Some(Err(XlsxError::Encoding(e))),
-                            };
+                    let v = match e.raw_attr(b"v") {
+                        Ok(v) => v,
+                        Err(e) => return Some(Err(e.into())),
+                    };
+                    if let Some(val) = v {
+                        let value_position = match atoi_simd::parse::<usize>(val) {
+                            Ok(val) => val,
+                            Err(_) => {
+                                return Some(Err(XlsxError::Unexpected(
+                                    "pivot cache x:v attribute must be a number",
+                                )));
+                            }
+                        };
 
-                            let column_name = &self.field_names[col_number];
-                            row.push(parse_item(
-                                &self.definitions[column_name][value_position],
-                                &self.reader.decoder(),
-                            ));
-                            break;
-                        }
+                        let column_name = &self.field_names[col_number];
+                        row.push(parse_item(
+                            &self.definitions[column_name][value_position],
+                            &self.reader.decoder(),
+                        ));
                     }
 
                     col_number += 1;
@@ -4190,10 +4012,12 @@ impl<'a, RS: Read + Seek + 'a> Iterator for PivotCacheIter<'a, RS> {
                 Err(e) => return Some(Err(XlsxError::Xml(e))),
                 Ok(Event::Start(e)) => {
                     if let Some(tag) = item_tag(&e) {
-                        if let Ok(value) = item_value(&e) {
-                            row.push(parse_item(&(tag, value), &self.reader.decoder()));
-                            col_number += 1;
-                        }
+                        let value = match item_value(&e) {
+                            Ok(value) => value,
+                            Err(e) => return Some(Err(e.into())),
+                        };
+                        row.push(parse_item(&(tag, value), &self.reader.decoder()));
+                        col_number += 1;
                     }
                 }
                 Ok(_) => {}


### PR DESCRIPTION
## Optimisation

Continuing to iterate through flamegraphs/profiling to tackle hotspots 👍

This PR replaces the `quick_xml` Attributes iterator with a custom  zero-overhead `RawAttrIter` that operates on the raw element attribute bytes and returns name/value byte-slice pairs , integrating it via trait extension and a `get_attrs!` macro. It's surprisingly straightforward, and noticeably faster.

Avoids the unnecessary (for us) per-item overhead from `Cow` and `QName` newtypes, UTF8 decoding (we only ever ask for simple ASCII keys), etc, finds all attributes in a  single pass, and stops iterating as soon as all requested attributes are identified.

## Code cleanup

A pleasant side-effect of the integration is how clean the calling code becomes; despite `attrs.rs` (where the new code lives) being ~125 lines of functional code, this PR actually _reduces_ the total amount of (non-test) code by ~100 lines. 

For example,
```rust
let mut pos_attr = None;
let mut style_attr = None;
let mut type_attr = None;
for a in c_element.attributes() {
    let a = a.map_err(XlsxError::XmlAttr)?;
    let Cow::Borrowed(val) = a.value else {
        continue;
    };
    match a.key {
        QName(b"r") => pos_attr = Some(val),
        QName(b"s") => style_attr = Some(val),
        QName(b"t") => type_attr = Some(val),
        _ => {}
    }
}
```
becomes...
```rust
let (pos_attr, style_attr, type_attr) =
    get_attrs!(c_element, b"r" => r, b"s" => s, b"t" => t);
```
...and
```rust
e.attributes()
    .filter_map(|a| a.ok())
    .find(|a| a.key == QName(b"numFmtId")).map_or(...)
```
is now just
```rust
e.raw_attr(b"numFmtId").map_or(...)
```

Also, spotted a few places that were missing entity unescaping on user-visible values like `displayName`, `tableColumn` names, and pivot field names; ensured they now go through `decode_attr`.

## Performance

* A very consistent **~16%** speedup[^1] in total reading speed for `xlsx` workbooks, across a variety of sizes.
* Tested from 10K cells all the way up to 100M cells.
  ```rust
  ┌──────────────────┬──────────────┬─────────────┬─────────────┬─────────┐
  │ file             │        cells │ master (ms) │ branch (ms) │ speedup │
  ├──────────────────┼──────────────┼─────────────┼─────────────┼─────────┤
  │ test_1000000_100 │  100,000,000 │      22,456 │      18,834 │   16.1% │
  ├──────────────────┼──────────────┼─────────────┼─────────────┼─────────┤
  │ test_100000_100  │   10,000,000 │       2,217 │       1,856 │   16.3% │
  ├──────────────────┼──────────────┼─────────────┼─────────────┼─────────┤
  │ test_10000_100   │    1,000,000 │         219 │         184 │   16.2% │
  ├──────────────────┼──────────────┼─────────────┼─────────────┼─────────┤
  │ test_10000_10    │      100,000 │        22.9 │        19.2 │   16.2% │
  ├──────────────────┼──────────────┼─────────────┼─────────────┼─────────┤
  │ test_1000_10     │       10,000 │        2.35 │        1.96 │   16.5% │
  └──────────────────┴──────────────┴─────────────┴─────────────┴─────────┘
  ```

[^1]: Benchmarked on: Apple Silicon M3 Max