### PR TITLE
More informative error if the file is very short

### DIFF
--- a/src/cfb.rs
+++ b/src/cfb.rs
@@ -49,11 +49,13 @@ impl std::fmt::Display for CfbError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             CfbError::Io(e) => write!(f, "I/O error: {e}"),
-            CfbError::Ole { len, magic } if *len < 512 => write!(
-                f,
-                "Invalid CFB file ({len} bytes is too small), magic: {:x?}",
-                &magic[..8.min(*len)]
-            ),
+            CfbError::Ole { len, magic } if *len < 512 => {
+                write!(f, "Invalid CFB file ({len} bytes is too small), magic: ",)?;
+                for b in &magic[..8.min(*len)] {
+                    write!(f, "\\x{b:02x?}")?;
+                }
+                Ok(())
+            }
             CfbError::Ole { magic, .. } => write!(
                 f,
                 "Invalid OLE signature (not an office document?) {magic:x?}"

--- a/src/cfb.rs
+++ b/src/cfb.rs
@@ -26,7 +26,7 @@ pub enum CfbError {
     Io(std::io::Error),
     Ole {
         len: usize,
-        magic: [u8; 8],
+        signature: Option<[u8; 8]>,
     },
     EmptyRootDir,
     StreamNotFound(String),
@@ -49,17 +49,23 @@ impl std::fmt::Display for CfbError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             CfbError::Io(e) => write!(f, "I/O error: {e}"),
-            CfbError::Ole { len, magic } if *len < 512 => {
-                write!(f, "Invalid CFB file ({len} bytes is too small), magic: ",)?;
-                for b in &magic[..8.min(*len)] {
-                    write!(f, "\\x{b:02x?}")?;
+            CfbError::Ole { len, signature } => {
+                write!(f, "Invalid OLE (",)?;
+                if *len < 512 {
+                    write!(f, "{len} bytes is too small")?;
                 }
-                Ok(())
+                if let Some(signature) = signature {
+                    if *len < 512 {
+                        write!(f, ", ")?;
+                    }
+                    write!(f, "signature ")?;
+                    for b in &signature[..8.min(*len)] {
+                        write!(f, "\\x{b:02x?}")?;
+                    }
+                    write!(f, " invalid, not an office document?")?;
+                }
+                write!(f, ")")
             }
-            CfbError::Ole { magic, .. } => write!(
-                f,
-                "Invalid OLE signature (not an office document?) {magic:x?}"
-            ),
             CfbError::EmptyRootDir => write!(f, "Empty Root directory"),
             CfbError::StreamNotFound(e) => write!(f, "Cannot find {e} stream"),
             CfbError::Invalid {
@@ -207,15 +213,13 @@ impl Header {
             n += k;
         }
         let [m0, m1, m2, m3, m4, m5, m6, m7, ..] = buf;
-        let magic = [m0, m1, m2, m3, m4, m5, m6, m7];
-        if n < buf.len() {
-            return Err(CfbError::Ole { len: n, magic });
-        }
-
         // check ole signature
-        let signature = u64::from_le_bytes(magic);
-        if signature != 0xE11A_B1A1_E011_CFD0 {
-            return Err(CfbError::Ole { len: n, magic });
+        let signature = [m0, m1, m2, m3, m4, m5, m6, m7];
+        if n < buf.len() || signature != *b"\xD0\xCF\x11\xE0\xA1\xB1\x1A\xE1" {
+            return Err(CfbError::Ole {
+                len: n,
+                signature: (signature != *b"\xD0\xCF\x11\xE0\xA1\xB1\x1A\xE1").then_some(signature),
+            });
         }
 
         let version = read_u16(&buf[26..28]);

--- a/src/cfb.rs
+++ b/src/cfb.rs
@@ -24,7 +24,10 @@ const ENDOFCHAIN: u32 = 0xFFFF_FFFE;
 #[derive(Debug)]
 pub enum CfbError {
     Io(std::io::Error),
-    Ole,
+    Ole {
+        len: usize,
+        magic: [u8; 8],
+    },
     EmptyRootDir,
     StreamNotFound(String),
     Invalid {
@@ -46,7 +49,15 @@ impl std::fmt::Display for CfbError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             CfbError::Io(e) => write!(f, "I/O error: {e}"),
-            CfbError::Ole => write!(f, "Invalid OLE signature (not an office document?)"),
+            CfbError::Ole { len, magic } if *len < 512 => write!(
+                f,
+                "Invalid CFB file ({len} bytes is too small), magic: {:x?}",
+                &magic[..8.min(*len)]
+            ),
+            CfbError::Ole { magic, .. } => write!(
+                f,
+                "Invalid OLE signature (not an office document?) {magic:x?}"
+            ),
             CfbError::EmptyRootDir => write!(f, "Empty Root directory"),
             CfbError::StreamNotFound(e) => write!(f, "Cannot find {e} stream"),
             CfbError::Invalid {
@@ -184,15 +195,25 @@ enum SectorSize {
 
 impl Header {
     fn from_reader<R: Read>(f: &mut R) -> Result<(Header, Vec<u32>), CfbError> {
+        let mut n = 0;
         let mut buf = [0u8; 512];
-        f.read_exact(&mut buf)?;
+        loop {
+            let k = f.read(&mut buf[n..])?;
+            if k == 0 {
+                break;
+            }
+            n += k;
+        }
+        let [m0, m1, m2, m3, m4, m5, m6, m7, ..] = buf;
+        let magic = [m0, m1, m2, m3, m4, m5, m6, m7];
+        if n < buf.len() {
+            return Err(CfbError::Ole { len: n, magic });
+        }
 
         // check ole signature
-        let signature = buf
-            .get(0..8)
-            .map(|slice| u64::from_le_bytes(slice.try_into().unwrap()));
-        if signature != Some(0xE11A_B1A1_E011_CFD0) {
-            return Err(CfbError::Ole);
+        let signature = u64::from_le_bytes(magic);
+        if signature != 0xE11A_B1A1_E011_CFD0 {
+            return Err(CfbError::Ole { len: n, magic });
         }
 
         let version = read_u16(&buf[26..28]);

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -3479,7 +3479,8 @@ fn too_small_xls() {
     let path = test_path("too_small.xls");
     let res: Result<Xls<_>, _> = open_workbook(&path);
     match res {
-        Err(calamine::XlsError::Cfb(e)) if e.to_string() == "Invalid CFB file (68 bytes is too small), magic: \\x41\\x74\\x74\\x61\\x63\\x68\\x6d\\x65" => {}
+
+        Err(calamine::XlsError::Cfb(e)) if e.to_string() == "Invalid OLE (68 bytes is too small, signature \\x41\\x74\\x74\\x61\\x63\\x68\\x6d\\x65 invalid, not an office document?)" => {}
         Err(calamine::XlsError::Cfb(e)) => {
             panic!("Is expected to return CfbError::Ole(_) error: {e}")
         }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -3479,7 +3479,7 @@ fn too_small_xls() {
     let path = test_path("too_small.xls");
     let res: Result<Xls<_>, _> = open_workbook(&path);
     match res {
-        Err(calamine::XlsError::Cfb(e)) if e.to_string() == "Invalid CFB file (68 bytes is too small), magic: [41, 74, 74, 61, 63, 68, 6d, 65]" => {}
+        Err(calamine::XlsError::Cfb(e)) if e.to_string() == "Invalid CFB file (68 bytes is too small), magic: \\x41\\x74\\x74\\x61\\x63\\x68\\x6d\\x65" => {}
         Err(calamine::XlsError::Cfb(e)) => {
             panic!("Is expected to return CfbError::Ole(_) error: {e}")
         }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -3473,3 +3473,16 @@ fn test_hyperlinks_xlsx() {
         Err(calamine::XlsxError::WorksheetNotFound(_))
     ));
 }
+
+#[test]
+fn too_small_xls() {
+    let path = test_path("too_small.xls");
+    let res: Result<Xls<_>, _> = open_workbook(&path);
+    match res {
+        Err(calamine::XlsError::Cfb(e)) if e.to_string() == "Invalid CFB file (68 bytes is too small), magic: [41, 74, 74, 61, 63, 68, 6d, 65]" => {}
+        Err(calamine::XlsError::Cfb(e)) => {
+            panic!("Is expected to return CfbError::Ole(_) error: {e}")
+        }
+        Ok(_) | Err(_) => panic!("Is expected to return CfbError::Ole(_) error"),
+    }
+}

--- a/tests/too_small.xls
+++ b/tests/too_small.xls
@@ -1,0 +1,1 @@
+Attachment f:\attachcus\arnold-j\Summer trading shots.xls not found!


### PR DESCRIPTION
If the file is very short, the error path will be triggered on an `fn read_exact` call, leaving an uninformative IO error, although it is probably better to hint that the file is invalid xls.