### PR TITLE
fix(xls): decode PtgStr as a ByteString before BIFF8

### DIFF
--- a/src/xls.rs
+++ b/src/xls.rs
@@ -1559,12 +1559,39 @@ fn parse_formula(
                 stack.push(formula.len());
             }
             0x17 => {
+                // PtgStr [MS-XLS 2.5.198.89]. In BIFF8 the literal is a
+                // ShortXLUnicodeString: cch, a 1-byte grbit, then the
+                // characters. Before BIFF8 it is a ShortByteString: cch
+                // immediately followed by cch bytes, with no grbit. Reading
+                // the BIFF8 layout out of a pre-BIFF8 stream consumes one byte
+                // too many, which desynchronises the rest of the token stream
+                // and panics on the slice when the literal ends the rgce.
                 stack.push(formula.len());
                 formula.push('\"');
                 let cch = rgce[0] as usize;
-                read_unicode_string_no_cch(encoding, &rgce[1..], &cch, &mut formula);
-                formula.push('\"');
-                rgce = &rgce[2 + cch..];
+                if is_pre_biff8 {
+                    if rgce.len() < 1 + cch {
+                        return Err(XlsError::Len {
+                            typ: "PtgStr",
+                            expected: 1 + cch,
+                            found: rgce.len(),
+                        });
+                    }
+                    encoding.decode_to(&rgce[1..1 + cch], cch, &mut formula, None);
+                    formula.push('\"');
+                    rgce = &rgce[1 + cch..];
+                } else {
+                    if rgce.len() < 2 + cch {
+                        return Err(XlsError::Len {
+                            typ: "PtgStr",
+                            expected: 2 + cch,
+                            found: rgce.len(),
+                        });
+                    }
+                    read_unicode_string_no_cch(encoding, &rgce[1..], &cch, &mut formula);
+                    formula.push('\"');
+                    rgce = &rgce[2 + cch..];
+                }
             }
             0x18 => {
                 rgce = &rgce[5..];
@@ -1962,5 +1989,40 @@ mod tests {
     fn test_parse_string() {
         let enc = XlsEncoding::from_codepage(1252).unwrap();
         parse_string(&[0, 1], &enc, Biff::Biff8).unwrap_err();
+    }
+
+    /// A pre-BIFF8 PtgStr carries no grbit byte: `cch` is directly followed by
+    /// `cch` bytes. Decoding it as BIFF8 used to read one byte past the end of
+    /// the token stream and panic.
+    #[test]
+    fn test_parse_formula_ptgstr_biff5() {
+        let enc = XlsEncoding::from_codepage(1252).unwrap();
+        // cce = 8, then PtgStr(0x17) cch=6 "SCHUCH" — the literal ends the rgce.
+        let mut rgce = vec![8u8, 0, 0x17, 6];
+        rgce.extend_from_slice(b"SCHUCH");
+        let f = parse_formula(&rgce, &[], &[], &[], &enc, Biff::Biff5).unwrap();
+        assert_eq!(f, "\"SCHUCH\"");
+    }
+
+    /// The BIFF8 layout keeps its grbit byte.
+    #[test]
+    fn test_parse_formula_ptgstr_biff8() {
+        // BIFF8 workbooks declare code page 1200 (UTF-16LE).
+        let enc = XlsEncoding::from_codepage(1200).unwrap();
+        // cce = 9, then PtgStr(0x17) cch=6, grbit=0 (compressed), "SCHUCH".
+        let mut rgce = vec![9u8, 0, 0x17, 6, 0];
+        rgce.extend_from_slice(b"SCHUCH");
+        let f = parse_formula(&rgce, &[], &[], &[], &enc, Biff::Biff8).unwrap();
+        assert_eq!(f, "\"SCHUCH\"");
+    }
+
+    /// A truncated literal is an error, never a panic.
+    #[test]
+    fn test_parse_formula_ptgstr_truncated() {
+        let enc = XlsEncoding::from_codepage(1252).unwrap();
+        // cce = 5 covers the whole token stream, but cch claims 6 bytes.
+        let mut rgce = vec![5u8, 0, 0x17, 6];
+        rgce.extend_from_slice(b"SCH");
+        parse_formula(&rgce, &[], &[], &[], &enc, Biff::Biff5).unwrap_err();
     }
 }


### PR DESCRIPTION
### Problem

Opening some BIFF5 (Excel 5.0/95) workbooks panics instead of returning an error:

```
thread panicked at src/xls.rs:1247:28:
range end index 11 out of range for slice of length 11
   calamine::xls::read_unicode_string_no_cch
   calamine::xls::parse_formula
   calamine::xls::Xls<RS>::parse_workbook
   calamine::open_workbook
```

Because `parse_workbook` parses formulas while loading each sheet, the panic escapes `open_workbook` and the whole file becomes unreadable — even though the call site already tolerates formula errors through `unwrap_or_else`.

### Cause

A string literal in a formula (`PtgStr`, [MS-XLS] 2.5.198.89) is a `ShortXLUnicodeString` in BIFF8 — `cch`, a 1-byte `grbit`, then the characters — but a `ShortByteString` before BIFF8: `cch` immediately followed by `cch` bytes, with no `grbit`.

`parse_formula` applies the BIFF8 layout unconditionally, although it already computes `is_pre_biff8` a few lines above. On a BIFF5 stream it therefore takes the first character as the `grbit`, reads one byte past the literal, and advances the cursor by `2 + cch` instead of `1 + cch`. When the literal ends the `rgce`, the slice overruns and panics.

Actual bytes from an affected file, an 11-character literal ending the token stream:

```
17 0b 32 30 31 39 30 30 32 34 38 37 39     (13 bytes)
│  │  └─ the 11 characters, no grbit
│  └──── cch = 11
└─────── PtgStr
```

The reader asks for 12 bytes after `cch` where only 11 exist — hence `range end index 11 out of range for slice of length 11`.

This shows up on BIFF5 exports whose cells hold string formulas rather than plain values (the file that surfaced this has ~524k `Formula` records for 9536 rows — every cell is `="..."`). A BIFF5 file of plain values never reaches this code.

### Fix

Decode the pre-BIFF8 layout as a byte string with `high_byte = None`, mirroring what `parse_string` already does for `Biff2..Biff5`, and bound-check both branches so a truncated literal returns `XlsError::Len` rather than panicking.

### Tests

Three unit tests over `parse_formula`: a BIFF5 literal ending the `rgce` (panicked before this change), the BIFF8 layout with its `grbit` (unchanged behaviour), and a truncated literal that must be an error and not a panic. The existing suite passes unchanged; `cargo fmt --check` and `cargo clippy --all-targets` are clean.

The file that surfaced this contains personal data so it is not attached, but I can produce a reduced fixture if you would like one in `tests/`.