### PR TITLE
deps: bump atoi_simd 0.17 to 0.18; quick-xml 0.39 to 0.41; zip from 7.0 to 8.6; MSRV from 1.83 to 1.88

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         toolchain:
-          - "1.83"  # MSRV.
+          - "1.88"  # MSRV.
           - stable
           - beta
           - nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,12 +17,12 @@ rust-version = "1.83" # For quick-xml + encoding_rs.
 log = "0.4"
 serde = "1.0"
 codepage = "0.1"
-atoi_simd = "0.17"
+atoi_simd = "0.18"
 byteorder = "1.5"
 encoding_rs = "0.8"
 fast-float2 = "0.2"
 zip = { version = "7.0", default-features = false, features = ["deflate"] }
-quick-xml = { version = "0.39", features = ["encoding"] }
+quick-xml = { version = "0.41", features = ["encoding"] }
 
 # Optional dependencies.
 chrono = { version = "0.4", features = ["serde"], optional = true, default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ atoi_simd = "0.18"
 byteorder = "1.5"
 encoding_rs = "0.8"
 fast-float2 = "0.2"
-zip = { version = "7.0", default-features = false, features = ["deflate"] }
+zip = { version = "8.6", default-features = false, features = ["deflate"] }
 quick-xml = { version = "0.41", features = ["encoding"] }
 
 # Optional dependencies.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["excel", "ods", "xls", "xlsx", "xlsb"]
 categories = ["encoding", "parsing", "text-processing"]
 exclude = ["tests/**/*"]
 edition = "2021"
-rust-version = "1.83" # For quick-xml + encoding_rs.
+rust-version = "1.88" # For zip
 
 [dependencies]
 log = "0.4"

--- a/src/datatype.rs
+++ b/src/datatype.rs
@@ -969,7 +969,7 @@ impl ExcelDateTime {
 
     // Check if a year is a leap year.
     fn is_leap_year(year: u64) -> bool {
-        year % 4 == 0 && (year % 100 != 0 || year % 400 == 0)
+        year.is_multiple_of(4) && (!year.is_multiple_of(100) || year.is_multiple_of(400))
     }
 }
 

--- a/src/datatype.rs
+++ b/src/datatype.rs
@@ -161,7 +161,7 @@ impl DataType for Data {
             Data::Int(v) => Some(*v),
             Data::Float(v) => Some(*v as i64),
             Data::Bool(v) => Some(*v as i64),
-            Data::String(v) => atoi_simd::parse::<i64>(v.as_bytes()).ok(),
+            Data::String(v) => atoi_simd::parse::<i64, true, false>(v.as_bytes()).ok(),
             _ => None,
         }
     }
@@ -473,8 +473,8 @@ impl DataType for DataRef<'_> {
             DataRef::Int(v) => Some(*v),
             DataRef::Float(v) => Some(*v as i64),
             DataRef::Bool(v) => Some(*v as i64),
-            DataRef::String(v) => atoi_simd::parse::<i64>(v.as_bytes()).ok(),
-            DataRef::SharedString(v) => atoi_simd::parse::<i64>(v.as_bytes()).ok(),
+            DataRef::String(v) => atoi_simd::parse::<i64, true, false>(v.as_bytes()).ok(),
+            DataRef::SharedString(v) => atoi_simd::parse::<i64, true, false>(v.as_bytes()).ok(),
             _ => None,
         }
     }

