### PR TITLE
Refactor the APIs/code for merge cells/range handling

### DIFF
--- a/src/xls.rs
+++ b/src/xls.rs
@@ -219,16 +219,157 @@ impl<RS: Read + Seek> Xls<RS> {
     }
 
     /// Gets the worksheet merge cell dimensions
+    #[doc(hidden)]
+    #[deprecated(
+        since = "0.36.0",
+        note = "use `merge_cells_by_sheet_name()` or `merge_cells_by_sheet_id()` instead"
+    )]
     pub fn worksheet_merge_cells(&self, name: &str) -> Option<Vec<Dimensions>> {
         self.sheets.get(name).map(|r| r.merge_cells.clone())
     }
 
     /// Get the nth worksheet. Shortcut for getting the nth
     /// sheet name, then the corresponding worksheet.
+    #[doc(hidden)]
+    #[deprecated(
+        since = "0.36.0",
+        note = "use `merge_cells_by_sheet_name()` or `merge_cells_by_sheet_id()` instead"
+    )]
     pub fn worksheet_merge_cells_at(&self, n: usize) -> Option<Vec<Dimensions>> {
         let sheet = self.metadata().sheets.get(n)?;
 
+        #[allow(deprecated)]
         self.worksheet_merge_cells(&sheet.name)
+    }
+
+    /// Get the merged cells/regions in a worksheet by sheet name.
+    ///
+    /// Merged cells in Excel are a range of cells that have been merged to act
+    /// as a single cell. It is often used to create headers or titles that span
+    /// multiple columns or rows.
+    ///
+    /// The function returns a vector of [`Dimensions`] for the merged cells in
+    /// the named worksheet.
+    ///
+    /// Note: unlike the equivalent [`crate::Xlsx`] method, this method takes
+    /// `&self` because XLS data is fully parsed at construction time and held
+    /// in memory.
+    ///
+    /// # Parameters
+    ///
+    /// - `name`: The name of the worksheet.
+    ///
+    /// # Errors
+    ///
+    /// - [`XlsError::WorksheetNotFound`] if no worksheet with the given name
+    ///   exists.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use calamine::{open_workbook, Error, Reader, Xls};
+    ///
+    /// fn main() -> Result<(), Error> {
+    ///     let path = "tests/merge_cells.xls";
+    ///
+    ///     // Open the workbook.
+    ///     let workbook: Xls<_> = open_workbook(path)?;
+    ///
+    ///     // Get the names of all the sheets in the workbook.
+    ///     let sheet_names = workbook.sheet_names();
+    ///
+    ///     for sheet_name in &sheet_names {
+    ///         println!("{sheet_name}:");
+    ///
+    ///         // Get the merged cells in the current sheet.
+    ///         let merge_cells = workbook.merge_cells_by_sheet_name(sheet_name)?;
+    ///
+    ///         // Print the dimensions of each merged region.
+    ///         for dimension in &merge_cells {
+    ///             println!("    {dimension:?}");
+    ///         }
+    ///     }
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
+    ///
+    /// Output:
+    ///
+    /// ```text
+    /// Dimensions { start: (0, 0), end: (0, 1) }
+    /// Dimensions { start: (1, 0), end: (3, 0) }
+    /// Dimensions { start: (1, 1), end: (3, 3) }
+    /// ```
+    ///
+    pub fn merge_cells_by_sheet_name(&self, name: &str) -> Result<Vec<Dimensions>, XlsError> {
+        self.sheets
+            .get(name)
+            .map(|r| r.merge_cells.clone())
+            .ok_or_else(|| XlsError::WorksheetNotFound(name.into()))
+    }
+
+    /// Get the merged cells/regions in a worksheet by sheet index.
+    ///
+    /// Merged cells in Excel are a range of cells that have been merged to act
+    /// as a single cell. It is often used to create headers or titles that span
+    /// multiple columns or rows.
+    ///
+    /// The function returns a vector of [`Dimensions`] for the merged cells in
+    /// the worksheet at the given index.
+    ///
+    /// Note: unlike the equivalent [`crate::Xlsx`] method, this method takes
+    /// `&self` because XLS data is fully parsed at construction time and held
+    /// in memory.
+    ///
+    /// # Parameters
+    ///
+    /// - `id`: The zero-based index of the worksheet.
+    ///
+    /// # Errors
+    ///
+    /// - [`XlsError::WorksheetNotFound`] if `id` is out of range.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use calamine::{open_workbook, Error, Xls};
+    ///
+    /// fn main() -> Result<(), Error> {
+    ///     let path = "tests/merge_cells.xls";
+    ///
+    ///     // Open the workbook.
+    ///     let workbook: Xls<_> = open_workbook(path)?;
+    ///
+    ///     // Get the merged cells in the first worksheet.
+    ///     let merge_cells = workbook.merge_cells_by_sheet_id(0)?;
+    ///
+    ///     // Print the dimensions of each merged region.
+    ///     for dimension in &merge_cells {
+    ///         println!("{dimension:?}");
+    ///     }
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
+    ///
+    /// Output:
+    ///
+    /// ```text
+    /// Dimensions { start: (0, 0), end: (0, 1) }
+    /// Dimensions { start: (1, 0), end: (3, 0) }
+    /// Dimensions { start: (1, 1), end: (3, 3) }
+    /// ```
+    ///
+    pub fn merge_cells_by_sheet_id(&self, id: usize) -> Result<Vec<Dimensions>, XlsError> {
+        let name = self
+            .metadata()
+            .sheets
+            .get(id)
+            .map(|sheet| sheet.name.clone())
+            .ok_or_else(|| XlsError::WorksheetNotFound(format!("Sheet index {id} out of range")))?;
+
+        self.merge_cells_by_sheet_name(&name)
     }
 
     /// Check if the workbook uses the 1904 date system.

