### PR TITLE
Add a `shared_strings()` accessor on `Xlsx` and `Xlsb`

### DIFF
--- a/src/xlsb/mod.rs
+++ b/src/xlsb/mod.rs
@@ -419,30 +419,7 @@ impl<RS: Read + Seek> Xlsb<RS> {
     }
 
     /// Get the workbook's shared-strings table.
-    ///
-    /// XLSB files store every distinct cell string once, in a shared-strings
-    /// table, and cells reference entries by index. The table is resolved when
-    /// the workbook is opened, and each
-    /// [`DataRef::SharedString`](crate::DataRef::SharedString) borrows from
-    /// one of its entries. Exposing the table lets consumers that re-serialize
-    /// cells, such as a server streaming a worksheet over RPC, send each
-    /// string once and reference it by index instead of repeating string
-    /// bodies per cell.
-    ///
-    /// The table can be empty: workbooks that only use inline strings do not
-    /// have one.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use calamine::{open_workbook, Error, Xlsb};
-    ///
-    /// fn main() -> Result<(), Error> {
-    ///     let workbook: Xlsb<_> = open_workbook("tests/date_1904.xlsb")?;
-    ///     println!("{} distinct strings", workbook.shared_strings().len());
-    ///     Ok(())
-    /// }
-    /// ```
+    #[doc(hidden)]
     pub fn shared_strings(&self) -> &[String] {
         &self.strings
     }

--- a/src/xlsb/mod.rs
+++ b/src/xlsb/mod.rs
@@ -418,6 +418,35 @@ impl<RS: Read + Seek> Xlsb<RS> {
         self.is_1904
     }
 
+    /// Get the workbook's shared-strings table.
+    ///
+    /// XLSB files store every distinct cell string once, in a shared-strings
+    /// table, and cells reference entries by index. The table is resolved when
+    /// the workbook is opened, and each
+    /// [`DataRef::SharedString`](crate::DataRef::SharedString) borrows from
+    /// one of its entries. Exposing the table lets consumers that re-serialize
+    /// cells, such as a server streaming a worksheet over RPC, send each
+    /// string once and reference it by index instead of repeating string
+    /// bodies per cell.
+    ///
+    /// The table can be empty: workbooks that only use inline strings do not
+    /// have one.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use calamine::{open_workbook, Error, Xlsb};
+    ///
+    /// fn main() -> Result<(), Error> {
+    ///     let workbook: Xlsb<_> = open_workbook("tests/date_1904.xlsb")?;
+    ///     println!("{} distinct strings", workbook.shared_strings().len());
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn shared_strings(&self) -> &[String] {
+        &self.strings
+    }
+
     /// Get a cells reader for a given worksheet
     pub fn worksheet_cells_reader<'a>(
         &'a mut self,

--- a/src/xlsx/mod.rs
+++ b/src/xlsx/mod.rs
@@ -1141,6 +1141,35 @@ impl<RS: Read + Seek> Xlsx<RS> {
         self.is_1904
     }
 
+    /// Get the workbook's shared-strings table.
+    ///
+    /// XLSX files store every distinct cell string once, in a shared-strings
+    /// table, and cells reference entries by index. The table is resolved when
+    /// the workbook is opened, and each
+    /// [`DataRef::SharedString`](crate::DataRef::SharedString) borrows from
+    /// one of its entries. Exposing the table lets consumers that re-serialize
+    /// cells, such as a server streaming a worksheet over RPC, send each
+    /// string once and reference it by index instead of repeating string
+    /// bodies per cell.
+    ///
+    /// The table can be empty: workbooks that only use inline strings do not
+    /// have one.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use calamine::{open_workbook, Error, Xlsx};
+    ///
+    /// fn main() -> Result<(), Error> {
+    ///     let workbook: Xlsx<_> = open_workbook("tests/issues.xlsx")?;
+    ///     println!("{} distinct strings", workbook.shared_strings().len());
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn shared_strings(&self) -> &[String] {
+        &self.strings
+    }
+
     /// Get all Pivot Tables in a workbook.
     ///
     /// # Note

--- a/src/xlsx/mod.rs
+++ b/src/xlsx/mod.rs
@@ -1142,30 +1142,7 @@ impl<RS: Read + Seek> Xlsx<RS> {
     }
 
     /// Get the workbook's shared-strings table.
