### PR TITLE
xls: mask fRwRel/fColRel flag bits in PtgArea/PtgArea3d column reads

### DIFF
--- a/src/xls.rs
+++ b/src/xls.rs
@@ -1322,11 +1322,11 @@ fn parse_formula(
                 stack.push(formula.len());
                 formula.push_str(sheets.get(ixti as usize).map_or("#REF", |s| &**s));
                 formula.push('!');
-                // TODO: check with relative columns
+                // mask off fRwRel/fColRel flag bits (RgceArea: bits 14/15 of each col)
                 formula.push('$');
-                push_column(read_u16(&rgce[6..8]) as u32, &mut formula);
+                push_column((read_u16(&rgce[6..8]) & 0x3FFF) as u32, &mut formula);
                 write!(&mut formula, "${}:$", read_u16(&rgce[2..4]) as u32 + 1).unwrap();
-                push_column(read_u16(&rgce[8..10]) as u32, &mut formula);
+                push_column((read_u16(&rgce[8..10]) & 0x3FFF) as u32, &mut formula);
                 write!(&mut formula, "${}", read_u16(&rgce[4..6]) as u32 + 1).unwrap();
                 rgce = &rgce[10..];
             }
@@ -1560,10 +1560,11 @@ fn parse_formula(
             }
             0x25 | 0x45 | 0x65 => {
                 stack.push(formula.len());
+                // mask off fRwRel/fColRel flag bits (RgceArea: bits 14/15 of each col)
                 formula.push('$');
-                push_column(read_u16(&rgce[4..6]) as u32, &mut formula);
+                push_column((read_u16(&rgce[4..6]) & 0x3FFF) as u32, &mut formula);
                 write!(&mut formula, "${}:$", read_u16(&rgce[0..2]) as u32 + 1).unwrap();
-                push_column(read_u16(&rgce[6..8]) as u32, &mut formula);
+                push_column((read_u16(&rgce[6..8]) & 0x3FFF) as u32, &mut formula);
                 write!(&mut formula, "${}", read_u16(&rgce[2..4]) as u32 + 1).unwrap();
                 rgce = &rgce[8..];
             }


### PR DESCRIPTION
The BIFF8 `RgceArea` / `RgceArea3d` structures encode each column as a u16 where bits 0–13 are the column index and bits 14/15 are `fColRel`/`fRwRel` ([MS-XLS 2.5.198.7](https://learn.microsoft.com/en-us/openspecs/office_file_formats/ms-xls/cb39f0e1-fb3e-4f90-8cca-7156828d40e1)).

The `PtgRef` (0x24) handler already masks the high byte with `0x3F`, but `PtgArea` (0x25) and `PtgArea3d` (0x3B) in `parse_formula` push the raw u16 to `push_column`. As a result any relative range reference — e.g. `=SUM(B2:B3)` saved by Excel — decompiles to garbage column letters (`$USN$2:$USN$3`, since 0xC001 → column 49153).

This masks with `0x3FFF` on the four column reads, matching the existing handling for `PtgRef` and the BIFF12 `PtgArea3d` branch which already does this.

I've kept the patch minimal — emitting `B2` vs `$B$2` based on the flag bits would be nicer but the existing code always emits absolute, so that's left as-is.