--- a/src/xlsx/mod.rs
+++ b/src/xlsx/mod.rs
@@ -921,6 +921,11 @@ impl<RS: Read + Seek> Xlsx<RS> {
     ///
     /// - [`XlsxError::Xml`].
     ///
+    #[doc(hidden)]
+    #[deprecated(
+        since = "0.36.0",
+        note = "use `merge_cells_by_sheet_name()` or `merge_cells_by_sheet_id()` instead"
+    )]
     pub fn load_merged_regions(&mut self) -> Result<(), XlsxError> {
         if self.merged_regions.is_none() {
             self.read_merged_regions()
@@ -987,6 +992,11 @@ impl<RS: Read + Seek> Xlsx<RS> {
     /// Sheet2: Dimensions { start: (0, 4), end: (1, 4) }
     /// ```
     ///
+    #[doc(hidden)]
+    #[deprecated(
+        since = "0.36.0",
+        note = "use `merge_cells_by_sheet_name()` or `merge_cells_by_sheet_id()` instead"
+    )]
     pub fn merged_regions(&self) -> &Vec<(String, String, Dimensions)> {
         self.merged_regions
             .as_ref()
@@ -1066,7 +1076,13 @@ impl<RS: Read + Seek> Xlsx<RS> {
     ///     Dimensions { start: (0, 4), end: (1, 4) }
     /// ```
     ///
+    #[doc(hidden)]
+    #[deprecated(
+        since = "0.36.0",
+        note = "use `merge_cells_by_sheet_name()` or `merge_cells_by_sheet_id()` instead"
+    )]
     pub fn merged_regions_by_sheet(&self, name: &str) -> Vec<(&String, &String, &Dimensions)> {
+        #[allow(deprecated)]
         self.merged_regions()
             .iter()
             .filter(|s| s.0 == name)
@@ -1447,6 +1463,8 @@ impl<RS: Read + Seek> Xlsx<RS> {
     ///     Dimensions { start: (0, 4), end: (1, 4) }
     /// ```
     ///
+    #[doc(hidden)]
+    #[deprecated(since = "0.36.0", note = "use `merge_cells_by_sheet_name()` instead")]
     pub fn worksheet_merge_cells(
         &mut self,
         name: &str,
@@ -1543,6 +1561,8 @@ impl<RS: Read + Seek> Xlsx<RS> {
     /// Dimensions { start: (0, 6), end: (1, 6) }
     /// ```
     ///
+    #[doc(hidden)]
+    #[deprecated(since = "0.36.0", note = "use `merge_cells_by_sheet_id()` instead")]
     pub fn worksheet_merge_cells_at(
         &mut self,
         sheet_index: usize,
@@ -1553,7 +1573,184 @@ impl<RS: Read + Seek> Xlsx<RS> {
             .get(sheet_index)
             .map(|sheet| sheet.name.clone())?;
 
+        #[allow(deprecated)]
         self.worksheet_merge_cells(&name)
+    }
+
+    /// Get the merged cells/regions in a worksheet by sheet name.
+    ///
+    /// Merged cells in Excel are a range of cells that have been merged to act
+    /// as a single cell. It is often used to create headers or titles that span
+    /// multiple columns or rows.
+    ///
+    /// The function returns a vector of [`Dimensions`] for the merged cells in
+    /// the named worksheet.
+    ///
+    /// # Parameters
+    ///
+    /// - `name`: The name of the worksheet.
+    ///
+    /// # Errors
+    ///
+    /// - [`XlsxError::WorksheetNotFound`] if no worksheet with the given name
+    ///   exists.
+    /// - [`XlsxError::Xml`] if the worksheet XML cannot be parsed.
+    ///
+    /// # Examples
+    ///
+    /// An example of getting the merged cells in an Excel workbook by sheet
+    /// name.
+    ///
+    /// ```
+    /// use calamine::{open_workbook, Error, Reader, Xlsx};
+    ///
+    /// fn main() -> Result<(), Error> {
+    ///     let path = "tests/merged_range.xlsx";
+    ///
+    ///     // Open the workbook.
+    ///     let mut workbook: Xlsx<_> = open_workbook(path)?;
+    ///
+    ///     // Get the names of all the sheets in the workbook.
+    ///     let sheet_names = workbook.sheet_names();
+    ///
+    ///     for sheet_name in &sheet_names {
+    ///         println!("{sheet_name}:");
+    ///
+    ///         // Get the merged cells in the current sheet.
+    ///         let merge_cells = workbook.merge_cells_by_sheet_name(sheet_name)?;
+    ///
+    ///         // Print the dimensions of each merged region.
+    ///         for dimension in &merge_cells {
+    ///             println!("    {dimension:?}");
+    ///         }
+    ///     }
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
+    ///
+    /// Output:
+    ///
+    /// ```text
+    /// Sheet1:
+    ///     Dimensions { start: (0, 7), end: (1, 7) }
+    ///     Dimensions { start: (0, 0), end: (1, 0) }
+    ///     Dimensions { start: (0, 1), end: (1, 1) }
+    ///     Dimensions { start: (0, 2), end: (1, 3) }
+    ///     Dimensions { start: (2, 2), end: (2, 3) }
+    ///     Dimensions { start: (3, 2), end: (3, 3) }
+    ///     Dimensions { start: (0, 4), end: (1, 4) }
+    ///     Dimensions { start: (0, 5), end: (1, 5) }
+    ///     Dimensions { start: (0, 6), end: (1, 6) }
+    /// Sheet2:
+    ///     Dimensions { start: (0, 0), end: (3, 0) }
+    ///     Dimensions { start: (2, 2), end: (3, 3) }
+    ///     Dimensions { start: (0, 5), end: (3, 7) }
+    ///     Dimensions { start: (0, 1), end: (1, 1) }
+    ///     Dimensions { start: (0, 2), end: (1, 3) }
+    ///     Dimensions { start: (0, 4), end: (1, 4) }
+    /// ```
+    ///
+    pub fn merge_cells_by_sheet_name(&mut self, name: &str) -> Result<Vec<Dimensions>, XlsxError> {
+        let (_, path) = self
+            .sheets
+            .iter()
+            .find(|(n, _)| n == name)
+            .ok_or_else(|| XlsxError::WorksheetNotFound(name.into()))?;
+
+        let xml = xml_reader(&mut self.zip, path, &self.zip_path_cache)
+            .ok_or_else(|| XlsxError::WorksheetNotFound(name.into()))?;
+
+        let mut xml = xml?;
+        let mut merge_cells = Vec::new();
+        let mut buffer = Vec::new();
+
+        loop {
+            buffer.clear();
+
+            match xml.read_event_into(&mut buffer) {
+                Ok(Event::Start(event)) if event.local_name().as_ref() == b"mergeCells" => {
+                    merge_cells = read_merge_cells(&mut xml)?;
+                    break;
+                }
+                Ok(Event::Eof) => break,
+                Err(e) => return Err(XlsxError::Xml(e)),
+                _ => (),
+            }
+        }
+
+        Ok(merge_cells)
+    }
+
+    /// Get the merged cells/regions in a worksheet by sheet index.
+    ///
+    /// Merged cells in Excel are a range of cells that have been merged to act
+    /// as a single cell. It is often used to create headers or titles that span
+    /// multiple columns or rows.
+    ///
+    /// The function returns a vector of [`Dimensions`] for the merged cells in
+    /// the worksheet at the given index.
+    ///
+    /// # Parameters
+    ///
+    /// - `id`: The zero-based index of the worksheet.
+    ///
+    /// # Errors
+    ///
+    /// - [`XlsxError::WorksheetNotFound`] if `id` is out of range.
+    /// - [`XlsxError::Xml`] if the worksheet XML cannot be parsed.
+    ///
+    /// # Examples
+    ///
+    /// An example of getting the merged cells in an Excel workbook by sheet
+    /// index.
+    ///
+    /// ```
+    /// use calamine::{open_workbook, Error, Xlsx};
+    ///
+    /// fn main() -> Result<(), Error> {
+    ///     let path = "tests/merged_range.xlsx";
+    ///
+    ///     // Open the workbook.
+    ///     let mut workbook: Xlsx<_> = open_workbook(path)?;
+    ///
+    ///     // Get the merged cells in the first worksheet.
+    ///     let merge_cells = workbook.merge_cells_by_sheet_id(0)?;
+    ///
+    ///     // Print the dimensions of each merged region.
+    ///     for dimension in &merge_cells {
+    ///         println!("{dimension:?}");
+    ///     }
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
+    ///
+    /// Output:
+    ///
+    /// ```text
+    /// Dimensions { start: (0, 7), end: (1, 7) }
+    /// Dimensions { start: (0, 0), end: (1, 0) }
+    /// Dimensions { start: (0, 1), end: (1, 1) }
+    /// Dimensions { start: (0, 2), end: (1, 3) }
+    /// Dimensions { start: (2, 2), end: (2, 3) }
+    /// Dimensions { start: (3, 2), end: (3, 3) }
+    /// Dimensions { start: (0, 4), end: (1, 4) }
+    /// Dimensions { start: (0, 5), end: (1, 5) }
+    /// Dimensions { start: (0, 6), end: (1, 6) }
+    /// ```
+    ///
+    pub fn merge_cells_by_sheet_id(&mut self, id: usize) -> Result<Vec<Dimensions>, XlsxError> {
+        let name = self
+            .metadata()
+            .sheets
+            .get(id)
+            .map(|sheet| sheet.name.clone())
+            .ok_or_else(|| {
+                XlsxError::WorksheetNotFound(format!("Sheet index {id} out of range"))
+            })?;
+
+        self.merge_cells_by_sheet_name(&name)
     }
 }
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1145,6 +1145,7 @@ fn issue_221() {
 }
 
 #[test]
+#[allow(deprecated)]
 fn merged_regions_xlsx() {
     use calamine::Dimensions;
     use std::string::String;
@@ -1436,6 +1437,7 @@ fn issue_271() -> Result<(), calamine::Error> {
 }
 
 #[test]
+#[allow(deprecated)]
 fn issue_305_merge_cells() {
     let mut excel: Xlsx<_> = wb("merge_cells.xlsx");
     let merge_cells = excel.worksheet_merge_cells_at(0).unwrap().unwrap();
@@ -1448,6 +1450,70 @@ fn issue_305_merge_cells() {
             Dimensions::new((1, 1), (3, 3))
         ]
     );
+}
+
+#[test]
+fn merge_cells_by_sheet_name_xlsx() {
+    let mut excel: Xlsx<_> = wb("merge_cells.xlsx");
+    let merge_cells = excel.merge_cells_by_sheet_name("Sheet1").unwrap();
+
+    assert_eq!(
+        merge_cells,
+        [
+            Dimensions::new((0, 0), (0, 1)),
+            Dimensions::new((1, 0), (3, 0)),
+            Dimensions::new((1, 1), (3, 3))
+        ]
+    );
+}
+
+#[test]
+fn merge_cells_by_sheet_id_xlsx() {
+    let mut excel: Xlsx<_> = wb("merge_cells.xlsx");
+    let merge_cells = excel.merge_cells_by_sheet_id(0).unwrap();
+
+    assert_eq!(
+        merge_cells,
+        [
+            Dimensions::new((0, 0), (0, 1)),
+            Dimensions::new((1, 0), (3, 0)),
+            Dimensions::new((1, 1), (3, 3))
+        ]
+    );
+}
+
+#[test]
+fn merge_cells_by_sheet_name_not_found() {
+    let mut excel: Xlsx<_> = wb("merge_cells.xlsx");
+    assert!(excel.merge_cells_by_sheet_name("NoSuchSheet").is_err());
+}
+
+#[test]
+fn merge_cells_by_sheet_id_out_of_range() {
+    let mut excel: Xlsx<_> = wb("merge_cells.xlsx");
+    assert!(excel.merge_cells_by_sheet_id(99).is_err());
+}
+
+#[test]
+fn merge_cells_all_sheets_by_name() {
+    use calamine::Dimensions;
+    use std::collections::BTreeSet;
+    let mut excel: Xlsx<_> = wb("merged_range.xlsx");
+    let sheet_names = excel.sheet_names();
+
+    let all: BTreeSet<(std::string::String, Dimensions)> = sheet_names
+        .iter()
+        .flat_map(|name| {
+            excel
+                .merge_cells_by_sheet_name(name)
+                .unwrap()
+                .into_iter()
+                .map(|d| (name.clone(), d))
+                .collect::<Vec<(std::string::String, Dimensions)>>()
+        })
+        .collect();
+
+    assert_eq!(all.len(), 15); // 9 in Sheet1 + 6 in Sheet2.
 }
 
 #[test]

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1517,6 +1517,7 @@ fn merge_cells_all_sheets_by_name() {
 }
 
 #[test]
+#[allow(deprecated)]
 fn issue_305_merge_cells_xls() {
     let excel: Xls<_> = wb("merge_cells.xls");
     let merge_cells = excel.worksheet_merge_cells_at(0).unwrap();
@@ -1529,6 +1530,48 @@ fn issue_305_merge_cells_xls() {
             Dimensions::new((1, 1), (3, 3))
         ]
     );
+}
+
+#[test]
+fn merge_cells_by_sheet_name_xls() {
+    let excel: Xls<_> = wb("merge_cells.xls");
+    let merge_cells = excel.merge_cells_by_sheet_name("Sheet1").unwrap();
+
+    assert_eq!(
+        merge_cells,
+        [
+            Dimensions::new((0, 0), (0, 1)),
+            Dimensions::new((1, 0), (3, 0)),
+            Dimensions::new((1, 1), (3, 3))
+        ]
+    );
+}
+
+#[test]
+fn merge_cells_by_sheet_id_xls() {
+    let excel: Xls<_> = wb("merge_cells.xls");
+    let merge_cells = excel.merge_cells_by_sheet_id(0).unwrap();
+
+    assert_eq!(
+        merge_cells,
+        [
+            Dimensions::new((0, 0), (0, 1)),
+            Dimensions::new((1, 0), (3, 0)),
+            Dimensions::new((1, 1), (3, 3))
+        ]
+    );
+}
+
+#[test]
+fn merge_cells_by_sheet_name_not_found_xls() {
+    let excel: Xls<_> = wb("merge_cells.xls");
+    assert!(excel.merge_cells_by_sheet_name("NoSuchSheet").is_err());
+}
+
+#[test]
+fn merge_cells_by_sheet_id_out_of_range_xls() {
+    let excel: Xls<_> = wb("merge_cells.xls");
+    assert!(excel.merge_cells_by_sheet_id(99).is_err());
 }
 
 #[cfg(feature = "picture")]


### PR DESCRIPTION
For historical reasons there was duplication of the methods for accessing merged cells in XLSX worksheets.
    
This change introduces a cleaner API and deprecates the existing APIs.
    
See the full explanation at #536

This change also has a commit to change the XLS merge cell handling (which didn't have duplication) to be the same as the XLSX APIs