### PR TITLE
perf: optimise buffer use for XLSB cell reads

### DIFF
--- a/src/xlsb/cells_reader.rs
+++ b/src/xlsb/cells_reader.rs
@@ -87,7 +87,6 @@ where
     pub fn next_cell(&mut self) -> Result<Option<Cell<DataRef<'a>>>, XlsbError> {
         // loop until end of sheet
         let value = loop {
-            self.buf.clear();
             self.typ = self.iter.read_type()?;
             let _ = self.iter.fill_buffer(&mut self.buf)?;
             let value = match self.typ {


### PR DESCRIPTION
One line update 😄 

As this is on the hottest of hot paths, dropping the unnecessary buffer `.clear()` nets roughly an 8-10% speedup for XLSB reads. This is because `fill_buffer` grows the buffer with `resize(len, 0)`, so clearing first means `memset` explicitly zeroes every byte in the buffer immediately before the read overwrites them (so the zeroing is unnecessary work).

Now `next_cell` matches `next_formula`, which also doesn't explicitly clear the buffer up-front.