### PR TITLE
Handle the `*` fill operator in custom number format detection

### DIFF
--- a/src/formats.rs
+++ b/src/formats.rs
@@ -22,7 +22,12 @@ pub fn detect_custom_number_format(format: &str) -> CellFormat {
     for s in format.chars() {
         match (s, escaped, is_quote, ap, brackets) {
             (_, true, ..) => escaped = false, // if escaped, ignore
-            ('_' | '\\', ..) => escaped = true,
+            // `\` escapes, `_` skips a character's width, and `*` repeats the
+            // next character to fill the cell. In all three cases the following
+            // character is a literal, not a format token, so it must be ignored
+            // (otherwise a fill/skip char such as `d`, `m` or `y` is mistaken
+            // for a date token and a numeric cell is reported as a date).
+            ('_' | '\\' | '*', ..) => escaped = true,
             ('"', _, true, _, _) => is_quote = false,
             (_, _, true, _, _) => (),
             ('"', _, _, _, _) => is_quote = true,
@@ -217,5 +222,16 @@ fn test_is_date_format() {
     assert_eq!(
         detect_custom_number_format("#,##0.00\\ _M\"H\"_);[Red]#,##0.00\\ _M\"S\"_)"),
         CellFormat::Other
+    );
+    // The `*` fill operator repeats the next character to fill the cell, so
+    // that character is a literal and must not be read as a date token even
+    // when it happens to be one (here `y`, `d`, `m`).
+    assert_eq!(detect_custom_number_format("#,##0*y"), CellFormat::Other);
+    assert_eq!(detect_custom_number_format("0\"x\"*d"), CellFormat::Other);
+    assert_eq!(detect_custom_number_format("*-#,##0"), CellFormat::Other);
+    // A real date token after the single fill char is still detected.
+    assert_eq!(
+        detect_custom_number_format("*-yyyy-mm-dd"),
+        CellFormat::DateTime
     );
 }

--- a/src/formats.rs
+++ b/src/formats.rs
@@ -22,11 +22,7 @@ pub fn detect_custom_number_format(format: &str) -> CellFormat {
     for s in format.chars() {
         match (s, escaped, is_quote, ap, brackets) {
             (_, true, ..) => escaped = false, // if escaped, ignore
-            // `\` escapes, `_` skips a character's width, and `*` repeats the
-            // next character to fill the cell. In all three cases the following
-            // character is a literal, not a format token, so it must be ignored
-            // (otherwise a fill/skip char such as `d`, `m` or `y` is mistaken
-            // for a date token and a numeric cell is reported as a date).
+            // `\` escapes, `_` skips width, `*` fills; the next char is always a literal, not a format token.
             ('_' | '\\' | '*', ..) => escaped = true,
             ('"', _, true, _, _) => is_quote = false,
             (_, _, true, _, _) => (),


### PR DESCRIPTION
`detect_custom_number_format` (`src/formats.rs`) — the number-format classifier shared by xlsx, xlsb and xls — treats `\` and `_` as "escape the next char" but does not handle Excel's `*` fill operator. With `*c`, the character after `*` is a literal used to pad the cell, so a numeric format whose fill char is a date letter, e.g. `#,##0*y`, is misread as `DateTime` and a number cell is reported as a date.

This sits in the same `match` that #665 just hardened for quote handling; `*` was the remaining unhandled case. The fix adds `'*'` to the existing escape arm.

Verified both ways: `#,##0*y` returns `DateTime` before the fix and `Other` after; `*-yyyy-mm-dd` still correctly returns `DateTime`. All 24 existing format tests are unchanged and `cargo test --lib` passes 42/42.