### PR TITLE
feat(xlsx): add Xlsx::document_properties to read core.xml metadata

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,8 +114,8 @@ pub use crate::ods::{Ods, OdsError};
 pub use crate::xls::{Xls, XlsError, XlsOptions};
 pub use crate::xlsb::{Xlsb, XlsbError};
 pub use crate::xlsx::{
-    expand_shared_formula, expand_shared_formula_into, Hyperlink, Xlsx, XlsxCellFormula,
-    XlsxCellFormulaMetadataRecord, XlsxCellReader, XlsxError, XlsxFormulaMetadata,
+    expand_shared_formula, expand_shared_formula_into, DocumentProperties, Hyperlink, Xlsx,
+    XlsxCellFormula, XlsxCellFormulaMetadataRecord, XlsxCellReader, XlsxError, XlsxFormulaMetadata,
 };
 
 use crate::vba::VbaProject;

--- a/src/xlsx/mod.rs
+++ b/src/xlsx/mod.rs
@@ -283,6 +283,50 @@ struct XlsxOptions {
     pub header_row: HeaderRow,
 }
 
+/// Document (core) properties of an xlsx workbook.
+///
+/// These are the metadata fields stored in the `docProps/core.xml` part of the
+/// package, such as the author of the file and the creation/modification dates.
+/// Every field is optional because a workbook may omit any of them, and files
+/// created by different applications populate different subsets.
+///
+/// The values are returned as they are stored in the file. In particular the
+/// `created`, `modified` and `last_printed` fields are ISO 8601 (W3CDTF) date
+/// strings, they are not parsed into a date type.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct DocumentProperties {
+    /// The title of the document (`dc:title`).
+    pub title: Option<String>,
+    /// The subject of the document (`dc:subject`).
+    pub subject: Option<String>,
+    /// The author of the document (`dc:creator`).
+    pub creator: Option<String>,
+    /// The keywords associated with the document (`cp:keywords`).
+    pub keywords: Option<String>,
+    /// A description or comment for the document (`dc:description`).
+    pub description: Option<String>,
+    /// The user who last modified the document (`cp:lastModifiedBy`).
+    pub last_modified_by: Option<String>,
+    /// The revision number (`cp:revision`).
+    pub revision: Option<String>,
+    /// The creation date as an ISO 8601 string (`dcterms:created`).
+    pub created: Option<String>,
+    /// The last modification date as an ISO 8601 string (`dcterms:modified`).
+    pub modified: Option<String>,
+    /// The last printed date as an ISO 8601 string (`cp:lastPrinted`).
+    pub last_printed: Option<String>,
+    /// The categorization of the document (`cp:category`).
+    pub category: Option<String>,
+    /// The status of the document, e.g. "Draft" or "Final" (`cp:contentStatus`).
+    pub content_status: Option<String>,
+    /// The language of the document (`dc:language`).
+    pub language: Option<String>,
+    /// A unique identifier for the document (`dc:identifier`).
+    pub identifier: Option<String>,
+    /// The version number (`cp:version`).
+    pub version: Option<String>,
+}
+
 impl<RS: Read + Seek> Xlsx<RS> {
     fn read_package_relationships(&mut self) -> Result<(), XlsxError> {
         let mut xml = match xml_reader(&mut self.zip, "_rels/.rels", &self.zip_path_cache) {
@@ -1139,6 +1183,146 @@ impl<RS: Read + Seek> Xlsx<RS> {
     /// ```
     pub fn has_1904_epoch(&self) -> bool {
         self.is_1904
+    }
+
+    /// Get the document (core) properties of the workbook.
+    ///
+    /// This reads the `docProps/core.xml` part of the package and returns the
+    /// metadata fields it contains, such as the author (`creator`) and the
+    /// creation date. Any field that is missing from the file is returned as
+    /// `None`. A workbook without a core properties part yields a
+    /// [`DocumentProperties`] with all fields set to `None`.
+    ///
+    /// # Examples
+    ///
+    /// An example of reading the author of an Excel workbook.
+    ///
+    /// ```
+    /// use calamine::{open_workbook, Error, Xlsx};
+    ///
+    /// fn main() -> Result<(), Error> {
+    ///     let path = "tests/table-multiple.xlsx";
+    ///
+    ///     // Open the workbook.
+    ///     let mut workbook: Xlsx<_> = open_workbook(path)?;
+    ///
+    ///     // Read the document properties.
+    ///     let properties = workbook.document_properties()?;
+    ///
+    ///     // Check the author.
+    ///     assert_eq!(properties.creator.as_deref(), Some("John"));
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// - [`XlsxError::Xml`].
+    /// - [`XlsxError::XmlEof`].
+    pub fn document_properties(&mut self) -> Result<DocumentProperties, XlsxError> {
+        let path = match self.core_properties_path()? {
+            Some(path) => path,
+            None => return Ok(DocumentProperties::default()),
+        };
+        self.read_core_properties(&path)
+    }
+
+    /// Find the path of the core properties part from the package relationships.
+    fn core_properties_path(&mut self) -> Result<Option<String>, XlsxError> {
+        let mut xml = match xml_reader(&mut self.zip, "_rels/.rels", &self.zip_path_cache) {
+            None => return Ok(None),
+            Some(x) => x?,
+        };
+
+        let mut buf = Vec::with_capacity(1024);
+        loop {
+            buf.clear();
+            match xml.read_event_into(&mut buf) {
+                Ok(Event::Start(e)) if e.local_name().as_ref() == b"Relationship" => {
+                    let (rel_type, target) =
+                        get_attrs!(e, b"Type" => rel_type, b"Target" => target)?;
+                    let is_core = rel_type
+                        .map(|t| t.ends_with(b"/core-properties"))
+                        .unwrap_or(false);
+                    if is_core {
+                        if let Some(target) = target {
+                            let target = decode_attr(&xml.decoder(), target)?;
+                            let target = target.strip_prefix('/').unwrap_or(&target).to_string();
+                            return Ok(Some(target));
+                        }
+                    }
+                }
+                Ok(Event::End(e)) if e.local_name().as_ref() == b"Relationships" => break,
+                Ok(Event::Eof) => return Err(XlsxError::XmlEof("Relationships")),
+                Err(e) => return Err(XlsxError::Xml(e)),
+                _ => (),
+            }
+        }
+
+        Ok(None)
+    }
+
+    /// Parse the core properties part at the given path.
+    fn read_core_properties(&mut self, path: &str) -> Result<DocumentProperties, XlsxError> {
+        let mut xml = match xml_reader(&mut self.zip, path, &self.zip_path_cache) {
+            None => return Ok(DocumentProperties::default()),
+            Some(x) => x?,
+        };
+
+        let mut props = DocumentProperties::default();
+        let mut buf = Vec::with_capacity(1024);
+        let mut val_buf = Vec::with_capacity(1024);
+        loop {
+            buf.clear();
+            match xml.read_event_into(&mut buf) {
+                Ok(Event::Start(e)) => {
+                    let slot: Option<&mut Option<String>> = match e.local_name().as_ref() {
+                        b"title" => Some(&mut props.title),
+                        b"subject" => Some(&mut props.subject),
+                        b"creator" => Some(&mut props.creator),
+                        b"keywords" => Some(&mut props.keywords),
+                        b"description" => Some(&mut props.description),
+                        b"lastModifiedBy" => Some(&mut props.last_modified_by),
+                        b"revision" => Some(&mut props.revision),
+                        b"created" => Some(&mut props.created),
+                        b"modified" => Some(&mut props.modified),
+                        b"lastPrinted" => Some(&mut props.last_printed),
+                        b"category" => Some(&mut props.category),
+                        b"contentStatus" => Some(&mut props.content_status),
+                        b"language" => Some(&mut props.language),
+                        b"identifier" => Some(&mut props.identifier),
+                        b"version" => Some(&mut props.version),
+                        _ => None,
+                    };
+                    if let Some(slot) = slot {
+                        let end_name = e.name();
+                        let mut value = String::new();
+                        loop {
+                            val_buf.clear();
+                            match xml.read_event_into(&mut val_buf)? {
+                                Event::Text(t) => value.push_str(&t.xml10_content()?),
+                                Event::GeneralRef(r) => {
+                                    unescape_entity_to_buffer(&r, &mut value)?;
+                                }
+                                Event::End(end) if end.name() == end_name => break,
+                                Event::Eof => return Err(XlsxError::XmlEof("coreProperties")),
+                                _ => (),
+                            }
+                        }
+                        if !value.is_empty() {
+                            *slot = Some(value);
+                        }
+                    }
+                }
+                Ok(Event::End(e)) if e.local_name().as_ref() == b"coreProperties" => break,
+                Ok(Event::Eof) => return Err(XlsxError::XmlEof("coreProperties")),
+                Err(e) => return Err(XlsxError::Xml(e)),
+                _ => (),
+            }
+        }
+
+        Ok(props)
     }
 
     /// Get all Pivot Tables in a workbook.

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -5,9 +5,9 @@
 use calamine::vba::Reference;
 use calamine::Data::{Bool, DateTime, DateTimeIso, DurationIso, Empty, Error, Float, Int, String};
 use calamine::{
-    open_workbook, open_workbook_auto, DataRef, DataType, Dimensions, ExcelDateTime,
-    ExcelDateTimeType, HeaderRow, Ods, Range, Reader, ReaderRef, Sheet, SheetType, SheetVisible,
-    Xls, Xlsb, Xlsx, XlsxFormulaMetadata,
+    open_workbook, open_workbook_auto, DataRef, DataType, Dimensions, DocumentProperties,
+    ExcelDateTime, ExcelDateTimeType, HeaderRow, Ods, Range, Reader, ReaderRef, Sheet, SheetType,
+    SheetVisible, Xls, Xlsb, Xlsx, XlsxFormulaMetadata,
 };
 use calamine::{CellErrorType::*, Data};
 use rstest::rstest;
@@ -3661,4 +3661,43 @@ fn xls_embedded_cross_sheet_chart_does_not_leak_cells() {
         range.get((5, 2)),
         Some(&Data::String("VALUE C6".to_string()))
     );
+}
+
+#[test]
+fn xlsx_document_properties() {
+    let mut excel: Xlsx<_> = wb("table-multiple.xlsx");
+    let props = excel.document_properties().unwrap();
+
+    assert_eq!(props.creator.as_deref(), Some("John"));
+    assert_eq!(props.last_modified_by.as_deref(), Some("John"));
+    assert_eq!(props.created.as_deref(), Some("2025-07-07T22:15:34Z"));
+    assert_eq!(props.modified.as_deref(), Some("2025-07-08T23:00:40Z"));
+
+    // Fields absent from the file stay None.
+    assert_eq!(props.title, None);
+    assert_eq!(props.subject, None);
+}
+
+#[test]
+fn xlsx_document_properties_unicode_creator() {
+    // The creator is stored with non-ASCII characters and must round-trip.
+    let mut excel: Xlsx<_> = wb("any_sheets.xlsx");
+    let props = excel.document_properties().unwrap();
+
+    assert_eq!(props.creator.as_deref(), Some("Алена"));
+    assert_eq!(props.last_modified_by.as_deref(), Some("Алена"));
+}
+
+#[test]
+fn xlsx_document_properties_empty_values_are_none() {
+    // date.xlsx has a core.xml where dc:creator is present but empty.
+    let mut excel: Xlsx<_> = wb("date.xlsx");
+    let props = excel.document_properties().unwrap();
+
+    assert_eq!(props.creator, None);
+    assert_eq!(props.language.as_deref(), Some("en-US"));
+    assert!(props.created.is_some());
+
+    // A default value has every field unset.
+    assert_eq!(DocumentProperties::default().creator, None);
 }


### PR DESCRIPTION
Closes #149.

This adds a `document_properties()` method on `Xlsx` that reads `docProps/core.xml` and returns the core properties of the workbook, so you can get things like the author and the created/modified dates that the `file` command shows.

The new `DocumentProperties` struct has an optional field per core property, since files created by different applications fill in different subsets. The `created`, `modified` and `last_printed` values are returned as the raw ISO 8601 (W3CDTF) strings stored in the file. I left them as strings so this doesn't pull in a date dependency just for the metadata.

It follows the same lazy pattern as `load_tables` and the pivot table methods: the part is only read when you call the method, and a workbook without a core properties part just gives back a default with every field set to `None`.

Tests cover `table-multiple.xlsx` (creator "John"), `any_sheets.xlsx` (a non-ASCII creator, to check decoding) and `date.xlsx` (which has an empty `dc:creator`, so it comes back as `None`).
