### PR TITLE
Expose ExcelDateTime::is_1904 via a public getter

### DIFF
--- a/src/datatype.rs
+++ b/src/datatype.rs
@@ -727,6 +727,12 @@ impl ExcelDateTime {
         self.value
     }
 
+    /// True if the workbook uses the 1904 date system, false for the 1900
+    /// date system
+    pub fn is_1904(&self) -> bool {
+        self.is_1904
+    }
+
     /// Convert an Excel serial datetime to standard date components.
     ///
     /// Datetimes in Excel are serial dates with days counted from an epoch


### PR DESCRIPTION
ExcelDateTime carries the workbook's date system (1900 vs 1904 epoch), but the flag was private with no accessor. Consumers that serialize or convert cell values outside the crate (e.g. gRPC/protobuf contracts) need the epoch to interpret the raw serial value losslessly.

Add a public is_1904() accessor alongside the existing is_duration(), is_datetime() and as_f64() getters. No behavior change.