### PR TITLE
lib: add RowNum and ColNum types

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -8,7 +8,7 @@ use serde::{forward_to_deserialize_any, Deserialize, Deserializer};
 use std::marker::PhantomData;
 use std::{fmt, slice, str};
 
-use super::{CellErrorType, CellType, Data, Range, Rows};
+use super::{CellErrorType, CellType, ColNum, Data, Range, RowNum, Rows};
 
 /// A cell deserialization specific error enum
 #[derive(Debug)]
@@ -16,21 +16,21 @@ pub enum DeError {
     /// Cell out of range
     CellOutOfRange {
         /// Position tried
-        try_pos: (u32, u32),
+        try_pos: (RowNum, ColNum),
         /// Minimum position
-        min_pos: (u32, u32),
+        min_pos: (RowNum, ColNum),
     },
     /// The cell value is an error
     CellError {
         /// Cell value error
         err: CellErrorType,
         /// Cell position
-        pos: (u32, u32),
+        pos: (RowNum, ColNum),
     },
     /// Unexpected end of row
     UnexpectedEndOfRow {
         /// Cell position
-        pos: (u32, u32),
+        pos: (RowNum, ColNum),
     },
     /// Required header not found
     HeaderNotFound(String),
@@ -320,8 +320,8 @@ where
     column_indexes: Vec<usize>,
     headers: Option<Vec<String>>,
     rows: Rows<'cell, T>,
-    current_pos: (u32, u32),
-    end_pos: (u32, u32),
+    current_pos: (RowNum, ColNum),
+    end_pos: (RowNum, ColNum),
     _priv: PhantomData<D>,
 }
 
@@ -426,7 +426,7 @@ struct RowDeserializer<'header, 'cell, T> {
     headers: Option<&'header [String]>,
     iter: slice::Iter<'header, usize>, // iterator over column indexes
     peek: Option<usize>,
-    pos: (u32, u32),
+    pos: (RowNum, ColNum),
 }
 
 impl<'header, 'cell, T> RowDeserializer<'header, 'cell, T>
@@ -437,7 +437,7 @@ where
         column_indexes: &'header [usize],
         headers: Option<&'header [String]>,
         cells: &'cell [T],