--- a/src/xlsx/cells_reader.rs
+++ b/src/xlsx/cells_reader.rs
@@ -326,7 +326,7 @@ where
         let (t_attr, si_attr, ref_attr) = get_attrs!(e, b"t" => t, b"si" => si, b"ref" => ref_)?;
         if t_attr == Some(b"shared".as_slice()) {
             let shared_index = match si_attr {
-                Some(res) => match atoi_simd::parse::<usize>(res) {
+                Some(res) => match atoi_simd::parse::<usize, true, false>(res) {
                     Ok(res) => res,
                     Err(_) => return Err(XlsxError::Unexpected("si attribute must be a number")),
                 },
@@ -630,7 +630,7 @@ fn read_v<'s>(
 ) -> Result<DataRef<'s>, XlsxError> {
     let cell_format = match style_attr {
         Some(style) => {
-            let id = atoi_simd::parse::<usize>(style).unwrap_or(0);
+            let id = atoi_simd::parse::<usize, true, false>(style).unwrap_or(0);
             ctx.formats.get(id)
         }
         None => Some(&CellFormat::Other),
@@ -640,7 +640,7 @@ fn read_v<'s>(
             if v.is_empty() {
                 return Ok(DataRef::Empty);
             }
-            let idx = atoi_simd::parse::<usize>(v).unwrap_or(0);
+            let idx = atoi_simd::parse::<usize, true, false>(v).unwrap_or(0);
             ctx.strings
                 .get(idx)
                 .map(|s| DataRef::SharedString(s))

--- a/src/xlsx/mod.rs
+++ b/src/xlsx/mod.rs
@@ -347,7 +347,7 @@ impl<RS: Read + Seek> Xlsx<RS> {
             match xml.read_event_into(&mut buf) {
                 Ok(Event::Start(e)) if e.local_name().as_ref() == b"sst" => {
                     if let Some(count) = e.raw_attr(b"uniqueCount")? {
-                        if let Ok(n) = atoi_simd::parse::<usize>(count) {
+                        if let Ok(n) = atoi_simd::parse::<usize, true, false>(count) {
                             self.strings.reserve(n);
                         }
                     }
@@ -1079,12 +1079,12 @@ impl<RS: Read + Seek> Xlsx<RS> {
                 match xml.read_event_into(&mut buf) {
                     Ok(Event::Start(e)) if e.local_name().as_ref() == b"row" => {
                         if let Some(r) = e.raw_attr(b"r")? {
-                            current_row = atoi_simd::parse::<u32>(r).unwrap_or(1) - 1;
+                            current_row = atoi_simd::parse::<u32, true, false>(r).unwrap_or(1) - 1;
                         }
                     }
                     Ok(Event::Start(e)) if e.local_name().as_ref() == b"c" => {
                         let (vm, r) = get_attrs!(e, b"vm" => vm, b"r" => r)?;
-                        let vm = vm.and_then(|v| atoi_simd::parse::<usize>(v).ok());
+                        let vm = vm.and_then(|v| atoi_simd::parse::<usize, true, false>(v).ok());
                         if let Some(vm_val) = vm {
                             let rv_idx = vm_val.saturating_sub(1);
                             if let Some(&img_idx) = rv_to_img_idx.get(&rv_idx) {
@@ -3636,7 +3636,7 @@ fn parse_item(item: &(Tag, Value), decoder: &Decoder) -> Data {
 // Parse failures are handled with None and left to `Self::parse_item` to address.
 fn bytes_to_i64(val: &[u8], decoder: &Decoder) -> Option<i64> {
     if let Ok(val) = decoder.decode(val) {
-        atoi_simd::parse::<i64>(val.as_bytes()).ok()
+        atoi_simd::parse::<i64, true, false>(val.as_bytes()).ok()
     } else {
         None
     }
@@ -3916,7 +3916,7 @@ impl<'a, RS: Read + Seek + 'a> Iterator for PivotCacheIter<'a, RS> {
                         Err(e) => return Some(Err(e.into())),
                     };
                     if let Some(val) = v {
-                        let value_position = match atoi_simd::parse::<usize>(val) {
+                        let value_position = match atoi_simd::parse::<usize, true, false>(val) {
                             Ok(val) => val,
                             Err(_) => {
                                 return Some(Err(XlsxError::Unexpected(


### PR DESCRIPTION
atoi_simd 0.18 makes `parse` generic over two const params, `SKIP_ZEROES` and `SKIP_PLUS`, so all call sites need them supplied.

See https://github.com/RoDmitry/atoi_simd/issues/14

For quick-xml, resolves:
* RUSTSEC-2026-0194 https://rustsec.org/advisories/RUSTSEC-2026-0194.html
* RUSTSEC-2026-0195: https://rustsec.org/advisories/RUSTSEC-2026-0195.html

For zip, we're several versions behind - https://github.com/zip-rs/zip2/blob/master/CHANGELOG.md

Bumped MSRV from 1.83 to 1.88 for zip 8.6

Applied clippy::manual_is_multiple_of lint to make CI happy