### PR TITLE
xlsx: normalise reversed dimension refs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,21 +169,18 @@ pub struct Dimensions {
 
 #[allow(clippy::len_without_is_empty)]
 impl Dimensions {
-    /// create dimensions info with start position and end position
-    ///
-    /// The corners may be given in either order; they are stored so that
-    /// `start <= end` on both axes.
+    /// Create a `Dimensions` instance with start and end cell positions.
     pub fn new(start: (u32, u32), end: (u32, u32)) -> Self {
         Self {
             start: (start.0.min(end.0), start.1.min(end.1)),
             end: (start.0.max(end.0), start.1.max(end.1)),
         }
     }
-    /// check if a position is in it
+    /// Check if a cell position is within the `Dimensions` range.
     pub fn contains(&self, row: u32, col: u32) -> bool {
         row >= self.start.0 && row <= self.end.0 && col >= self.start.1 && col <= self.end.1
     }
-    /// len
+    /// Get the `len()` of the `Dimensions` range, which is equivalent to the cell area.
     pub fn len(&self) -> u64 {
         // Widened before the `+ 1` so a full-width axis cannot overflow.
         (u64::from(self.end.0 - self.start.0) + 1) * (u64::from(self.end.1 - self.start.1) + 1)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -170,8 +170,14 @@ pub struct Dimensions {
 #[allow(clippy::len_without_is_empty)]
 impl Dimensions {
     /// create dimensions info with start position and end position
+    ///
+    /// The corners may be given in either order; they are stored so that
+    /// `start <= end` on both axes.
     pub fn new(start: (u32, u32), end: (u32, u32)) -> Self {
-        Self { start, end }
+        Self {
+            start: (start.0.min(end.0), start.1.min(end.1)),
+            end: (start.0.max(end.0), start.1.max(end.1)),
+        }
     }
     /// check if a position is in it
     pub fn contains(&self, row: u32, col: u32) -> bool {
@@ -179,7 +185,8 @@ impl Dimensions {
     }
     /// len
     pub fn len(&self) -> u64 {
-        (self.end.0 - self.start.0 + 1) as u64 * (self.end.1 - self.start.1 + 1) as u64
+        // Widened before the `+ 1` so a full-width axis cannot overflow.
+        (u64::from(self.end.0 - self.start.0) + 1) * (u64::from(self.end.1 - self.start.1) + 1)
     }
 }
 

--- a/src/xlsx/mod.rs
+++ b/src/xlsx/mod.rs
@@ -2789,18 +2789,21 @@ pub(crate) fn get_dimension(dimension: &[u8]) -> Result<Dimensions, XlsxError> {
             end: parts[0],
         }),
         2 => {
-            let rows = parts[1].0 - parts[0].0;
-            let columns = parts[1].1 - parts[0].1;
-            if rows > MAX_ROWS {
-                warn!("xlsx has more than maximum number of rows ({rows} > {MAX_ROWS})");
+            // The `ref` may be in reversed order like `C5:A1`.
+            let dim = Dimensions::new(parts[0], parts[1]);
+            if dim.end.0 > MAX_ROWS {
+                warn!(
+                    "xlsx has more than maximum number of rows ({} > {MAX_ROWS})",
+                    dim.end.0
+                );
             }
-            if columns > MAX_COLUMNS {
-                warn!("xlsx has more than maximum number of columns ({columns} > {MAX_COLUMNS})");
+            if dim.end.1 > MAX_COLUMNS {
+                warn!(
+                    "xlsx has more than maximum number of columns ({} > {MAX_COLUMNS})",
+                    dim.end.1
+                );
             }
-            Ok(Dimensions {
-                start: parts[0],
-                end: parts[1],
-            })
+            Ok(dim)
         }
         len => Err(XlsxError::DimensionCount(len)),
     }
@@ -4008,6 +4011,48 @@ mod tests {
             get_dimension(b"A1:XFD1048576").unwrap().len(),
             17_179_869_184
         );
+    }
+
+    #[test]
+    fn test_reversed_dimension_is_normalised() {
+        // A reversed `ref` such as `C5:A1` gives the same `Dimensions` as `A1:C5`.
+        let reversed = get_dimension(b"C5:A1").unwrap();
+        assert_eq!(
+            reversed,
+            Dimensions {
+                start: (0, 0),
+                end: (4, 2),
+            }
+        );
+        assert_eq!(reversed, get_dimension(b"A1:C5").unwrap());
+        assert_eq!(reversed.len(), 15);
+
+        // Reversed on one axis only.
+        assert_eq!(
+            get_dimension(b"A5:C1").unwrap(),
+            get_dimension(b"A1:C5").unwrap()
+        );
+        assert_eq!(
+            get_dimension(b"C1:A5").unwrap(),
+            get_dimension(b"A1:C5").unwrap()
+        );
+    }
+
+    #[test]
+    fn test_dimensions_new_normalises_order() {
+        let dim = Dimensions::new((4, 2), (0, 0));
+        assert_eq!(
+            dim,
+            Dimensions {
+                start: (0, 0),
+                end: (4, 2),
+            }
+        );
+        assert_eq!(dim.len(), 15);
+        // A single cell is still one cell, and a full-width axis does not
+        // overflow the `+ 1`.
+        assert_eq!(Dimensions::new((7, 7), (7, 7)).len(), 1);
+        assert_eq!(Dimensions::new((0, 0), (u32::MAX, 0)).len(), 4_294_967_296);
     }
 
     #[test]

--- a/src/xlsx/mod.rs
+++ b/src/xlsx/mod.rs
@@ -2793,13 +2793,13 @@ pub(crate) fn get_dimension(dimension: &[u8]) -> Result<Dimensions, XlsxError> {
             let dim = Dimensions::new(parts[0], parts[1]);
             if dim.end.0 > MAX_ROWS {
                 warn!(
-                    "xlsx has more than maximum number of rows ({} > {MAX_ROWS})",
+                    "file has more than maximum supported number of rows ({} > {MAX_ROWS})",
                     dim.end.0
                 );
             }
             if dim.end.1 > MAX_COLUMNS {
                 warn!(
-                    "xlsx has more than maximum number of columns ({} > {MAX_COLUMNS})",
+                    "file has more than maximum supported number of columns ({} > {MAX_COLUMNS})",
                     dim.end.1
                 );
             }
@@ -4049,8 +4049,7 @@ mod tests {
             }
         );
         assert_eq!(dim.len(), 15);
-        // A single cell is still one cell, and a full-width axis does not
-        // overflow the `+ 1`.
+        // A single cell is one cell; a full-width axis does not overflow.
         assert_eq!(Dimensions::new((7, 7), (7, 7)).len(), 1);
         assert_eq!(Dimensions::new((0, 0), (u32::MAX, 0)).len(), 4_294_967_296);
     }

--- a/src/xlsx/mod.rs
+++ b/src/xlsx/mod.rs
@@ -4049,8 +4049,9 @@ mod tests {
             }
         );
         assert_eq!(dim.len(), 15);
-        // A single cell is one cell; a full-width axis does not overflow.
         assert_eq!(Dimensions::new((7, 7), (7, 7)).len(), 1);
+
+        // A full axis must not overflow the `+ 1` in `len()`.
         assert_eq!(Dimensions::new((0, 0), (u32::MAX, 0)).len(), 4_294_967_296);
     }
 


### PR DESCRIPTION
Fixes #692.

A `<dimension>` whose end cell precedes its start, like `C5:A1`, underflowed the u32 subtractions in `get_dimension`: a debug build panics and a release build reports `Dimensions::len()` values around 1.8e19.

`Dimensions::new` now orders the corners so `start <= end` on both axes, and `get_dimension` goes through it, so a reversed `ref` parses the same as its ordered form. The `MAX_ROWS` / `MAX_COLUMNS` warnings compute from the normalised end corner. `Dimensions::len()` also widens to u64 before the `+ 1`, so a full axis no longer overflows.

A `Dimensions` built as a struct literal still bypasses the ordering; making the fields private is left to the wider API discussion from the review.

Tests: `test_reversed_dimension_is_normalised` (reversed on both axes and on each axis alone) and `test_dimensions_new_normalises_order`.

Touches the same `get_dimension` arm as #696; whichever lands second gets rebased.