-        pos: (u32, u32),
+        pos: (RowNum, ColNum),
     ) -> Self {
         RowDeserializer {
             iter: column_indexes.iter(),
@@ -571,7 +571,7 @@ pub trait ToCellDeserializer<'a>: CellType {
     type Deserializer: for<'de> serde::Deserializer<'de, Error = DeError>;
 
     /// Construct a `CellType` deserializer at the specified position.
-    fn to_cell_deserializer(&'a self, pos: (u32, u32)) -> Self::Deserializer;
+    fn to_cell_deserializer(&'a self, pos: (RowNum, ColNum)) -> Self::Deserializer;
 
     /// Assess if the cell is empty.
     fn is_empty(&self) -> bool;
@@ -580,7 +580,7 @@ pub trait ToCellDeserializer<'a>: CellType {
 impl<'a> ToCellDeserializer<'a> for Data {
     type Deserializer = DataDeserializer<'a>;
 
-    fn to_cell_deserializer(&'a self, pos: (u32, u32)) -> DataDeserializer<'a> {
+    fn to_cell_deserializer(&'a self, pos: (RowNum, ColNum)) -> DataDeserializer<'a> {
         DataDeserializer {
             data_type: self,
             pos,
@@ -625,7 +625,7 @@ macro_rules! deserialize_num {
 /// A deserializer for the `Data` type.
 pub struct DataDeserializer<'a> {
     data_type: &'a Data,
-    pos: (u32, u32),
+    pos: (RowNum, ColNum),
 }
 
 impl<'a, 'de> serde::Deserializer<'de> for DataDeserializer<'a> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,6 +113,14 @@ pub use crate::xlsx::{Xlsx, XlsxError};
 
 use crate::vba::VbaProject;
 
+/// Integer type to represent a zero indexed row number. The Excel and ODS limit
+/// for rows in a worksheet is 1,048,576.
+pub type RowNum = u32;
+
+/// Integer type to represent a zero indexed column number. The Excel and ODS
+/// limit for columns in a worksheet is 16,384.
+pub type ColNum = u16;
+
 // https://msdn.microsoft.com/en-us/library/office/ff839168.aspx
 /// An enum to represent all different errors that can appear as
 /// a value in a worksheet cell
@@ -155,24 +163,24 @@ impl fmt::Display for CellErrorType {
 #[derive(Debug, Default, PartialEq, Eq, Hash, Ord, PartialOrd, Copy, Clone)]
 pub struct Dimensions {
     /// start: (row, col)
-    pub start: (u32, u32),
+    pub start: (RowNum, ColNum),
     /// end: (row, col)
-    pub end: (u32, u32),
+    pub end: (RowNum, ColNum),
 }
 
 #[allow(clippy::len_without_is_empty)]
 impl Dimensions {
     /// create dimensions info with start position and end position
-    pub fn new(start: (u32, u32), end: (u32, u32)) -> Self {
+    pub fn new(start: (RowNum, ColNum), end: (RowNum, ColNum)) -> Self {
         Self { start, end }
     }
     /// check if a position is in it
-    pub fn contains(&self, row: u32, col: u32) -> bool {
+    pub fn contains(&self, row: RowNum, col: ColNum) -> bool {
         row >= self.start.0 && row <= self.end.0 && col >= self.start.1 && col <= self.end.1
     }
     /// len
     pub fn len(&self) -> u64 {
-        (self.end.0 - self.start.0 + 1) as u64 * (self.end.1 - self.start.1 + 1) as u64
+        (self.end.0 - self.start.0 + 1) as u64 * (self.end.1 as u64 - self.start.1 as u64 + 1)
     }
 }
 
@@ -261,7 +269,7 @@ pub enum HeaderRow {
     #[default]
     FirstNonEmptyRow,
     /// Index of the header row
-    Row(u32),
+    Row(RowNum),
 }
 
 // FIXME `Reader` must only be seek `Seek` for `Xls::xls`. Because of the present API this limits
@@ -472,7 +480,7 @@ impl CellType for usize {} // for tests
 #[derive(Debug, Clone)]
 pub struct Cell<T: CellType> {
     // The position for the cell (row, column).
-    pos: (u32, u32),
+    pos: (RowNum, ColNum),
 
     // The [`CellType`] value of the cell.
     val: T,
@@ -500,7 +508,7 @@ impl<T: CellType> Cell<T> {
     /// assert_eq!(&Data::Int(42), cell.get_value());
     /// ```
     ///
-    pub fn new(position: (u32, u32), value: T) -> Cell<T> {
+    pub fn new(position: (RowNum, ColNum), value: T) -> Cell<T> {
         Cell {
             pos: position,
             val: value,
@@ -521,7 +529,7 @@ impl<T: CellType> Cell<T> {
     /// assert_eq!((1, 2), cell.get_position());
     /// ```
     ///
-    pub fn get_position(&self) -> (u32, u32) {
+    pub fn get_position(&self) -> (RowNum, ColNum) {
         self.pos
     }
 
@@ -591,8 +599,8 @@ impl<T: CellType> Cell<T> {
 ///
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct Range<T> {
-    start: (u32, u32),
-    end: (u32, u32),
+    start: (RowNum, ColNum),
+    end: (RowNum, ColNum),
     inner: Vec<T>,
 }
 
@@ -635,12 +643,15 @@ impl<T: CellType> Range<T> {
     ///
     ///
     #[inline]
-    pub fn new(start: (u32, u32), end: (u32, u32)) -> Range<T> {
+    pub fn new(start: (RowNum, ColNum), end: (RowNum, ColNum)) -> Range<T> {
         assert!(start <= end, "invalid range bounds");
         Range {
             start,
             end,
-            inner: vec![T::default(); ((end.0 - start.0 + 1) * (end.1 - start.1 + 1)) as usize],
+            inner: vec![
+                T::default();
+                (end.0 - start.0 + 1) as usize * (end.1 as usize - start.1 as usize + 1)
+            ],
         }
     }
 
@@ -691,7 +702,7 @@ impl<T: CellType> Range<T> {
     /// ```
     ///
     #[inline]
-    pub fn start(&self) -> Option<(u32, u32)> {
+    pub fn start(&self) -> Option<(RowNum, ColNum)> {
         if self.is_empty() {
             None
         } else {
@@ -719,7 +730,7 @@ impl<T: CellType> Range<T> {
     /// ```
     ///
     #[inline]
-    pub fn end(&self) -> Option<(u32, u32)> {
+    pub fn end(&self) -> Option<(RowNum, ColNum)> {
         if self.is_empty() {
             None
         } else {
@@ -855,10 +866,10 @@ impl<T: CellType> Range<T> {
         }
         // cells do not always appear in (row, col) order
         // search bounds
-        let mut row_start = u32::MAX;
-        let mut row_end = 0;
-        let mut col_start = u32::MAX;
-        let mut col_end = 0;
+        let mut row_start: RowNum = u32::MAX;
+        let mut row_end: RowNum = 0;
+        let mut col_start: ColNum = u16::MAX;
+        let mut col_end: ColNum = 0;
         for (r, c) in cells.iter().map(|c| c.pos) {
             row_start = min(r, row_start);
             row_end = max(r, row_end);
@@ -923,7 +934,7 @@ impl<T: CellType> Range<T> {
     /// assert_eq!(range.get_value((2, 1)), Some(&Data::Float(1.0)));
     /// ```
     ///
-    pub fn set_value(&mut self, absolute_position: (u32, u32), value: T) {
+    pub fn set_value(&mut self, absolute_position: (RowNum, ColNum), value: T) {
         assert!(
             self.start.0 <= absolute_position.0 && self.start.1 <= absolute_position.1,
             "absolute_position out of bounds"
@@ -1002,7 +1013,7 @@ impl<T: CellType> Range<T> {
     /// assert_eq!(range.get_value((0, 0)), None);
     /// ```
     ///
-    pub fn get_value(&self, absolute_position: (u32, u32)) -> Option<&T> {
+    pub fn get_value(&self, absolute_position: (RowNum, ColNum)) -> Option<&T> {
         let p = absolute_position;
         if p.0 >= self.start.0 && p.0 <= self.end.0 && p.1 >= self.start.1 && p.1 <= self.end.1 {
             return self.get((
@@ -1297,7 +1308,7 @@ impl<T: CellType> Range<T> {
     /// assert_eq!(c.get_value((5, 5)), Some(&Data::Empty));
     /// ```
     ///
-    pub fn range(&self, start: (u32, u32), end: (u32, u32)) -> Range<T> {
+    pub fn range(&self, start: (RowNum, ColNum), end: (RowNum, ColNum)) -> Range<T> {
         let mut other = Range::new(start, end);
         let (self_start_row, self_start_col) = self.start;
         let (self_end_row, self_end_col) = self.end;

--- a/src/ods.rs
+++ b/src/ods.rs
@@ -577,8 +577,8 @@ fn get_range<T: Default + Clone + PartialEq>(
     let row_min = row_min + first_empty_rows_repeated;
     let row_max = row_max + first_empty_rows_repeated;
     Ok(Range {
-        start: (row_min as u32, col_min as u32),
-        end: (row_max as u32, col_max as u32),
+        start: (row_min as u32, col_min as u16),
+        end: (row_max as u32, col_max as u16),
         inner: cells,
     })
 }

--- a/src/xls.rs
+++ b/src/xls.rs
@@ -449,7 +449,7 @@ impl<RS: Read + Seek> Xls<RS> {
             let records = RecordIter { stream: sh };
             let mut cells = Vec::new();
             let mut formulas = Vec::new();
-            let mut fmla_pos = (0, 0);
+            let mut fmla_pos: (u32, u16) = (0, 0);
             let mut merge_cells = Vec::new();
             for record in records {
                 let r = record?;
@@ -486,7 +486,7 @@ impl<RS: Read + Seek> Xls<RS> {
                         }
                         let row = read_u16(r.data);
                         let col = read_u16(&r.data[2..]);
-                        fmla_pos = (row as u32, col as u32);
+                        fmla_pos = (row as u32, col);
                         if let Some(val) = parse_formula_value(&r.data[6..14])? {
                             // If the value is a string
                             // it will appear in 0x0207 record coming next
@@ -670,7 +670,7 @@ fn parse_number(r: &[u8], formats: &[CellFormat], is_1904: bool) -> Result<Cell<
         });
     }
     let row = read_u16(r) as u32;
-    let col = read_u16(&r[2..]) as u32;
+    let col = read_u16(&r[2..]);
     let v = read_f64(&r[6..]);
     let format = formats.get(read_u16(&r[4..]) as usize);
 
@@ -687,7 +687,7 @@ fn parse_bool_err(r: &[u8]) -> Result<Cell<Data>, XlsError> {
     }
     let row = read_u16(r);
     let col = read_u16(&r[2..]);
-    let pos = (row as u32, col as u32);
+    let pos = (row as u32, col);
     match r[7] {
         0x00 => Ok(Cell::new(pos, Data::Bool(r[6] != 0))),
         0x01 => Ok(Cell::new(pos, parse_err(r[6])?)),
@@ -727,7 +727,7 @@ fn parse_rk(r: &[u8], formats: &[CellFormat], is_1904: bool) -> Result<Cell<Data
     let col = read_u16(&r[2..]);
 
     Ok(Cell::new(
-        (row as u32, col as u32),
+        (row as u32, col),
         rk_num(&r[4..10], formats, is_1904),
     ))
 }
@@ -744,8 +744,8 @@ fn parse_merge_cells(r: &[u8], merge_cells: &mut Vec<Dimensions>) -> Result<(), 
         let cl = read_u16(&r[offset + 6..]);
 
         merge_cells.push(Dimensions {
-            start: (rf.into(), cf.into()),
-            end: (rl.into(), cl.into()),
+            start: (rf.into(), cf),
+            end: (rl.into(), cl),
         });
     }
 
@@ -778,7 +778,7 @@ fn parse_mul_rk(
         });
     }
 
-    let mut col = col_first as u32;
+    let mut col = col_first;
 
     for rk in r[4..r.len() - 2].chunks(6) {
         cells.push(Cell::new((row as u32, col), rk_num(rk, formats, is_1904)));
@@ -875,7 +875,7 @@ fn parse_label(r: &[u8], encoding: &XlsEncoding, biff: Biff) -> Result<Cell<Data
     let col = read_u16(&r[2..]);
     let _ixfe = read_u16(&r[4..]);
     Ok(Cell::new(
-        (row as u32, col as u32),
+        (row as u32, col),
         Data::String(parse_string(&r[6..], encoding, biff)?),
     ))
 }
@@ -893,10 +893,7 @@ fn parse_label_sst(r: &[u8], strings: &[String]) -> Result<Option<Cell<Data>>, X
     let i = read_u32(&r[6..]) as usize;
     if let Some(s) = strings.get(i) {
         if !s.is_empty() {
-            return Ok(Some(Cell::new(
-                (row as u32, col as u32),
-                Data::String(s.clone()),
-            )));
+            return Ok(Some(Cell::new((row as u32, col), Data::String(s.clone()))));
         }
     }
     Ok(None)
@@ -907,14 +904,14 @@ fn parse_dimensions(r: &[u8]) -> Result<Dimensions, XlsError> {
         10 => (
             read_u16(&r[0..2]) as u32,
             read_u16(&r[2..4]) as u32,
-            read_u16(&r[4..6]) as u32,
-            read_u16(&r[6..8]) as u32,
+            read_u16(&r[4..6]),
+            read_u16(&r[6..8]),
         ),
         14 => (
             read_u32(&r[0..4]),
             read_u32(&r[4..8]),
-            read_u16(&r[8..10]) as u32,
-            read_u16(&r[10..12]) as u32,
+            read_u16(&r[8..10]),
+            read_u16(&r[10..12]),
         ),
         _ => {
             return Err(XlsError::Len {

--- a/src/xlsb/cells_reader.rs
+++ b/src/xlsb/cells_reader.rs
@@ -8,7 +8,7 @@ use crate::{
     datatype::DataRef,
     formats::{format_excel_f64_ref, CellFormat},
     utils::{read_f64, read_i32, read_u32, read_usize},
-    Cell, CellErrorType, Dimensions, XlsbError,
+    Cell, CellErrorType, ColNum, Dimensions, XlsbError,
 };
 
 use super::{cell_format, parse_formula, wide_str, RecordIter};
@@ -157,7 +157,7 @@ where
             };
             break value;
         };
-        let col = read_u32(&self.buf);
+        let col = read_u32(&self.buf) as ColNum;
         Ok(Some(Cell::new((self.row, col), value)))
     }
 
@@ -203,14 +203,14 @@ where
             };
             break value;
         };
-        let col = read_u32(&self.buf);
+        let col = read_u32(&self.buf) as ColNum;
         Ok(Some(Cell::new((self.row, col), value)))
     }
 }
 
 fn parse_dimensions(buf: &[u8]) -> Dimensions {
     Dimensions {
-        start: (read_u32(&buf[0..4]), read_u32(&buf[8..12])),
-        end: (read_u32(&buf[4..8]), read_u32(&buf[12..16])),
+        start: (read_u32(&buf[0..4]), read_u32(&buf[8..12]) as ColNum),
+        end: (read_u32(&buf[4..8]), read_u32(&buf[12..16]) as ColNum),
     }
 }

--- a/src/xlsx/cells_reader.rs
+++ b/src/xlsx/cells_reader.rs
@@ -20,10 +20,10 @@ use crate::{
     datatype::DataRef,
     formats::{format_excel_f64_ref, CellFormat},
     utils::unescape_entity_to_buffer,
-    Cell, XlsxError,
+    Cell, ColNum, RowNum, XlsxError,
 };
 
-type FormulaMap = HashMap<(u32, u32), (i64, i64)>;
+type FormulaMap = HashMap<(RowNum, ColNum), (i64, i64)>;
 
 /// Workbook-level context used when reading cell values.
 struct WorkbookContext<'a> {
@@ -59,8 +59,8 @@ where
     formats: &'a [CellFormat],
     is_1904: bool,
     dimensions: Dimensions,
-    row_index: u32,
-    col_index: u32,
+    row_index: RowNum,
+    col_index: ColNum,
     buf: Vec<u8>,
     cell_buf: Vec<u8>,
     value_bufs: ValueBufs,
@@ -248,8 +248,7 @@ where
                                     get_attribute(e.attributes(), QName(b"t"))
                                 {
                                     // shared formula
-                                    let mut offset_map: HashMap<(u32, u32), (i64, i64)> =
-                                        HashMap::new();
+                                    let mut offset_map: FormulaMap = HashMap::new();
                                     // shared index
                                     let shared_index =
                                         match get_attribute(e.attributes(), QName(b"si"))? {

--- a/src/xlsx/mod.rs
+++ b/src/xlsx/mod.rs
@@ -29,8 +29,8 @@ use crate::utils::{
 };
 use crate::vba::VbaProject;
 use crate::{
-    Cell, CellErrorType, Data, Dimensions, HeaderRow, Metadata, Range, Reader, ReaderRef, Sheet,
-    SheetType, SheetVisible, Table,
+    Cell, CellErrorType, ColNum, Data, Dimensions, HeaderRow, Metadata, Range, Reader, ReaderRef,
+    RowNum, Sheet, SheetType, SheetVisible, Table,
 };
 pub use cells_reader::XlsxCellReader;
 
@@ -1814,7 +1814,7 @@ pub(crate) fn get_dimension(dimension: &[u8]) -> Result<Dimensions, XlsxError> {
         }),
         2 => {
             let rows = parts[1].0 - parts[0].0;
-            let columns = parts[1].1 - parts[0].1;
+            let columns = parts[1].1 as u32 - parts[0].1 as u32;
             if rows > MAX_ROWS {
                 warn!("xlsx has more than maximum number of rows ({rows} > {MAX_ROWS})");
             }
@@ -1832,7 +1832,7 @@ pub(crate) fn get_dimension(dimension: &[u8]) -> Result<Dimensions, XlsxError> {
 
 /// Converts a text range name into its position (row, column) (0 based index).
 /// If the row or column component in the range is missing, an Error is returned.
-pub(crate) fn get_row_column(range: &[u8]) -> Result<(u32, u32), XlsxError> {
+pub(crate) fn get_row_column(range: &[u8]) -> Result<(RowNum, ColNum), XlsxError> {
     let (row, col) = get_row_and_optional_column(range)?;
     let col = col.ok_or(XlsxError::RangeWithoutColumnComponent)?;
     Ok((row, col))
@@ -1841,14 +1841,14 @@ pub(crate) fn get_row_column(range: &[u8]) -> Result<(u32, u32), XlsxError> {
 /// Converts a text row name into its position (0 based index).
 /// If the row component in the range is missing, an Error is returned.
 /// If the text row name also contains a column component, it is ignored.
-pub(crate) fn get_row(range: &[u8]) -> Result<u32, XlsxError> {
+pub(crate) fn get_row(range: &[u8]) -> Result<RowNum, XlsxError> {
     get_row_and_optional_column(range).map(|(row, _)| row)
 }
 
 /// Converts a text-based range name into its `(row, column)` position (0-based index).
 /// If the column component of the range is missing, a None is returned (for the column).
 /// If the row component of the range is missing, an Error is returned.
-fn get_row_and_optional_column(range: &[u8]) -> Result<(u32, Option<u32>), XlsxError> {
+fn get_row_and_optional_column(range: &[u8]) -> Result<(RowNum, Option<ColNum>), XlsxError> {
     let len = range.len();
     let mut i = 0;
 
@@ -1884,7 +1884,7 @@ fn get_row_and_optional_column(range: &[u8]) -> Result<(u32, Option<u32>), XlsxE
     let row = row
         .checked_sub(1)
         .ok_or(XlsxError::RangeWithoutRowComponent)?;
-    Ok((row, col.checked_sub(1)))
+    Ok((row, col.checked_sub(1).map(|c| c as ColNum)))
 }
 
 /// Attempts to read either a simple or richtext string, reusing caller-provided

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1976,7 +1976,7 @@ fn non_monotonic_si_shared_formula() {
     for (row_idx, row) in expected_formulas.iter().enumerate() {
         for (col_idx, expected_formula) in row.iter().enumerate() {
             assert_eq!(
-                formula.get_value((row_idx as u32 + 1, col_idx as u32)),
+                formula.get_value((row_idx as u32 + 1, col_idx as u16)),
                 Some(&expected_formula.to_string())
             );
         }
@@ -1994,7 +1994,7 @@ fn issue_565_multi_axis_shared_formula() {
     for (row_idx, row) in expected_formulas.iter().enumerate() {
         for (col_idx, expected_formula) in row.iter().enumerate() {
             assert_eq!(
-                formula.get_value((row_idx as u32, col_idx as u32)),
+                formula.get_value((row_idx as u32, col_idx as u16)),
                 Some(&expected_formula.to_string())
             );
         }
@@ -2044,7 +2044,7 @@ fn issue_567_absolute_shared_formula() {
     for (row_idx, row) in expected_formulas.iter().enumerate() {
         for (col_idx, expected_formula) in row.iter().enumerate() {
             assert_eq!(
-                formula.get_value((row_idx as u32, col_idx as u32)),
+                formula.get_value((row_idx as u32, col_idx as u16)),
                 Some(&expected_formula.to_string())
             );
         }
@@ -2070,7 +2070,7 @@ fn column_row_ranges() {
     for (row_idx, row) in expected_formulas.iter().enumerate() {
         for (col_idx, expected_formula) in row.iter().enumerate() {
             assert_eq!(
-                formula.get_value((row_idx as u32, col_idx as u32)),
+                formula.get_value((row_idx as u32, col_idx as u16)),
                 Some(&expected_formula.to_string()),
                 "Column ranges mismatch at ({}, {})",
                 row_idx,
@@ -2091,7 +2091,7 @@ fn column_row_ranges() {
     for (row_idx, row) in expected_formulas.iter().enumerate() {
         for (col_idx, expected_formula) in row.iter().enumerate() {
             assert_eq!(
-                formula.get_value((row_idx as u32, col_idx as u32)),
+                formula.get_value((row_idx as u32, col_idx as u16)),
                 Some(&expected_formula.to_string()),
                 "Row ranges mismatch at ({}, {})",
                 row_idx,
@@ -2224,8 +2224,8 @@ fn test_ref_xlsb() {
 fn test_header_row_xlsx(
     #[case] fixture_path: &str,
     #[case] header_row: HeaderRow,
-    #[case] expected_start: (u32, u32),
-    #[case] expected_end: (u32, u32),
+    #[case] expected_start: (u32, u16),
+    #[case] expected_end: (u32, u16),
     #[case] expected_first_row: &[Data],
     #[case] expected_total_cells: usize,
 ) {


### PR DESCRIPTION
Replaced various row and column `(u32, u32)` instances with type aliases `RowNum` and `ColNum` which are `(u32, u16)`. This makes the API types self documenting and helps avoid row/column mistakes internally.

This is in response to feature request #625. I implemented it mainly to see what would be  required to do this. I don't have a strong desire to add this but on balance it does improve the documentation and also may make the internals a little clearer.