### PR TITLE
lib: expose 1900/1904 epoch for xls/xlsx/xlsb files

### DIFF
--- a/src/xls.rs
+++ b/src/xls.rs
@@ -230,6 +230,27 @@ impl<RS: Read + Seek> Xls<RS> {
 
         self.worksheet_merge_cells(&sheet.name)
     }
+
+    /// Check if the workbook uses the 1904 date system.
+    ///
+    /// Returns `true` if the workbook uses the 1904 date epoch (used by some older
+    /// Mac versions of Excel), or `false` if it uses the standard 1900 date epoch.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use calamine::{open_workbook, Error, Xls};
+    ///
+    /// fn main() -> Result<(), Error> {
+    ///     let workbook: Xls<_> = open_workbook("tests/date_1904.xls")?;
+    ///     let is_1904 = workbook.has_1904_epoch();
+    ///     println!("Uses 1904 date system: {}", is_1904);
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn has_1904_epoch(&self) -> bool {
+        self.is_1904
+    }
 }
 
 impl<RS: Read + Seek> Reader<RS> for Xls<RS> {

--- a/src/xlsb/mod.rs
+++ b/src/xlsb/mod.rs
@@ -415,6 +415,27 @@ impl<RS: Read + Seek> Xlsb<RS> {
         }
     }
 
+    /// Check if the workbook uses the 1904 date system.
+    ///
+    /// Returns `true` if the workbook uses the 1904 date epoch (used by some older
+    /// Mac versions of Excel), or `false` if it uses the standard 1900 date epoch.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use calamine::{open_workbook, Error, Xlsb};
+    ///
+    /// fn main() -> Result<(), Error> {
+    ///     let workbook: Xlsb<_> = open_workbook("tests/date_1904.xlsb")?;
+    ///     let is_1904 = workbook.has_1904_epoch();
+    ///     println!("Uses 1904 date system: {}", is_1904);
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn has_1904_epoch(&self) -> bool {
+        self.is_1904
+    }
+
     /// Get a cells reader for a given worksheet
     pub fn worksheet_cells_reader<'a>(
         &'a mut self,

--- a/src/xlsx/mod.rs
+++ b/src/xlsx/mod.rs
@@ -737,6 +737,27 @@ impl<RS: Read + Seek> Xlsx<RS> {
         Ok(())
     }
 
+    /// Check if the workbook uses the 1904 date system.
+    ///
+    /// Returns `true` if the workbook uses the 1904 date epoch (used by some older
+    /// Mac versions of Excel), or `false` if it uses the standard 1900 date epoch.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use calamine::{open_workbook, Error, Xlsx};
+    ///
+    /// fn main() -> Result<(), Error> {
+    ///     let workbook: Xlsx<_> = open_workbook("tests/date_1904.xlsx")?;
+    ///     let is_1904 = workbook.has_1904_epoch();
+    ///     println!("Uses 1904 date system: {}", is_1904);
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn has_1904_epoch(&self) -> bool {
+        self.is_1904
+    }
+
     /// Get all Pivot Tables in a workbook.
     ///
     /// # Note

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -823,6 +823,7 @@ fn table_by_ref() {
 #[test]
 fn date_xls() {
     let mut xls: Xls<_> = wb("date.xls");
+    assert!(!xls.has_1904_epoch());
     let range = xls.worksheet_range_at(0).unwrap().unwrap();
 
     assert_eq!(
@@ -858,6 +859,7 @@ fn date_xls() {
 #[test]
 fn date_xls_1904() {
     let mut xls: Xls<_> = wb("date_1904.xls");
+    assert!(xls.has_1904_epoch());
     let range = xls.worksheet_range_at(0).unwrap().unwrap();
 
     assert_eq!(
@@ -893,6 +895,7 @@ fn date_xls_1904() {
 #[test]
 fn date_xlsx() {
     let mut xls: Xlsx<_> = wb("date.xlsx");
+    assert!(!xls.has_1904_epoch());
     let range = xls.worksheet_range_at(0).unwrap().unwrap();
 
     assert_eq!(
@@ -928,6 +931,7 @@ fn date_xlsx() {
 #[test]
 fn date_xlsx_1904() {
     let mut xls: Xlsx<_> = wb("date_1904.xlsx");
+    assert!(xls.has_1904_epoch());
     let range = xls.worksheet_range_at(0).unwrap().unwrap();
 
     assert_eq!(
@@ -1051,6 +1055,7 @@ fn date_ods() {
 #[test]
 fn date_xlsb() {
     let mut xls: Xlsb<_> = wb("date.xlsb");
+    assert!(!xls.has_1904_epoch());
     let range = xls.worksheet_range_at(0).unwrap().unwrap();
 
     assert_eq!(
@@ -1086,6 +1091,7 @@ fn date_xlsb() {
 #[test]
 fn date_xlsb_1904() {
     let mut xls: Xlsb<_> = wb("date_1904.xlsb");
+    assert!(xls.has_1904_epoch());
     let range = xls.worksheet_range_at(0).unwrap().unwrap();
 
     assert_eq!(


### PR DESCRIPTION
Add `has_1904_epoch()` method to Xls/Xlsx/Xlsb structs to allow the user to determine which date epoch is in use by Excel.

Feature request #629

You can now do something like this:

```rust
use calamine::{open_workbook, Error, Xlsx};

fn main() -> Result<(), Error> {
    let workbook: Xlsx<_> = open_workbook("tests/date_1904.xlsx")?;

    // Check if the workbook uses the 1904 date system.
    if workbook.has_1904_epoch() {
        println!("This workbook uses the 1904 date epoch.");
    } else {
        println!("This workbook uses the standard 1900 date epoch.");
    }

    Ok(())
}
```


You can test it by adding the GitHub repo to your `Cargo.toml` file:

```
cargo add --git https://github.com/jmcnamara/calamine.git --branch has_1904_epoch calamine
```


