### PR TITLE
example: fix cargo test warning for read_picture_data example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,11 @@ criterion = { version = "0.7", features = ["html_reports"] }
 name = "basic"
 harness = false
 
+# Example that requires the `picture` feature.
+[[example]]
+name = "read_picture_data"
+required-features = ["picture"]
+
 [features]
 default = []
 


### PR DESCRIPTION
The `read_picture_data.rs` example requires the "picture" feature flag to be enabled. This fix identifies that requirement in the `Cargo.toml` file in order to suppress the `cargo test` warning for the file when testing
without the "picture" feature flag.