-    ///
-    /// XLSX files store every distinct cell string once, in a shared-strings
-    /// table, and cells reference entries by index. The table is resolved when
-    /// the workbook is opened, and each
-    /// [`DataRef::SharedString`](crate::DataRef::SharedString) borrows from
-    /// one of its entries. Exposing the table lets consumers that re-serialize
-    /// cells, such as a server streaming a worksheet over RPC, send each
-    /// string once and reference it by index instead of repeating string
-    /// bodies per cell.
-    ///
-    /// The table can be empty: workbooks that only use inline strings do not
-    /// have one.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use calamine::{open_workbook, Error, Xlsx};
-    ///
-    /// fn main() -> Result<(), Error> {
-    ///     let workbook: Xlsx<_> = open_workbook("tests/issues.xlsx")?;
-    ///     println!("{} distinct strings", workbook.shared_strings().len());
-    ///     Ok(())
-    /// }
-    /// ```
+    #[doc(hidden)]
     pub fn shared_strings(&self) -> &[String] {
         &self.strings
     }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -3616,3 +3616,39 @@ fn xls_empty_string() {
     let range = wb.worksheet_range("Sheet1").unwrap();
     assert_eq!(range.get_value((0, 0)), Some(&String("".to_string())));
 }
+
+#[test]
+fn test_xlsx_shared_strings() {
+    let mut excel: Xlsx<_> = wb("issues.xlsx");
+    let table = excel.shared_strings().to_vec();
+    assert!(!table.is_empty());
+    let mut seen = 0;
+    for name in excel.sheet_names() {
+        let range = excel.worksheet_range_ref(&name).unwrap();
+        for (_, _, cell) in range.used_cells() {
+            if let DataRef::SharedString(s) = cell {
+                assert!(table.iter().any(|t| t == s), "{s:?} not in the table");
+                seen += 1;
+            }
+        }
+    }
+    assert!(seen > 0);
+}
+
+#[test]
+fn test_xlsb_shared_strings() {
+    let mut excel: Xlsb<_> = wb("issues.xlsb");
+    let table = excel.shared_strings().to_vec();
+    assert!(!table.is_empty());
+    let mut seen = 0;
+    for name in excel.sheet_names() {
+        let range = excel.worksheet_range_ref(&name).unwrap();
+        for (_, _, cell) in range.used_cells() {
+            if let DataRef::SharedString(s) = cell {
+                assert!(table.iter().any(|t| t == s), "{s:?} not in the table");
+                seen += 1;
+            }
+        }
+    }
+    assert!(seen > 0);
+}


### PR DESCRIPTION
This PR is made to speed up remote calls using a method Apache Arrow uses to shrink structures pinned by heavy serialization.

With the accessor below, a remote gRPC client can dictionary-encode calamine's string cells; the test results below show a transfer savings of 4.6x (12.7x with zstd on top) while streaming a 105.7 MB workbook over 10 GbE as fast as calamine parses it in-process.

The savings hold for any client language: a Python client transfers the same 62 MB instead of 789 MB for that workbook, and on loopback the gRPC stream into Python already runs at python-calamine speed (4.8 s vs 5.6 s).

So I made the same run against the NYC 311 data the calamine README benchmarks with: it cuts the transfer 6.4x. Charts and full captures are in [grpc-calamine]'s [bench].

The change is a public accessor for the resolved shared-strings table, `pub fn shared_strings(&self) -> &[String]` on `Xlsx` and `Xlsb`, with doc examples and tests checking that every `DataRef::SharedString` borrow resolves into the table. An index-preserving `DataRef::SharedStringIndex(u32)` cell variant was the other option considered; the accessor is the smaller API surface.

Calamine's reader already resolves each cell's sst index (`xlsx/cells_reader.rs:643` in 0.36.0) and discards it, so a streaming consumer today has to re-intern every resolved borrow that streams past in order to rebuild a table calamine is already holding in memory. The accessor seems like the most direct route, but let me know if there's a better one.

## Measurements

Dictionary mode is an opt-in flag in [grpc-calamine], built today on the interning workaround; the accessor would remove the table rebuild, about a second of CPU on a million-row workbook. Every mode feeds the same order-sensitive digest, so no mode wins by dropping data. On the NYC file (the README's CSV converted with LibreOffice into the same 186 MB xlsx) the full row stream is 662 MB plain, 301 MB with the dictionary, and 104 MB with zstd on top; the 105.7 MB workbook goes 789, 173, and 62 MB. Total CPU lands slightly below the plain stream because neither side copies string bodies per cell.

![Bytes on the socket per mode, both datasets](https://raw.githubusercontent.com/ai-pipestream/grpc-calamine/main/bench/charts/wire-bytes.svg?v=2)

[grpc-calamine]: https://github.com/ai-pipestream/grpc-calamine
[bench]: https://github.com/ai-pipestream/grpc-calamine/blob/main/bench/RESULTS.md
