### PR TITLE
update quick-xml to 0.42.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ byteorder = "1.5"
 encoding_rs = "0.8"
 fast-float2 = "0.2"
 zip = { version = "8.6", default-features = false, features = ["deflate"] }
-quick-xml = { version = "0.42.0", features = ["encoding"] }
+quick-xml = { version = "0.42", features = ["encoding"] }
 
 # Optional dependencies.
 chrono = { version = "0.4", features = ["serde"], optional = true, default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ byteorder = "1.5"
 encoding_rs = "0.8"
 fast-float2 = "0.2"
 zip = { version = "8.6", default-features = false, features = ["deflate"] }
-quick-xml = { version = "0.41", features = ["encoding"] }
+quick-xml = { version = "0.42.0", features = ["encoding"] }
 
 # Optional dependencies.
 chrono = { version = "0.4", features = ["serde"], optional = true, default-features = false }

--- a/src/attrs.rs
+++ b/src/attrs.rs
@@ -5,8 +5,8 @@
 //! Zero-allocation XML attribute extraction utilities.
 //!
 //! These replace quick_xml's own `Attributes` iterator, avoiding its per-item
-//! `Cow`/`QName` newtypes, quote-type tracking, namespace bookkeeping, entity
-//! decoding, and UTF8 validation. We can do this as we have a constrained
+//! `Cow`/`QName` newtypes, quote-type tracking, namespace bookkeeping, and
+//! entity decoding. We can do this as we have a constrained
 //! set of keys that we access internally (all of them are simple ASCII).
 //!
 //! Like quick_xml, malformed attributes are reported as [`AttrError`] items rather
@@ -17,36 +17,36 @@
 use quick_xml::escape::unescape;
 use quick_xml::events::attributes::AttrError;
 use quick_xml::events::BytesStart;
-use quick_xml::Decoder;
 
-/// Zero-allocation iterator over raw XML attribute bytes, yielding
-/// `(key, value)` byte-slice pairs or an [`AttrError`] for malformed input.
+/// Zero-allocation iterator over raw XML attributes, yielding
+/// `(key, value)` string-slice pairs or an [`AttrError`] for malformed input.
 pub(crate) struct RawAttrIter<'a> {
-    raw: &'a [u8],
+    raw: &'a str,
     pos: usize,
 }
 
 impl<'a> RawAttrIter<'a> {
     #[inline]
-    fn new(raw: &'a [u8]) -> Self {
+    fn new(raw: &'a str) -> Self {
         Self { raw, pos: 0 }
     }
 }
 
 impl<'a> Iterator for RawAttrIter<'a> {
-    type Item = Result<(&'a [u8], &'a [u8]), AttrError>;
+    type Item = Result<(&'a str, &'a str), AttrError>;
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         let raw = self.raw;
-        let len = raw.len();
+        let bytes = raw.as_bytes();
+        let len = bytes.len();
 
         // note: make "pos" local to ensure the compiler keeps it in
         // a register across the scan loops (struct field otherwise)
         let mut pos = self.pos;
 
         // skip whitespace before the key
-        while pos < len && raw[pos].is_ascii_whitespace() {
+        while pos < len && bytes[pos].is_ascii_whitespace() {
             pos += 1;
         }
         if pos >= len {
@@ -57,7 +57,7 @@ impl<'a> Iterator for RawAttrIter<'a> {
         // key: scan to '=' with a single comparison
         // per byte (handling whitespace around '=')
         let key_start = pos;
-        while pos < len && raw[pos] != b'=' {
+        while pos < len && bytes[pos] != b'=' {
             pos += 1;
         }
         if pos >= len {
@@ -70,13 +70,13 @@ impl<'a> Iterator for RawAttrIter<'a> {
         pos += 1; // skip '='
 
         // skip whitespace after '=' (normally none: loop exits immediately)
-        while pos < len && raw[pos].is_ascii_whitespace() {
+        while pos < len && bytes[pos].is_ascii_whitespace() {
             pos += 1;
         }
 
         // quoted value (XML mandates quotes; anything else, including a missing
         // value at end-of-input, is malformed)
-        let quote = raw.get(pos).copied();
+        let quote = bytes.get(pos).copied();
         if quote != Some(b'"') && quote != Some(b'\'') {
             self.pos = len;
             return Some(Err(AttrError::UnquotedValue(pos)));
@@ -84,7 +84,7 @@ impl<'a> Iterator for RawAttrIter<'a> {
         let quote = quote.unwrap();
         pos += 1; // skip opening quote
         let val_start = pos;
-        while pos < len && raw[pos] != quote {
+        while pos < len && bytes[pos] != quote {
             pos += 1;
         }
         let val = &raw[val_start..pos];
@@ -97,26 +97,26 @@ impl<'a> Iterator for RawAttrIter<'a> {
 }
 
 /// Compare an attribute key against a local name, ignoring any namespace
-/// prefix, eg: both `id` and `r:id` would match a `local_name` of `b"id"`.
+/// prefix, eg: both `id` and `r:id` would match a `local_name` of `"id"`.
 #[inline]
-pub(crate) fn local_name_matches(key: &[u8], local_name: &[u8]) -> bool {
+pub(crate) fn local_name_matches(key: &str, local_name: &str) -> bool {
     // exact match, or `<prefix>:<local>`
     key == local_name
         || key
             .strip_suffix(local_name) // compare on subslice to avoid allocation
-            .is_some_and(|prefix| prefix.last() == Some(&b':'))
+            .is_some_and(|prefix| prefix.as_bytes().last() == Some(&b':'))
 }
 
 /// Extension trait for fast/raw attribute access on XML elements.
 pub(crate) trait RawAttributes {
-    /// Iterate over attributes, yielding `(key, value)` byte-slice
+    /// Iterate over attributes, yielding `(key, value)` string-slice
     /// pairs (or an [`AttrError`] for malformed input).
     fn iter_raw_attrs(&self) -> RawAttrIter<'_>;
 
     /// Get a single attribute by exact key, returning `Ok(None)` if absent and
     /// an `Err` if a malformed attribute is encountered while scanning.
     #[inline]
-    fn raw_attr(&self, name: &[u8]) -> Result<Option<&[u8]>, AttrError> {
+    fn raw_attr(&self, name: &str) -> Result<Option<&str>, AttrError> {
         for item in self.iter_raw_attrs() {
             let (k, v) = item?;
             if k == name {
@@ -127,10 +127,10 @@ pub(crate) trait RawAttributes {
     }
 
     /// Like `raw_attr`, but matches on the attribute's *local* name, ignoring
-    /// any namespace prefix (so both `id` and `r:id` would match `b"id"`).
+    /// any namespace prefix (so both `id` and `r:id` would match `"id"`).
     #[allow(dead_code)] // note: currently only reached from `picture`-gated code
     #[inline] // but the function is general-purpose and will be useful elsewhere
-    fn raw_attr_local(&self, local_name: &[u8]) -> Result<Option<&[u8]>, AttrError> {
+    fn raw_attr_local(&self, local_name: &str) -> Result<Option<&str>, AttrError> {
         for item in self.iter_raw_attrs() {
             let (k, v) = item?;
             if local_name_matches(k, local_name) {
@@ -181,11 +181,10 @@ macro_rules! get_attrs {
     (@count_one $e:expr) => { 1u8 };
 }
 
-/// Decode raw attribute bytes into a `String`, with XML entity unescaping.
+/// Decode a raw attribute into a `String`, with XML entity unescaping.
 /// Only needed for values that can contain entities (eg: sheet names, table names, etc).
-pub(crate) fn decode_attr(decoder: &Decoder, val: &[u8]) -> Result<String, quick_xml::Error> {
-    let decoded = decoder.decode(val)?;
-    let unescaped = unescape(&decoded).map_err(quick_xml::Error::from)?;
+pub(crate) fn decode_attr(val: &str) -> Result<String, quick_xml::Error> {
+    let unescaped = unescape(val).map_err(quick_xml::Error::from)?;
     Ok(unescaped.into_owned())
 }
 
@@ -194,7 +193,7 @@ mod tests {
     use super::*;
 
     /// Collect well-formed attributes, panicking on any malformed item.
-    fn collect(raw: &[u8]) -> Vec<(&[u8], &[u8])> {
+    fn collect(raw: &str) -> Vec<(&str, &str)> {
         RawAttrIter::new(raw)
             .map(|r| r.expect("unexpected malformed attribute"))
             .collect()
@@ -202,80 +201,73 @@ mod tests {
 
     #[test]
     fn test_basic_attrs() {
-        let bytes = b"key1=\"val1\" key2='val2'";
-        let mut iter = RawAttrIter::new(bytes);
-        assert_eq!(iter.next(), Some(Ok((&b"key1"[..], &b"val1"[..]))));
-        assert_eq!(iter.next(), Some(Ok((&b"key2"[..], &b"val2"[..]))));
+        let raw = "key1=\"val1\" key2='val2'";
+        let mut iter = RawAttrIter::new(raw);
+        assert_eq!(iter.next(), Some(Ok(("key1", "val1"))));
+        assert_eq!(iter.next(), Some(Ok(("key2", "val2"))));
         assert_eq!(iter.next(), None);
     }
 
     #[test]
     fn test_whitespace_around_equals() {
-        let bytes = b"key = \"value\"";
-        let mut iter = RawAttrIter::new(bytes);
-        assert_eq!(iter.next(), Some(Ok((&b"key"[..], &b"value"[..]))));
+        let raw = "key = \"value\"";
+        let mut iter = RawAttrIter::new(raw);
+        assert_eq!(iter.next(), Some(Ok(("key", "value"))));
         assert_eq!(iter.next(), None);
     }
 
     #[test]
     fn test_empty_value() {
-        let bytes = b"key=\"\"";
-        let mut iter = RawAttrIter::new(bytes);
-        assert_eq!(iter.next(), Some(Ok((&b"key"[..], &b""[..]))));
+        let raw = "key=\"\"";
+        let mut iter = RawAttrIter::new(raw);
+        assert_eq!(iter.next(), Some(Ok(("key", ""))));
         assert_eq!(iter.next(), None);
     }
 
     #[test]
     fn test_no_trailing_space() {
-        let bytes = b"key=\"value\"";
-        let mut iter = RawAttrIter::new(bytes);
-        assert_eq!(iter.next(), Some(Ok((&b"key"[..], &b"value"[..]))));
+        let raw = "key=\"value\"";
+        let mut iter = RawAttrIter::new(raw);
+        assert_eq!(iter.next(), Some(Ok(("key", "value"))));
         assert_eq!(iter.next(), None);
     }
 
     #[test]
     fn test_no_attributes() {
-        assert_eq!(collect(b""), vec![]);
-        assert_eq!(collect(b"   "), vec![]);
+        assert_eq!(collect(""), vec![]);
+        assert_eq!(collect("   "), vec![]);
     }
 
     #[test]
     fn test_leading_and_trailing_whitespace() {
         // `attributes_raw()` yields a leading space; a self-closing tag can
         // leave a trailing one (e.g. `<c r="A1" />` -> ` r="A1" `).
-        assert_eq!(collect(b" r=\"A1\" "), vec![(&b"r"[..], &b"A1"[..])]);
+        assert_eq!(collect(" r=\"A1\" "), vec![("r", "A1")]);
     }
 
     #[test]
     fn test_mixed_whitespace_and_quotes() {
         // Whitespace around `=` combined with both quote styles, as a real
         // (if unusual) tag like `<row r = "50" spans = '1:4'>` would produce.
-        let bytes = b" r = \"50\" spans = '1:4'";
-        assert_eq!(
-            collect(bytes),
-            vec![(&b"r"[..], &b"50"[..]), (&b"spans"[..], &b"1:4"[..])]
-        );
+        let raw = " r = \"50\" spans = '1:4'";
+        assert_eq!(collect(raw), vec![("r", "50"), ("spans", "1:4")]);
     }
 
     #[test]
     fn test_value_containing_other_quote() {
         // A single-quoted value may contain double quotes and vice versa.
-        assert_eq!(collect(b"k='a\"b'"), vec![(&b"k"[..], &b"a\"b"[..])]);
-        assert_eq!(collect(b"k=\"a'b\""), vec![(&b"k"[..], &b"a'b"[..])]);
+        assert_eq!(collect("k='a\"b'"), vec![("k", "a\"b")]);
+        assert_eq!(collect("k=\"a'b\""), vec![("k", "a'b")]);
     }
 
     #[test]
     fn test_namespaced_attributes() {
         // Namespace declarations and prefixed names are yielded verbatim with
         // their prefix; call sites match the full raw key (see issue #632).
-        let bytes = b" xmlns:foo=\"bar\" foo:id=\"x\" r:id=\"rId1\"";
+        let raw = " xmlns:foo=\"bar\" foo:id=\"x\" r:id=\"rId1\"";
         assert_eq!(
-            collect(bytes),
-            vec![
-                (&b"xmlns:foo"[..], &b"bar"[..]),
-                (&b"foo:id"[..], &b"x"[..]),
-                (&b"r:id"[..], &b"rId1"[..]),
-            ]
+            collect(raw),
+            vec![("xmlns:foo", "bar"), ("foo:id", "x"), ("r:id", "rId1"),]
         );
     }
 
@@ -283,8 +275,8 @@ mod tests {
     fn test_malformed_unquoted_value_reports_error() {
         // Unquoted values are malformed: yield the valid attr,
         // then the UnquotedValue error, then stop.
-        let mut iter = RawAttrIter::new(b"good=\"1\" bad=2");
-        assert_eq!(iter.next(), Some(Ok((&b"good"[..], &b"1"[..]))));
+        let mut iter = RawAttrIter::new("good=\"1\" bad=2");
+        assert_eq!(iter.next(), Some(Ok(("good", "1"))));
         assert!(matches!(
             iter.next(),
             Some(Err(AttrError::UnquotedValue(_)))
@@ -295,12 +287,12 @@ mod tests {
     #[test]
     fn test_no_equals_reports_error() {
         // A bare name with no '=' is reported as ExpectedEq, then iteration ends.
-        let mut iter = RawAttrIter::new(b"disabled");
+        let mut iter = RawAttrIter::new("disabled");
         assert!(matches!(iter.next(), Some(Err(AttrError::ExpectedEq(_)))));
         assert_eq!(iter.next(), None);
 
         // Leading whitespace then a bare name behaves the same.
-        let mut iter = RawAttrIter::new(b"  spans  ");
+        let mut iter = RawAttrIter::new("  spans  ");
         assert!(matches!(iter.next(), Some(Err(AttrError::ExpectedEq(_)))));
         assert_eq!(iter.next(), None);
     }
@@ -309,8 +301,8 @@ mod tests {
     fn test_tabs_and_newlines_as_separators() {
         // Attributes may be split by tabs/newlines, not just spaces.
         assert_eq!(
-            collect(b"\tr=\"A1\"\n\ts=\"3\""),
-            vec![(&b"r"[..], &b"A1"[..]), (&b"s"[..], &b"3"[..])]
+            collect("\tr=\"A1\"\n\ts=\"3\""),
+            vec![("r", "A1"), ("s", "3")]
         );
     }
 
@@ -323,24 +315,24 @@ mod tests {
         let Event::Empty(e) = reader.read_event().unwrap() else {
             panic!("expected empty element");
         };
-        assert_eq!(e.raw_attr(b"r"), Ok(Some(&b"A1"[..])));
-        assert_eq!(e.raw_attr(b"s"), Ok(Some(&b"3"[..])));
-        assert_eq!(e.raw_attr(b"t"), Ok(Some(&b"s"[..])));
-        assert_eq!(e.raw_attr(b"missing"), Ok(None));
+        assert_eq!(e.raw_attr("r"), Ok(Some("A1")));
+        assert_eq!(e.raw_attr("s"), Ok(Some("3")));
+        assert_eq!(e.raw_attr("t"), Ok(Some("s")));
+        assert_eq!(e.raw_attr("missing"), Ok(None));
     }
 
     #[test]
     fn test_local_name_matches() {
         // match
-        assert!(local_name_matches(b"id", b"id"));
-        assert!(local_name_matches(b"r:id", b"id"));
-        assert!(local_name_matches(b"x:embed", b"embed"));
-        assert!(local_name_matches(b":id", b"id"));
+        assert!(local_name_matches("id", "id"));
+        assert!(local_name_matches("r:id", "id"));
+        assert!(local_name_matches("x:embed", "embed"));
+        assert!(local_name_matches(":id", "id"));
 
         // don't match
-        assert!(!local_name_matches(b"xmlid", b"id"));
-        assert!(!local_name_matches(b"rid", b"id"));
-        assert!(!local_name_matches(b"name", b"id"));
+        assert!(!local_name_matches("xmlid", "id"));
+        assert!(!local_name_matches("rid", "id"));
+        assert!(!local_name_matches("name", "id"));
     }
 
     #[test]
@@ -353,9 +345,9 @@ mod tests {
             panic!("expected empty element");
         };
         // namespaced key matched on local name, exact key still works
-        assert_eq!(e.raw_attr_local(b"embed"), Ok(Some(&b"rId1"[..])));
-        assert_eq!(e.raw_attr_local(b"cstate"), Ok(Some(&b"print"[..])));
-        assert_eq!(e.raw_attr_local(b"missing"), Ok(None));
+        assert_eq!(e.raw_attr_local("embed"), Ok(Some("rId1")));
+        assert_eq!(e.raw_attr_local("cstate"), Ok(Some("print")));
+        assert_eq!(e.raw_attr_local("missing"), Ok(None));
     }
 
     #[test]
@@ -368,9 +360,9 @@ mod tests {
         let Event::Empty(e) = reader.read_event().unwrap() else {
             panic!("expected empty element");
         };
-        let (r, s, t) = get_attrs!(e, b"r" => r, b"s" => s, b"t" => t).unwrap();
-        assert_eq!(r, Some(&b"A1"[..]));
+        let (r, s, t) = get_attrs!(e, "r" => r, "s" => s, "t" => t).unwrap();
+        assert_eq!(r, Some("A1"));
         assert_eq!(s, None);
-        assert_eq!(t, Some(&b"s"[..]));
+        assert_eq!(t, Some("s"));
     }
 }

--- a/src/formats.rs
+++ b/src/formats.rs
@@ -49,32 +49,32 @@ pub fn detect_custom_number_format(format: &str) -> CellFormat {
     CellFormat::Other
 }
 
-pub fn builtin_format_by_id(id: &[u8]) -> CellFormat {
+pub fn builtin_format_by_id(id: &str) -> CellFormat {
     match id {
         // mm-dd-yy
-        b"14" |
+        "14" |
         // d-mmm-yy
-        b"15" |
+        "15" |
         // d-mmm
-        b"16" |
+        "16" |
         // mmm-yy
-        b"17" |
+        "17" |
         // h:mm AM/PM
-        b"18" |
+        "18" |
         // h:mm:ss AM/PM
-        b"19" |
+        "19" |
         // h:mm
-        b"20" |
+        "20" |
         // h:mm:ss
-        b"21" |
+        "21" |
         // m/d/yy h:mm
-        b"22" |
+        "22" |
         // mm:ss
-        b"45" |
+        "45" |
         // mmss.0
-        b"47" => CellFormat::DateTime,
+        "47" => CellFormat::DateTime,
         // [h]:mm:ss
-        b"46" => CellFormat::TimeDelta,
+        "46" => CellFormat::TimeDelta,
         _ => CellFormat::Other
     }
 }

--- a/src/ods.rs
+++ b/src/ods.rs
@@ -670,10 +670,9 @@ where
         let (key, value) = attr?;
         match key {
             "office:value" if !is_value_set => {
-                let v = value;
                 val = Data::Float(
-                    fast_float2::parse(v.as_bytes())
-                        .map_err(|_| OdsError::ParseFloat(v.parse::<f64>().unwrap_err()))?,
+                    fast_float2::parse(value.as_bytes())
+                        .map_err(|_| OdsError::ParseFloat(value.parse::<f64>().unwrap_err()))?,
                 );
                 is_value_set = true;
             }

--- a/src/ods.rs
+++ b/src/ods.rs
@@ -302,10 +302,10 @@ fn check_for_password_protected<RS: Read + Seek>(zip: &mut ZipArchive<RS>) -> Re
     let mut inner = Vec::new();
     loop {
         match reader.read_event_into(&mut buf) {
-            Ok(Event::Start(e)) if e.name() == QName(b"manifest:file-entry") => {
+            Ok(Event::Start(e)) if e.name() == QName("manifest:file-entry") => {
                 loop {
                     match reader.read_event_into(&mut inner) {
-                        Ok(Event::Start(e)) if e.name() == QName(b"manifest:encryption-data") => {
+                        Ok(Event::Start(e)) if e.name() == QName("manifest:encryption-data") => {
                             return Err(OdsError::Password)
                         }
                         Ok(Event::Eof) => break,
@@ -348,18 +348,15 @@ fn parse_content<RS: Read + Seek>(mut zip: ZipArchive<RS>) -> Result<Content, Od
     let mut style_name: Option<String> = None;
     loop {
         match reader.read_event_into(&mut buf) {
-            Ok(Event::Start(e)) if e.name() == QName(b"style:style") => {
-                style_name = e
-                    .raw_attr(b"style:name")?
-                    .map(|v| decode_attr(&reader.decoder(), v))
-                    .transpose()?;
+            Ok(Event::Start(e)) if e.name() == QName("style:style") => {
+                style_name = e.raw_attr("style:name")?.map(decode_attr).transpose()?;
             }
             Ok(Event::Start(e))
-                if style_name.is_some() && e.name() == QName(b"style:table-properties") =>
+                if style_name.is_some() && e.name() == QName("style:table-properties") =>
             {
-                let visible = match e.raw_attr(b"table:display")? {
+                let visible = match e.raw_attr("table:display")? {
                     Some(v) => {
-                        if decode_attr(&reader.decoder(), v)?.parse()? {
+                        if decode_attr(v)?.parse()? {
                             SheetVisible::Visible
                         } else {
                             SheetVisible::Hidden
@@ -369,17 +366,17 @@ fn parse_content<RS: Read + Seek>(mut zip: ZipArchive<RS>) -> Result<Content, Od
                 };
                 styles.insert(style_name.clone(), visible);
             }
-            Ok(Event::Start(e)) if e.name() == QName(b"table:table") => {
+            Ok(Event::Start(e)) if e.name() == QName("table:table") => {
                 let visible = styles
                     .get(
-                        &e.raw_attr(b"table:style-name")?
-                            .map(|v| decode_attr(&reader.decoder(), v))
+                        &e.raw_attr("table:style-name")?
+                            .map(decode_attr)
                             .transpose()?,
                     )
                     .cloned()
                     .unwrap_or(SheetVisible::Visible);
-                if let Some(v) = e.raw_attr(b"table:name")? {
-                    let name = decode_attr(&reader.decoder(), v)?;
+                if let Some(v) = e.raw_attr("table:name")? {
+                    let name = decode_attr(v)?;
                     let (range, formulas) = read_table(&mut reader)?;
                     sheets_metadata.push(Sheet {
                         name: name.clone(),
@@ -389,7 +386,7 @@ fn parse_content<RS: Read + Seek>(mut zip: ZipArchive<RS>) -> Result<Content, Od
                     sheets.insert(name, (range, formulas));
                 }
             }
-            Ok(Event::Start(e)) if e.name() == QName(b"table:named-expressions") => {
+            Ok(Event::Start(e)) if e.name() == QName("table:named-expressions") => {
                 defined_names = read_named_expressions(&mut reader)?;
             }
             Ok(Event::Eof) => break,
@@ -420,9 +417,9 @@ where
     cols.push(0);
     loop {
         match reader.read_event_into(&mut buf) {
-            Ok(Event::Start(e)) if e.name() == QName(b"table:table-row") => {
-                let row_repeats = match e.raw_attr(b"table:number-rows-repeated")? {
-                    Some(v) => decode_attr(&reader.decoder(), v)?.parse()?,
+            Ok(Event::Start(e)) if e.name() == QName("table:table-row") => {
+                let row_repeats = match e.raw_attr("table:number-rows-repeated")? {
+                    Some(v) => decode_attr(v)?.parse()?,
                     None => 1,
                 };
 
@@ -446,7 +443,7 @@ where
                 cols.push(cells.len());
                 rows_repeats.push(capped_repeats);
             }
-            Ok(Event::End(e)) if e.name() == QName(b"table:table") => break,
+            Ok(Event::End(e)) if e.name() == QName("table:table") => break,
             Err(e) => return Err(OdsError::Xml(e)),
             Ok(_) => (),
         }
@@ -593,11 +590,11 @@ where
         row_buf.clear();
         match reader.read_event_into(row_buf) {
             Ok(Event::Start(e))
-                if e.name() == QName(b"table:table-cell")
-                    || e.name() == QName(b"table:covered-table-cell") =>
+                if e.name() == QName("table:table-cell")
+                    || e.name() == QName("table:covered-table-cell") =>
             {
-                let repeats = match e.raw_attr(b"table:number-columns-repeated")? {
-                    Some(v) => reader.decoder().decode(v)?.parse()?,
+                let repeats = match e.raw_attr("table:number-columns-repeated")? {
+                    Some(v) => v.parse()?,
                     None => 1,
                 };
 
@@ -641,7 +638,7 @@ where
                     reader.read_to_end_into(e.name(), cell_buf)?;
                 }
             }
-            Ok(Event::End(e)) if e.name() == QName(b"table:table-row") => break,
+            Ok(Event::End(e)) if e.name() == QName("table:table-row") => break,
             Err(e) => return Err(OdsError::Xml(e)),
             Ok(e) => {
                 return Err(OdsError::Mismatch {
@@ -672,33 +669,31 @@ where
     for attr in e.iter_raw_attrs() {
         let (key, value) = attr?;
         match key {
-            b"office:value" if !is_value_set => {
-                let v = reader.decoder().decode(value)?;
+            "office:value" if !is_value_set => {
+                let v = value;
                 val = Data::Float(
                     fast_float2::parse(v.as_bytes())
                         .map_err(|_| OdsError::ParseFloat(v.parse::<f64>().unwrap_err()))?,
                 );
                 is_value_set = true;
             }
-            b"office:string-value" | b"office:date-value" | b"office:time-value"
-                if !is_value_set =>
-            {
-                let attr = decode_attr(&reader.decoder(), value)?;
+            "office:string-value" | "office:date-value" | "office:time-value" if !is_value_set => {
+                let attr = decode_attr(value)?;
                 val = match key {
-                    b"office:date-value" => Data::DateTimeIso(attr),
-                    b"office:time-value" => Data::DurationIso(attr),
+                    "office:date-value" => Data::DateTimeIso(attr),
+                    "office:time-value" => Data::DurationIso(attr),
                     _ => Data::String(attr),
                 };
                 is_value_set = true;
             }
-            b"office:boolean-value" if !is_value_set => {
-                let b = value == b"TRUE" || value == b"true";
+            "office:boolean-value" if !is_value_set => {
+                let b = value == "TRUE" || value == "true";
                 val = Data::Bool(b);
                 is_value_set = true;
             }
-            b"office:value-type" if !is_value_set => is_string = value == b"string",
-            b"table:formula" => {
-                formula = decode_attr(&reader.decoder(), value)?;
+            "office:value-type" if !is_value_set => is_string = value == "string",
+            "table:formula" => {
+                formula = decode_attr(value)?;
             }
             _ => (),
         }
@@ -712,36 +707,36 @@ where
             buf.clear();
             match reader.read_event_into(buf) {
                 Ok(Event::Text(t)) => {
-                    s.push_str(&t.xml10_content()?);
+                    s.push_str(&t.xml10_content());
                 }
                 Ok(Event::GeneralRef(e)) => {
                     unescape_entity_to_buffer(&e, &mut s)?;
                 }
                 Ok(Event::End(e))
-                    if e.name() == QName(b"table:table-cell")
-                        || e.name() == QName(b"table:covered-table-cell") =>
+                    if e.name() == QName("table:table-cell")
+                        || e.name() == QName("table:covered-table-cell") =>
                 {
                     return Ok((Data::String(s), formula, true));
                 }
-                Ok(Event::Start(e)) if e.name() == QName(b"office:annotation") => loop {
+                Ok(Event::Start(e)) if e.name() == QName("office:annotation") => loop {
                     match reader.read_event_into(buf) {
-                        Ok(Event::End(e)) if e.name() == QName(b"office:annotation") => {
+                        Ok(Event::End(e)) if e.name() == QName("office:annotation") => {
                             break;
                         }
                         Err(e) => return Err(OdsError::Xml(e)),
                         _ => (),
                     }
                 },
-                Ok(Event::Start(e)) if e.name() == QName(b"text:p") => {
+                Ok(Event::Start(e)) if e.name() == QName("text:p") => {
                     if first_paragraph {
                         first_paragraph = false;
                     } else {
                         s.push('\n');
                     }
                 }
-                Ok(Event::Start(e)) if e.name() == QName(b"text:s") => {
-                    let count = match e.raw_attr(b"text:c")? {
-                        Some(v) => decode_attr(&reader.decoder(), v)?.parse()?,
+                Ok(Event::Start(e)) if e.name() == QName("text:s") => {
+                    let count = match e.raw_attr("text:c")? {
+                        Some(v) => decode_attr(v)?.parse()?,
                         None => 1,
                     };
                     for _ in 0..count {
@@ -770,19 +765,19 @@ where
         buf.clear();
         match reader.read_event_into(&mut buf) {
             Ok(Event::Start(e))
-                if e.name() == QName(b"table:named-range")
-                    || e.name() == QName(b"table:named-expression") =>
+                if e.name() == QName("table:named-range")
+                    || e.name() == QName("table:named-expression") =>
             {
                 let mut name = String::new();
                 let mut formula = String::new();
                 for attr in e.iter_raw_attrs() {
                     let (key, value) = attr?;
                     match key {
-                        b"table:name" => {
-                            name = decode_attr(&reader.decoder(), value)?;
+                        "table:name" => {
+                            name = decode_attr(value)?;
                         }
-                        b"table:cell-range-address" | b"table:expression" => {
-                            formula = decode_attr(&reader.decoder(), value)?;
+                        "table:cell-range-address" | "table:expression" => {
+                            formula = decode_attr(value)?;
                         }
                         _ => (),
                     }
@@ -790,9 +785,9 @@ where
                 defined_names.push((name, formula));
             }
             Ok(Event::End(e))
-                if e.name() == QName(b"table:named-range")
-                    || e.name() == QName(b"table:named-expression") => {}
-            Ok(Event::End(e)) if e.name() == QName(b"table:named-expressions") => break,
+                if e.name() == QName("table:named-range")
+                    || e.name() == QName("table:named-expression") => {}
+            Ok(Event::End(e)) if e.name() == QName("table:named-expressions") => break,
             Err(e) => return Err(OdsError::Xml(e)),
             Ok(e) => {
                 return Err(OdsError::Mismatch {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -98,10 +98,10 @@ pub(crate) fn unescape_entity_to_buffer(
     entity: &BytesRef,
     buffer: &mut String,
 ) -> Result<(), quick_xml::Error> {
-    let decoded = entity.decode()?;
+    let decoded = entity.as_ref();
 
     // Handle standard XML entities directly.
-    if let Some(unescaped_xml_entity) = resolve_xml_entity(&decoded) {
+    if let Some(unescaped_xml_entity) = resolve_xml_entity(decoded) {
         buffer.push_str(unescaped_xml_entity);
         return Ok(());
     }

--- a/src/xlsb/mod.rs
+++ b/src/xlsb/mod.rs
@@ -168,7 +168,7 @@ pub struct Xlsb<RS> {
 
 impl<RS: Read + Seek> Xlsb<RS> {
     /// MS-XLSB
-    fn read_relationships(&mut self) -> Result<HashMap<Vec<u8>, String>, XlsbError> {
+    fn read_relationships(&mut self) -> Result<HashMap<String, String>, XlsbError> {
         let mut relationships = HashMap::new();
         match self.zip.by_name("xl/_rels/workbook.bin.rels") {
             Ok(f) => {
@@ -185,7 +185,7 @@ impl<RS: Read + Seek> Xlsb<RS> {
                         Ok(Event::Start(e)) if e.name() == QName("Relationship") => {
                             let (id, target) = get_attrs!(e, "Id" => id, "Target" => target)?;
                             if let (Some(id), Some(target)) = (id, target) {
-                                relationships.insert(id.as_bytes().to_vec(), decode_attr(target)?);
+                                relationships.insert(id.to_string(), decode_attr(target)?);
                             }
                         }
                         Ok(Event::Eof) => break,
@@ -285,7 +285,7 @@ impl<RS: Read + Seek> Xlsb<RS> {
     }
 
     /// MS-XLSB 2.1.7.61
-    fn read_workbook(&mut self, relationships: &HashMap<Vec<u8>, String>) -> Result<(), XlsbError> {
+    fn read_workbook(&mut self, relationships: &HashMap<String, String>) -> Result<(), XlsbError> {
         let mut iter =
             RecordIter::from_zip(&mut self.zip, "xl/workbook.bin", &self.zip_path_cache)?;
         let mut buf = Vec::with_capacity(1024);
@@ -305,7 +305,7 @@ impl<RS: Read + Seek> Xlsb<RS> {
                         let relid = &buf[12..12 + rel_len];
                         // converts utf16le to utf8 for HashMap search
                         let relid = UTF_16LE.decode(relid).0;
-                        let path = format!("xl/{}", relationships[relid.as_bytes()]);
+                        let path = format!("xl/{}", relationships[&*relid]);
                         // ST_SheetState
                         let visible = match read_u32(&buf) {
                             0 => SheetVisible::Visible,

--- a/src/xlsb/mod.rs
+++ b/src/xlsb/mod.rs
@@ -182,11 +182,10 @@ impl<RS: Read + Seek> Xlsb<RS> {
 
                 loop {
                     match xml.read_event_into(&mut buf) {
-                        Ok(Event::Start(e)) if e.name() == QName(b"Relationship") => {
-                            let (id, target) = get_attrs!(e, b"Id" => id, b"Target" => target)?;
+                        Ok(Event::Start(e)) if e.name() == QName("Relationship") => {
+                            let (id, target) = get_attrs!(e, "Id" => id, "Target" => target)?;
                             if let (Some(id), Some(target)) = (id, target) {
-                                relationships
-                                    .insert(id.to_vec(), decode_attr(&xml.decoder(), target)?);
+                                relationships.insert(id.as_bytes().to_vec(), decode_attr(target)?);
                             }
                         }
                         Ok(Event::Eof) => break,

--- a/src/xlsx/cells_reader.rs
+++ b/src/xlsx/cells_reader.rs
@@ -210,7 +210,7 @@ where
                 Event::Start(e) => match e.local_name().as_ref() {
                     "dimension" => {
                         if let Some(rdim) = e.raw_attr("ref")? {
-                            dimensions = get_dimension(rdim.as_bytes())?;
+                            dimensions = get_dimension(rdim)?;
                             continue 'xml;
                         }
                         return Err(XlsxError::UnexpectedNode("dimension"));
@@ -259,7 +259,7 @@ where
             match self.xml.read_event_into(&mut self.buf) {
                 Ok(Event::Start(row_element)) if row_element.local_name().as_ref() == "row" => {
                     if let Some(r) = row_element.raw_attr("r")? {
-                        self.row_index = get_row(r.as_bytes())?;
+                        self.row_index = get_row(r)?;
                     }
                 }
                 Ok(Event::End(row_element)) if row_element.local_name().as_ref() == "row" => {
@@ -270,7 +270,7 @@ where
                     let (pos_attr, style_attr, type_attr) =
                         get_attrs!(c_element, "r" => r, "s" => s, "t" => t)?;
                     let pos = if let Some(range) = pos_attr {
-                        let (row, col) = get_row_column(range.as_bytes())?;
+                        let (row, col) = get_row_column(range)?;
                         self.col_index = col;
                         (row, col)
                     } else {
@@ -339,7 +339,7 @@ where
 
             return match ref_attr {
                 Some(res) => {
-                    let range = get_dimension(res.as_bytes())?;
+                    let range = get_dimension(res)?;
                     let formula = formula.unwrap_or_default();
                     if expand_shared_derived {
                         if formulas.len() <= shared_index {
@@ -420,7 +420,7 @@ where
             match self.xml.read_event_into(&mut self.buf) {
                 Ok(Event::Start(row_element)) if row_element.local_name().as_ref() == "row" => {
                     if let Some(r) = row_element.raw_attr("r")? {
-                        self.row_index = get_row(r.as_bytes())?;
+                        self.row_index = get_row(r)?;
                     }
                 }
                 Ok(Event::End(row_element)) if row_element.local_name().as_ref() == "row" => {
@@ -431,7 +431,7 @@ where
                     let (pos_attr, style_attr, type_attr) =
                         get_attrs!(c_element, "r" => r, "s" => s, "t" => t)?;
                     let pos = if let Some(range) = pos_attr {
-                        let (row, col) = get_row_column(range.as_bytes())?;
+                        let (row, col) = get_row_column(range)?;
                         self.col_index = col;
                         (row, col)
                     } else {
@@ -496,7 +496,7 @@ where
             match self.xml.read_event_into(&mut self.buf) {
                 Ok(Event::Start(row_element)) if row_element.local_name().as_ref() == "row" => {
                     if let Some(r) = row_element.raw_attr("r")? {
-                        self.row_index = get_row(r.as_bytes())?;
+                        self.row_index = get_row(r)?;
                     }
                 }
                 Ok(Event::End(row_element)) if row_element.local_name().as_ref() == "row" => {
@@ -505,7 +505,7 @@ where
                 }
                 Ok(Event::Start(c_element)) if c_element.local_name().as_ref() == "c" => {
                     let pos = if let Some(r) = c_element.raw_attr("r")? {
-                        let (row, col) = get_row_column(r.as_bytes())?;
+                        let (row, col) = get_row_column(r)?;
                         self.col_index = col;
                         (row, col)
                     } else {

--- a/src/xlsx/cells_reader.rs
+++ b/src/xlsx/cells_reader.rs
@@ -208,17 +208,17 @@ where
             buf.clear();
             match xml.read_event_into(&mut buf).map_err(XlsxError::Xml)? {
                 Event::Start(e) => match e.local_name().as_ref() {
-                    b"dimension" => {
-                        if let Some(rdim) = e.raw_attr(b"ref")? {
-                            dimensions = get_dimension(rdim)?;
+                    "dimension" => {
+                        if let Some(rdim) = e.raw_attr("ref")? {
+                            dimensions = get_dimension(rdim.as_bytes())?;
                             continue 'xml;
                         }
                         return Err(XlsxError::UnexpectedNode("dimension"));
                     }
-                    b"sheetData" => break,
+                    "sheetData" => break,
                     typ => {
                         if sh_type.is_none() {
-                            sh_type = Some(xml.decoder().decode(typ)?.to_string());
+                            sh_type = Some(typ.to_string());
                         }
                     }
                 },
@@ -257,20 +257,20 @@ where
         loop {
             self.buf.clear();
             match self.xml.read_event_into(&mut self.buf) {
-                Ok(Event::Start(row_element)) if row_element.local_name().as_ref() == b"row" => {
-                    if let Some(r) = row_element.raw_attr(b"r")? {
-                        self.row_index = get_row(r)?;
+                Ok(Event::Start(row_element)) if row_element.local_name().as_ref() == "row" => {
+                    if let Some(r) = row_element.raw_attr("r")? {
+                        self.row_index = get_row(r.as_bytes())?;
                     }
                 }
-                Ok(Event::End(row_element)) if row_element.local_name().as_ref() == b"row" => {
+                Ok(Event::End(row_element)) if row_element.local_name().as_ref() == "row" => {
                     self.row_index += 1;
                     self.col_index = 0;
                 }
-                Ok(Event::Start(c_element)) if c_element.local_name().as_ref() == b"c" => {
+                Ok(Event::Start(c_element)) if c_element.local_name().as_ref() == "c" => {
                     let (pos_attr, style_attr, type_attr) =
-                        get_attrs!(c_element, b"r" => r, b"s" => s, b"t" => t)?;
+                        get_attrs!(c_element, "r" => r, "s" => s, "t" => t)?;
                     let pos = if let Some(range) = pos_attr {
-                        let (row, col) = get_row_column(range)?;
+                        let (row, col) = get_row_column(range.as_bytes())?;
                         self.col_index = col;
                         (row, col)
                     } else {
@@ -295,7 +295,7 @@ where
                                     &mut self.value_bufs,
                                 )?;
                             }
-                            Ok(Event::End(e)) if e.local_name().as_ref() == b"c" => break,
+                            Ok(Event::End(e)) if e.local_name().as_ref() == "c" => break,
                             Ok(Event::Eof) => return Err(XlsxError::XmlEof("c")),
                             Err(e) => return Err(XlsxError::Xml(e)),
                             _ => (),
@@ -304,7 +304,7 @@ where
                     self.col_index += 1;
                     return Ok(Some(Cell::new(pos, value)));
                 }
-                Ok(Event::End(e)) if e.local_name().as_ref() == b"sheetData" => {
+                Ok(Event::End(e)) if e.local_name().as_ref() == "sheetData" => {
                     return Ok(None);
                 }
                 Ok(Event::Eof) => return Err(XlsxError::XmlEof("sheetData")),
@@ -323,10 +323,10 @@ where
     ) -> Result<Option<FormulaMetadata>, XlsxError> {
         let formula = read_formula(xml, e)?;
 
-        let (t_attr, si_attr, ref_attr) = get_attrs!(e, b"t" => t, b"si" => si, b"ref" => ref_)?;
-        if t_attr == Some(b"shared".as_slice()) {
+        let (t_attr, si_attr, ref_attr) = get_attrs!(e, "t" => t, "si" => si, "ref" => ref_)?;
+        if t_attr == Some("shared") {
             let shared_index = match si_attr {
-                Some(res) => match atoi_simd::parse::<usize, true, false>(res) {
+                Some(res) => match atoi_simd::parse::<usize, true, false>(res.as_bytes()) {
                     Ok(res) => res,
                     Err(_) => return Err(XlsxError::Unexpected("si attribute must be a number")),
                 },
@@ -339,7 +339,7 @@ where
 
             return match ref_attr {
                 Some(res) => {
-                    let range = get_dimension(res)?;
+                    let range = get_dimension(res.as_bytes())?;
                     let formula = formula.unwrap_or_default();
                     if expand_shared_derived {
                         if formulas.len() <= shared_index {
@@ -418,20 +418,20 @@ where
         loop {
             self.buf.clear();
             match self.xml.read_event_into(&mut self.buf) {
-                Ok(Event::Start(row_element)) if row_element.local_name().as_ref() == b"row" => {
-                    if let Some(r) = row_element.raw_attr(b"r")? {
-                        self.row_index = get_row(r)?;
+                Ok(Event::Start(row_element)) if row_element.local_name().as_ref() == "row" => {
+                    if let Some(r) = row_element.raw_attr("r")? {
+                        self.row_index = get_row(r.as_bytes())?;
                     }
                 }
-                Ok(Event::End(row_element)) if row_element.local_name().as_ref() == b"row" => {
+                Ok(Event::End(row_element)) if row_element.local_name().as_ref() == "row" => {
                     self.row_index += 1;
                     self.col_index = 0;
                 }
-                Ok(Event::Start(c_element)) if c_element.local_name().as_ref() == b"c" => {
+                Ok(Event::Start(c_element)) if c_element.local_name().as_ref() == "c" => {
                     let (pos_attr, style_attr, type_attr) =
-                        get_attrs!(c_element, b"r" => r, b"s" => s, b"t" => t)?;
+                        get_attrs!(c_element, "r" => r, "s" => s, "t" => t)?;
                     let pos = if let Some(range) = pos_attr {
-                        let (row, col) = get_row_column(range)?;
+                        let (row, col) = get_row_column(range.as_bytes())?;
                         self.col_index = col;
                         (row, col)
                     } else {
@@ -442,7 +442,7 @@ where
                     loop {
                         self.cell_buf.clear();
                         match self.xml.read_event_into(&mut self.cell_buf) {
-                            Ok(Event::Start(e)) if e.local_name().as_ref() == b"f" => {
+                            Ok(Event::Start(e)) if e.local_name().as_ref() == "f" => {
                                 formula = Self::read_formula_record(
                                     &mut self.xml,
                                     &mut self.formulas,
@@ -466,7 +466,7 @@ where
                                     &mut self.value_bufs,
                                 )?;
                             }
-                            Ok(Event::End(e)) if e.local_name().as_ref() == b"c" => break,
+                            Ok(Event::End(e)) if e.local_name().as_ref() == "c" => break,
                             Ok(Event::Eof) => return Err(XlsxError::XmlEof("c")),
                             Err(e) => return Err(XlsxError::Xml(e)),
                             _ => (),
@@ -479,7 +479,7 @@ where
                         formula,
                     }));
                 }
-                Ok(Event::End(e)) if e.local_name().as_ref() == b"sheetData" => {
+                Ok(Event::End(e)) if e.local_name().as_ref() == "sheetData" => {
                     return Ok(None);
                 }
                 Ok(Event::Eof) => return Err(XlsxError::XmlEof("sheetData")),
@@ -494,18 +494,18 @@ where
         loop {
             self.buf.clear();
             match self.xml.read_event_into(&mut self.buf) {
-                Ok(Event::Start(row_element)) if row_element.local_name().as_ref() == b"row" => {
-                    if let Some(r) = row_element.raw_attr(b"r")? {
-                        self.row_index = get_row(r)?;
+                Ok(Event::Start(row_element)) if row_element.local_name().as_ref() == "row" => {
+                    if let Some(r) = row_element.raw_attr("r")? {
+                        self.row_index = get_row(r.as_bytes())?;
                     }
                 }
-                Ok(Event::End(row_element)) if row_element.local_name().as_ref() == b"row" => {
+                Ok(Event::End(row_element)) if row_element.local_name().as_ref() == "row" => {
                     self.row_index += 1;
                     self.col_index = 0;
                 }
-                Ok(Event::Start(c_element)) if c_element.local_name().as_ref() == b"c" => {
-                    let pos = if let Some(r) = c_element.raw_attr(b"r")? {
-                        let (row, col) = get_row_column(r)?;
+                Ok(Event::Start(c_element)) if c_element.local_name().as_ref() == "c" => {
+                    let pos = if let Some(r) = c_element.raw_attr("r")? {
+                        let (row, col) = get_row_column(r.as_bytes())?;
                         self.col_index = col;
                         (row, col)
                     } else {
@@ -529,7 +529,7 @@ where
                                     value = Some(formula_text);
                                 }
                             }
-                            Ok(Event::End(e)) if e.local_name().as_ref() == b"c" => break,
+                            Ok(Event::End(e)) if e.local_name().as_ref() == "c" => break,
                             Ok(Event::Eof) => return Err(XlsxError::XmlEof("c")),
                             Err(e) => return Err(XlsxError::Xml(e)),
                             _ => (),
@@ -538,7 +538,7 @@ where
                     self.col_index += 1;
                     return Ok(Some(Cell::new(pos, value.unwrap_or_default())));
                 }
-                Ok(Event::End(e)) if e.local_name().as_ref() == b"sheetData" => {
+                Ok(Event::End(e)) if e.local_name().as_ref() == "sheetData" => {
                     return Ok(None);
                 }
                 Ok(Event::Eof) => return Err(XlsxError::XmlEof("sheetData")),
@@ -555,33 +555,33 @@ fn read_value<'s, RS>(
     ctx: &WorkbookContext<'s>,
     xml: &mut XlReader<'_, RS>,
     e: &BytesStart<'_>,
-    style_attr: Option<&[u8]>,
-    type_attr: Option<&[u8]>,
+    style_attr: Option<&str>,
+    type_attr: Option<&str>,
     bufs: &mut ValueBufs,
 ) -> Result<DataRef<'s>, XlsxError>
 where
     RS: Read + Seek,
 {
     Ok(match e.local_name().as_ref() {
-        b"is" => {
+        "is" => {
             // inlineStr
             read_string_with_bufs(xml, e.name(), &mut bufs.xml, &mut bufs.str_inner)?
                 .map_or(DataRef::Empty, DataRef::String)
         }
         // Ignore <v> for inlineStr cells since it is redundant. The value is in
         // the <is> element, which is handled above.
-        b"v" if matches!(type_attr, Some(b"inlineStr") | Some(b"is")) => {
+        "v" if matches!(type_attr, Some("inlineStr") | Some("is")) => {
             bufs.xml.clear();
             xml.read_to_end_into(e.name(), &mut bufs.xml)?;
             DataRef::Empty
         }
-        b"v" => match type_attr {
-            Some(b"n") | Some(b"s") | Some(b"b") | Some(b"e") | None => {
+        "v" => match type_attr {
+            Some("n") | Some("s") | Some("b") | Some("e") | None => {
                 // These types are always plain ASCII (no CR/LF or entities), so we can
                 // parse directly from raw bytes, skipping `xml10_content()` + String
                 bufs.xml.clear();
                 let val = match xml.read_event_into(&mut bufs.xml)? {
-                    Event::Text(t) => read_v(ctx, &t, style_attr, type_attr)?,
+                    Event::Text(t) => read_v(ctx, t.as_ref(), style_attr, type_attr)?,
                     Event::End(end) if end.name() == e.name() => return Ok(DataRef::Empty),
                     Event::Eof => return Err(XlsxError::XmlEof("v")),
                     _ => DataRef::Empty,
@@ -596,17 +596,17 @@ where
                 loop {
                     bufs.xml.clear();
                     match xml.read_event_into(&mut bufs.xml)? {
-                        Event::Text(t) => bufs.value.push_str(&t.xml10_content()?),
+                        Event::Text(t) => bufs.value.push_str(&t.xml10_content()),
                         Event::GeneralRef(e) => unescape_entity_to_buffer(&e, &mut bufs.value)?,
                         Event::End(end) if end.name() == e.name() => break,
                         Event::Eof => return Err(XlsxError::XmlEof("v")),
                         _ => (),
                     }
                 }
-                read_v(ctx, bufs.value.as_bytes(), style_attr, type_attr)?
+                read_v(ctx, &bufs.value, style_attr, type_attr)?
             }
         },
-        b"f" => {
+        "f" => {
             bufs.xml.clear();
             xml.read_to_end_into(e.name(), &mut bufs.xml)?;
             DataRef::Empty
@@ -615,32 +615,27 @@ where
     })
 }
 
-/// Convert raw `<v>` bytes to a `&str`, returning an error on invalid UTF-8.
-fn v_as_str(v: &[u8]) -> Result<&str, XlsxError> {
-    std::str::from_utf8(v).map_err(|_| XlsxError::Unexpected("invalid UTF-8 in cell value"))
-}
-
-/// Parse a `<v>` cell value from raw bytes with pre-extracted
+/// Parse a `<v>` cell value from raw text with pre-extracted
 /// `s` (style) and `t` (type) attributes.
 fn read_v<'s>(
     ctx: &WorkbookContext<'s>,
-    v: &[u8],
-    style_attr: Option<&[u8]>,
-    type_attr: Option<&[u8]>,
+    v: &str,
+    style_attr: Option<&str>,
+    type_attr: Option<&str>,
 ) -> Result<DataRef<'s>, XlsxError> {
     let cell_format = match style_attr {
         Some(style) => {
-            let id = atoi_simd::parse::<usize, true, false>(style).unwrap_or(0);
+            let id = atoi_simd::parse::<usize, true, false>(style.as_bytes()).unwrap_or(0);
             ctx.formats.get(id)
         }
         None => Some(&CellFormat::Other),
     };
     match type_attr {
-        Some(b"s") => {
+        Some("s") => {
             if v.is_empty() {
                 return Ok(DataRef::Empty);
             }
-            let idx = atoi_simd::parse::<usize, true, false>(v).unwrap_or(0);
+            let idx = atoi_simd::parse::<usize, true, false>(v.as_bytes()).unwrap_or(0);
             ctx.strings
                 .get(idx)
                 .map(|s| DataRef::SharedString(s))
@@ -648,33 +643,28 @@ fn read_v<'s>(
                     "Cell string index not found in shared strings table",
                 ))
         }
-        Some(b"b") => Ok(DataRef::Bool(v != b"0")),
-        Some(b"d") => Ok(DataRef::DateTimeIso(v_as_str(v)?.to_string())),
-        Some(b"e") => Ok(DataRef::Error(v_as_str(v)?.parse()?)),
-        Some(b"str") => Ok(DataRef::String(v_as_str(v)?.to_string())),
-        Some(b"n") | None => {
+        Some("b") => Ok(DataRef::Bool(v != "0")),
+        Some("d") => Ok(DataRef::DateTimeIso(v.to_string())),
+        Some("e") => Ok(DataRef::Error(v.parse()?)),
+        Some("str") => Ok(DataRef::String(v.to_string())),
+        Some("n") | None => {
             if v.is_empty() {
                 return Ok(DataRef::Empty);
             }
             // If type is not known, we try to parse as Float for utility, but fall back to
             // String if this fails.
-            fast_float2::parse::<f64, _>(v)
+            fast_float2::parse::<f64, _>(v.as_bytes())
                 .map(|n| format_excel_f64_ref(n, cell_format, ctx.is_1904))
                 .or_else(|_| {
                     if type_attr.is_none() {
                         // No explicit type: fall back to String if not a valid float
-                        Ok(DataRef::String(v_as_str(v)?.to_string()))
+                        Ok(DataRef::String(v.to_string()))
                     } else {
-                        Err(XlsxError::ParseFloat(
-                            v_as_str(v)?.parse::<f64>().unwrap_err(),
-                        ))
+                        Err(XlsxError::ParseFloat(v.parse::<f64>().unwrap_err()))
                     }
                 })
         }
-        Some(t) => {
-            let t = std::str::from_utf8(t).unwrap_or("<utf8 error>").to_string();
-            Err(XlsxError::CellTAttribute(t))
-        }
+        Some(t) => Err(XlsxError::CellTAttribute(t.to_string())),
     }
 }
 
@@ -683,16 +673,16 @@ where
     RS: Read + Seek,
 {
     match e.local_name().as_ref() {
-        b"is" | b"v" => {
+        "is" | "v" => {
             xml.read_to_end_into(e.name(), &mut Vec::new())?;
             Ok(None)
         }
-        b"f" => {
+        "f" => {
             let mut f_buf = Vec::with_capacity(512);
             let mut f = String::new();
             loop {
                 match xml.read_event_into(&mut f_buf)? {
-                    Event::Text(t) => f.push_str(&t.xml10_content()?),
+                    Event::Text(t) => f.push_str(&t.xml10_content()),
                     Event::GeneralRef(e) => unescape_entity_to_buffer(&e, &mut f)?,
                     Event::End(end) if end.name() == e.name() => break,
                     Event::Eof => return Err(XlsxError::XmlEof("f")),

--- a/src/xlsx/mod.rs
+++ b/src/xlsx/mod.rs
@@ -420,7 +420,7 @@ impl<RS: Read + Seek> Xlsx<RS> {
                                 CellFormat::Other,
                                 |val| match number_formats.get(val) {
                                     Some(fmt) => detect_custom_number_format(fmt),
-                                    None => builtin_format_by_id(val.as_bytes()),
+                                    None => builtin_format_by_id(val),
                                 },
                             ));
                         }
@@ -441,7 +441,7 @@ impl<RS: Read + Seek> Xlsx<RS> {
 
     fn read_workbook(
         &mut self,
-        relationships: &HashMap<Vec<u8>, (String, String)>,
+        relationships: &HashMap<String, (String, String)>,
     ) -> Result<(), XlsxError> {
         let path = format!("{}workbook.xml", self.xl_path);
         let mut xml = match xml_reader(&mut self.zip, path.as_ref(), &self.zip_path_cache) {
@@ -456,7 +456,7 @@ impl<RS: Read + Seek> Xlsx<RS> {
             match xml.read_event_into(&mut buf) {
                 Ok(Event::Start(e)) if e.local_name().as_ref() == "sheet" => {
                     let mut name = String::new();
-                    let mut rel_id = Vec::new();
+                    let mut rel_id = "";
                     let mut visible = SheetVisible::Visible;
                     for attr in e.iter_raw_attrs() {
                         let (key, val) = attr?;
@@ -479,13 +479,13 @@ impl<RS: Read + Seek> Xlsx<RS> {
                             }
                             // Ignore the "r:id" attribute namespace and match on the "id" name.
                             key if local_name_matches(key, "id") => {
-                                rel_id = val.as_bytes().to_vec();
+                                rel_id = val;
                             }
                             _ => {}
                         }
                     }
                     let (r, rel_type) = relationships
-                        .get(&rel_id)
+                        .get(rel_id)
                         .ok_or(XlsxError::RelationshipNotFound)?;
                     // target may be absolute or relative path;
                     let path = if let Some(abs_path) = r.strip_prefix("/") {
@@ -546,7 +546,7 @@ impl<RS: Read + Seek> Xlsx<RS> {
         Ok(())
     }
 
-    fn read_relationships(&mut self) -> Result<HashMap<Vec<u8>, (String, String)>, XlsxError> {
+    fn read_relationships(&mut self) -> Result<HashMap<String, (String, String)>, XlsxError> {
         let rels_path = format!("{}_rels/workbook.xml.rels", self.xl_path);
         let mut xml = match xml_reader(&mut self.zip, rels_path.as_ref(), &self.zip_path_cache) {
             None => {
@@ -565,7 +565,7 @@ impl<RS: Read + Seek> Xlsx<RS> {
                     if let Some(id) = id {
                         let rel_type = rel_type.map(ToOwned::to_owned).unwrap_or_default();
                         let target = target.map(ToOwned::to_owned).unwrap_or_default();
-                        relationships.insert(id.as_bytes().to_vec(), (target, rel_type));
+                        relationships.insert(id.to_string(), (target, rel_type));
                     }
                 }
                 Ok(Event::End(e)) if e.local_name().as_ref() == "Relationships" => break,
@@ -669,7 +669,7 @@ impl<RS: Read + Seek> Xlsx<RS> {
                         _ => (),
                     }
                 }
-                let mut dims = get_dimension(table_meta.ref_cells.as_bytes())?;
+                let mut dims = get_dimension(&table_meta.ref_cells)?;
                 if table_meta.header_row_count != 0 {
                     dims.start.0 += table_meta.header_row_count;
                 }
@@ -1087,8 +1087,7 @@ impl<RS: Read + Seek> Xlsx<RS> {
                                 if let Some(media_path) = idx_to_media.get(img_idx) {
                                     if !media_path.is_empty() {
                                         if let Some((ext, data)) = media.get(media_path) {
-                                            let col =
-                                                r.map_or(0, |r| col_from_cell_ref(r.as_bytes()));
+                                            let col = r.map_or(0, col_from_cell_ref);
                                             seen.insert(media_path.clone());
                                             pics.push(Picture {
                                                 extension: ext.clone(),
@@ -1238,7 +1237,7 @@ impl<RS: Read + Seek> Xlsx<RS> {
                     match xml.read_event_into(&mut buf) {
                         Ok(Event::Start(e)) if e.local_name().as_ref() == "mergeCell" => {
                             if let Some(val) = e.raw_attr("ref")? {
-                                let dimension = get_dimension(val.as_bytes())?;
+                                let dimension = get_dimension(val)?;
                                 regions.push((
                                     sheet_name.to_string(),
                                     sheet_path.to_string(),
@@ -2435,7 +2434,7 @@ where
                     let (key, val) = attr?;
                     match key {
                         "ref" => {
-                            range = Some(get_dimension(val.as_bytes())?);
+                            range = Some(get_dimension(val)?);
                         }
                         "location" => {
                             location = Some(unescape_xml(val).into_owned());
@@ -2724,12 +2723,11 @@ fn resolve_path(base: &str, target: &str) -> String {
     }
 }
 
-// Parse the 0-based column index from the raw bytes of an A1-style cell
-// reference like `B2`.
+// Parse the 0-based column index from an A1-style cell reference like `B2`.
 #[cfg(feature = "picture")]
-fn col_from_cell_ref(cell_ref: &[u8]) -> u32 {
+fn col_from_cell_ref(cell_ref: &str) -> u32 {
     let mut col: u32 = 0;
-    for &b in cell_ref {
+    for &b in cell_ref.as_bytes() {
         if b.is_ascii_alphabetic() {
             col = col * 26 + (b.to_ascii_uppercase() - b'A') as u32 + 1;
         } else {
@@ -2764,9 +2762,9 @@ fn xml_reader<'a, RS: Read + Seek>(
 /// converts a text representation (e.g. "A6:G67") of a dimension into integers
 /// - top left (row, column),
 /// - bottom right (row, column)
-pub(crate) fn get_dimension(dimension: &[u8]) -> Result<Dimensions, XlsxError> {
+pub(crate) fn get_dimension(dimension: &str) -> Result<Dimensions, XlsxError> {
     let parts: Vec<_> = dimension
-        .split(|c| *c == b':')
+        .split(':')
         .map(get_row_column)
         .collect::<Result<Vec<_>, XlsxError>>()?;
 
@@ -2796,7 +2794,7 @@ pub(crate) fn get_dimension(dimension: &[u8]) -> Result<Dimensions, XlsxError> {
 
 /// Converts a text range name into its position (row, column) (0 based index).
 /// If the row or column component in the range is missing, an Error is returned.
-pub(crate) fn get_row_column(range: &[u8]) -> Result<(u32, u32), XlsxError> {
+pub(crate) fn get_row_column(range: &str) -> Result<(u32, u32), XlsxError> {
     let (row, col) = get_row_and_optional_column(range)?;
     let col = col.ok_or(XlsxError::RangeWithoutColumnComponent)?;
     Ok((row, col))
@@ -2805,14 +2803,17 @@ pub(crate) fn get_row_column(range: &[u8]) -> Result<(u32, u32), XlsxError> {
 /// Converts a text row name into its position (0 based index).
 /// If the row component in the range is missing, an Error is returned.
 /// If the text row name also contains a column component, it is ignored.
-pub(crate) fn get_row(range: &[u8]) -> Result<u32, XlsxError> {
+pub(crate) fn get_row(range: &str) -> Result<u32, XlsxError> {
     get_row_and_optional_column(range).map(|(row, _)| row)
 }
 
 /// Converts a text-based range name into its `(row, column)` position (0-based index).
 /// If the column component of the range is missing, a None is returned (for the column).
 /// If the row component of the range is missing, an Error is returned.
-fn get_row_and_optional_column(range: &[u8]) -> Result<(u32, Option<u32>), XlsxError> {
+fn get_row_and_optional_column(range: &str) -> Result<(u32, Option<u32>), XlsxError> {
+    // Cell references are ASCII; scan the bytes directly. Any non-ASCII byte
+    // falls through to the `Alphanumeric` error arms below.
+    let range = range.as_bytes();
     let len = range.len();
     let mut i = 0;
 
@@ -2944,7 +2945,7 @@ where
         match xml.read_event_into(&mut buffer) {
             Ok(Event::Start(event)) if event.local_name().as_ref() == "mergeCell" => {
                 if let Some(val) = event.raw_attr("ref")? {
-                    merge_cells.push(get_dimension(val.as_bytes())?);
+                    merge_cells.push(get_dimension(val)?);
                 }
             }
             Ok(Event::End(event)) if event.local_name().as_ref() == "mergeCells" => {
@@ -3943,17 +3944,17 @@ mod tests {
 
     #[test]
     fn test_dimensions() {
-        assert_eq!(get_row_column(b"A1").unwrap(), (0, 0));
-        assert_eq!(get_row_column(b"C107").unwrap(), (106, 2));
+        assert_eq!(get_row_column("A1").unwrap(), (0, 0));
+        assert_eq!(get_row_column("C107").unwrap(), (106, 2));
         assert_eq!(
-            get_dimension(b"C2:D35").unwrap(),
+            get_dimension("C2:D35").unwrap(),
             Dimensions {
                 start: (1, 2),
                 end: (34, 3)
             }
         );
         assert_eq!(
-            get_dimension(b"A1:XFD1048576").unwrap(),
+            get_dimension("A1:XFD1048576").unwrap(),
             Dimensions {
                 start: (0, 0),
                 end: (1_048_575, 16_383),
@@ -3963,9 +3964,9 @@ mod tests {
 
     #[test]
     fn test_dimension_length() {
-        assert_eq!(get_dimension(b"A1:Z99").unwrap().len(), 2_574);
+        assert_eq!(get_dimension("A1:Z99").unwrap().len(), 2_574);
         assert_eq!(
-            get_dimension(b"A1:XFD1048576").unwrap().len(),
+            get_dimension("A1:XFD1048576").unwrap().len(),
             17_179_869_184
         );
     }

--- a/src/xlsx/mod.rs
+++ b/src/xlsx/mod.rs
@@ -16,7 +16,6 @@ use std::str::FromStr;
 use log::warn;
 use quick_xml::events::{BytesStart, Event};
 use quick_xml::name::QName;
-use quick_xml::Decoder;
 use quick_xml::Reader as XmlReader;
 use zip::read::{ZipArchive, ZipFile};
 use zip::result::ZipError;
@@ -294,7 +293,7 @@ impl<RS: Read + Seek> Xlsx<RS> {
         loop {
             buf.clear();
             match xml.read_event_into(&mut buf) {
-                Ok(Event::Start(e)) if e.local_name().as_ref() == b"Relationships" => break,
+                Ok(Event::Start(e)) if e.local_name().as_ref() == "Relationships" => break,
                 Ok(Event::Eof) => return Err(XlsxError::XmlEof("Relationships")),
                 Err(e) => return Err(XlsxError::Xml(e)),
                 _ => (),
@@ -305,19 +304,18 @@ impl<RS: Read + Seek> Xlsx<RS> {
         loop {
             buf.clear();
             match xml.read_event_into(&mut buf) {
-                Ok(Event::Start(e)) if e.local_name().as_ref() == b"Relationship" => {
-                    let (rel_type, target) =
-                        get_attrs!(e, b"Type" => rel_type, b"Target" => target)?;
+                Ok(Event::Start(e)) if e.local_name().as_ref() == "Relationship" => {
+                    let (rel_type, target) = get_attrs!(e, "Type" => rel_type, "Target" => target)?;
                     let is_office_doc = rel_type
-                        .map(|t| t.ends_with(b"/relationships/officeDocument"))
+                        .map(|t| t.ends_with("/relationships/officeDocument"))
                         .unwrap_or(false);
                     if is_office_doc {
                         if let Some(target) = target {
-                            document_target = Some(decode_attr(&xml.decoder(), target)?);
+                            document_target = Some(decode_attr(target)?);
                         }
                     }
                 }
-                Ok(Event::End(e)) if e.local_name().as_ref() == b"Relationships" => break,
+                Ok(Event::End(e)) if e.local_name().as_ref() == "Relationships" => break,
                 Ok(Event::Eof) => return Err(XlsxError::XmlEof("Relationships")),
                 Err(e) => return Err(XlsxError::Xml(e)),
                 _ => (),
@@ -348,9 +346,9 @@ impl<RS: Read + Seek> Xlsx<RS> {
         loop {
             buf.clear();
             match xml.read_event_into(&mut buf) {
-                Ok(Event::Start(e)) if e.local_name().as_ref() == b"sst" => {
-                    if let Some(count) = e.raw_attr(b"uniqueCount")? {
-                        if let Ok(n) = atoi_simd::parse::<usize, true, false>(count) {
+                Ok(Event::Start(e)) if e.local_name().as_ref() == "sst" => {
+                    if let Some(count) = e.raw_attr("uniqueCount")? {
+                        if let Ok(n) = atoi_simd::parse::<usize, true, false>(count.as_bytes()) {
                             self.strings.reserve(n);
                         }
                     }
@@ -367,14 +365,14 @@ impl<RS: Read + Seek> Xlsx<RS> {
         loop {
             buf.clear();
             match xml.read_event_into(&mut buf) {
-                Ok(Event::Start(e)) if e.local_name().as_ref() == b"si" => {
+                Ok(Event::Start(e)) if e.local_name().as_ref() == "si" => {
                     if let Some(s) =
                         read_string_with_bufs(&mut xml, e.name(), &mut str_buf, &mut str_val_buf)?
                     {
                         self.strings.push(s);
                     }
                 }
-                Ok(Event::End(e)) if e.local_name().as_ref() == b"sst" => break,
+                Ok(Event::End(e)) if e.local_name().as_ref() == "sst" => break,
                 Ok(Event::Eof) => return Err(XlsxError::XmlEof("sst")),
                 Err(e) => return Err(XlsxError::Xml(e)),
                 _ => (),
@@ -397,42 +395,42 @@ impl<RS: Read + Seek> Xlsx<RS> {
         loop {
             buf.clear();
             match xml.read_event_into(&mut buf) {
-                Ok(Event::Start(e)) if e.local_name().as_ref() == b"numFmts" => loop {
+                Ok(Event::Start(e)) if e.local_name().as_ref() == "numFmts" => loop {
                     inner_buf.clear();
                     match xml.read_event_into(&mut inner_buf) {
-                        Ok(Event::Start(e)) if e.local_name().as_ref() == b"numFmt" => {
+                        Ok(Event::Start(e)) if e.local_name().as_ref() == "numFmt" => {
                             let (id, format_code) =
-                                get_attrs!(e, b"numFmtId" => id, b"formatCode" => fmt)?;
+                                get_attrs!(e, "numFmtId" => id, "formatCode" => fmt)?;
                             if let (Some(id), Some(fc)) = (id, format_code) {
-                                let format = decode_attr(&xml.decoder(), fc)?;
-                                number_formats.insert(id.to_vec(), format);
+                                let format = decode_attr(fc)?;
+                                number_formats.insert(id.to_string(), format);
                             }
                         }
-                        Ok(Event::End(e)) if e.local_name().as_ref() == b"numFmts" => break,
+                        Ok(Event::End(e)) if e.local_name().as_ref() == "numFmts" => break,
                         Ok(Event::Eof) => return Err(XlsxError::XmlEof("numFmts")),
                         Err(e) => return Err(XlsxError::Xml(e)),
                         _ => (),
                     }
                 },
-                Ok(Event::Start(e)) if e.local_name().as_ref() == b"cellXfs" => loop {
+                Ok(Event::Start(e)) if e.local_name().as_ref() == "cellXfs" => loop {
                     inner_buf.clear();
                     match xml.read_event_into(&mut inner_buf) {
-                        Ok(Event::Start(e)) if e.local_name().as_ref() == b"xf" => {
-                            self.formats.push(e.raw_attr(b"numFmtId")?.map_or(
+                        Ok(Event::Start(e)) if e.local_name().as_ref() == "xf" => {
+                            self.formats.push(e.raw_attr("numFmtId")?.map_or(
                                 CellFormat::Other,
                                 |val| match number_formats.get(val) {
                                     Some(fmt) => detect_custom_number_format(fmt),
-                                    None => builtin_format_by_id(val),
+                                    None => builtin_format_by_id(val.as_bytes()),
                                 },
                             ));
                         }
-                        Ok(Event::End(e)) if e.local_name().as_ref() == b"cellXfs" => break,
+                        Ok(Event::End(e)) if e.local_name().as_ref() == "cellXfs" => break,
                         Ok(Event::Eof) => return Err(XlsxError::XmlEof("cellXfs")),
                         Err(e) => return Err(XlsxError::Xml(e)),
                         _ => (),
                     }
                 },
-                Ok(Event::End(e)) if e.local_name().as_ref() == b"styleSheet" => break,
+                Ok(Event::End(e)) if e.local_name().as_ref() == "styleSheet" => break,
                 Ok(Event::Eof) => return Err(XlsxError::XmlEof("styleSheet")),
                 Err(e) => return Err(XlsxError::Xml(e)),
                 _ => (),
@@ -456,33 +454,32 @@ impl<RS: Read + Seek> Xlsx<RS> {
         loop {
             buf.clear();
             match xml.read_event_into(&mut buf) {
-                Ok(Event::Start(e)) if e.local_name().as_ref() == b"sheet" => {
+                Ok(Event::Start(e)) if e.local_name().as_ref() == "sheet" => {
                     let mut name = String::new();
                     let mut rel_id = Vec::new();
                     let mut visible = SheetVisible::Visible;
                     for attr in e.iter_raw_attrs() {
                         let (key, val) = attr?;
                         match key {
-                            b"name" => {
-                                name = decode_attr(&xml.decoder(), val)?;
+                            "name" => {
+                                name = decode_attr(val)?;
                             }
-                            b"state" => {
+                            "state" => {
                                 visible = match val {
-                                    b"visible" => SheetVisible::Visible,
-                                    b"hidden" => SheetVisible::Hidden,
-                                    b"veryHidden" => SheetVisible::VeryHidden,
+                                    "visible" => SheetVisible::Visible,
+                                    "hidden" => SheetVisible::Hidden,
+                                    "veryHidden" => SheetVisible::VeryHidden,
                                     v => {
-                                        let v = xml.decoder().decode(v)?;
                                         return Err(XlsxError::Unrecognized {
                                             typ: "sheet:state",
-                                            val: v.into_owned(),
+                                            val: v.to_string(),
                                         });
                                     }
                                 }
                             }
                             // Ignore the "r:id" attribute namespace and match on the "id" name.
-                            key if local_name_matches(key, b"id") => {
-                                rel_id = val.to_vec();
+                            key if local_name_matches(key, "id") => {
+                                rel_id = val.as_bytes().to_vec();
                             }
                             _ => {}
                         }
@@ -514,22 +511,22 @@ impl<RS: Read + Seek> Xlsx<RS> {
                     });
                     self.sheets.push((name, path));
                 }
-                Ok(Event::Start(e)) if e.local_name().as_ref() == b"workbookPr" => {
+                Ok(Event::Start(e)) if e.local_name().as_ref() == "workbookPr" => {
                     // Set the 1904 date flag, if present. The attribute is
                     // optional here because `<x15:workbookPr>` inside `<extLst>`
                     // shares this local name and never carries `date1904`.
-                    if let Some(v) = e.raw_attr(b"date1904")? {
-                        self.is_1904 = v == b"1" || v == b"true";
+                    if let Some(v) = e.raw_attr("date1904")? {
+                        self.is_1904 = v == "1" || v == "true";
                     }
                 }
-                Ok(Event::Start(e)) if e.local_name().as_ref() == b"definedName" => {
-                    if let Some(val) = e.raw_attr(b"name")? {
-                        let name = decode_attr(&xml.decoder(), val)?;
+                Ok(Event::Start(e)) if e.local_name().as_ref() == "definedName" => {
+                    if let Some(val) = e.raw_attr("name")? {
+                        let name = decode_attr(val)?;
                         val_buf.clear();
                         let mut value = String::new();
                         loop {
                             match xml.read_event_into(&mut val_buf)? {
-                                Event::Text(t) => value.push_str(&t.xml10_content()?),
+                                Event::Text(t) => value.push_str(&t.xml10_content()),
                                 Event::GeneralRef(e) => unescape_entity_to_buffer(&e, &mut value)?,
                                 Event::End(end) if end.name() == e.name() => break,
                                 Event::Eof => return Err(XlsxError::XmlEof("workbook")),
@@ -539,7 +536,7 @@ impl<RS: Read + Seek> Xlsx<RS> {
                         defined_names.push((name, value));
                     }
                 }
-                Ok(Event::End(e)) if e.local_name().as_ref() == b"workbook" => break,
+                Ok(Event::End(e)) if e.local_name().as_ref() == "workbook" => break,
                 Ok(Event::Eof) => return Err(XlsxError::XmlEof("workbook")),
                 Err(e) => return Err(XlsxError::Xml(e)),
                 _ => (),
@@ -562,23 +559,16 @@ impl<RS: Read + Seek> Xlsx<RS> {
         loop {
             buf.clear();
             match xml.read_event_into(&mut buf) {
-                Ok(Event::Start(e)) if e.local_name().as_ref() == b"Relationship" => {
+                Ok(Event::Start(e)) if e.local_name().as_ref() == "Relationship" => {
                     let (id, rel_type, target) =
-                        get_attrs!(e, b"Id" => id, b"Type" => rel_type, b"Target" => target)?;
+                        get_attrs!(e, "Id" => id, "Type" => rel_type, "Target" => target)?;
                     if let Some(id) = id {
-                        let decoder = xml.decoder();
-                        let rel_type = rel_type
-                            .map(|v| decoder.decode(v).map(|s| s.into_owned()))
-                            .transpose()?
-                            .unwrap_or_default();
-                        let target = target
-                            .map(|v| decoder.decode(v).map(|s| s.into_owned()))
-                            .transpose()?
-                            .unwrap_or_default();
-                        relationships.insert(id.to_vec(), (target, rel_type));
+                        let rel_type = rel_type.map(ToOwned::to_owned).unwrap_or_default();
+                        let target = target.map(ToOwned::to_owned).unwrap_or_default();
+                        relationships.insert(id.as_bytes().to_vec(), (target, rel_type));
                     }
                 }
-                Ok(Event::End(e)) if e.local_name().as_ref() == b"Relationships" => break,
+                Ok(Event::End(e)) if e.local_name().as_ref() == "Relationships" => break,
                 Ok(Event::Eof) => return Err(XlsxError::XmlEof("Relationships")),
                 Err(e) => return Err(XlsxError::Xml(e)),
                 _ => (),
@@ -606,13 +596,13 @@ impl<RS: Read + Seek> Xlsx<RS> {
                 loop {
                     buf.clear();
                     match xml.read_event_into(&mut buf) {
-                        Ok(Event::Start(e)) if e.local_name().as_ref() == b"Relationship" => {
+                        Ok(Event::Start(e)) if e.local_name().as_ref() == "Relationship" => {
                             let (_, target, typ) =
-                                get_attrs!(e, b"Id" => id, b"Target" => target, b"Type" => typ)?;
-                            let table_type = typ == Some(b"http://schemas.openxmlformats.org/officeDocument/2006/relationships/table" as &[u8]);
+                                get_attrs!(e, "Id" => id, "Target" => target, "Type" => typ)?;
+                            let table_type = typ == Some("http://schemas.openxmlformats.org/officeDocument/2006/relationships/table");
                             if table_type {
                                 let target = match target {
-                                    Some(t) => decode_attr(&xml.decoder(), t)?,
+                                    Some(t) => decode_attr(t)?,
                                     None => String::new(),
                                 };
                                 if target.starts_with("../") {
@@ -631,7 +621,7 @@ impl<RS: Read + Seek> Xlsx<RS> {
                                 }
                             }
                         }
-                        Ok(Event::End(e)) if e.local_name().as_ref() == b"Relationships" => break,
+                        Ok(Event::End(e)) if e.local_name().as_ref() == "Relationships" => break,
                         Ok(Event::Eof) => return Err(XlsxError::XmlEof("Relationships")),
                         Err(e) => return Err(XlsxError::Xml(e)),
                         _ => (),
@@ -648,35 +638,32 @@ impl<RS: Read + Seek> Xlsx<RS> {
                 loop {
                     buf.clear();
                     match xml.read_event_into(&mut buf) {
-                        Ok(Event::Start(e)) if e.local_name().as_ref() == b"table" => {
+                        Ok(Event::Start(e)) if e.local_name().as_ref() == "table" => {
                             for attr in e.iter_raw_attrs() {
                                 let (key, val) = attr?;
                                 match key {
-                                    b"displayName" => {
-                                        table_meta.display_name = decode_attr(&xml.decoder(), val)?;
+                                    "displayName" => {
+                                        table_meta.display_name = decode_attr(val)?;
                                     }
-                                    b"ref" => {
-                                        table_meta.ref_cells =
-                                            xml.decoder().decode(val)?.into_owned();
+                                    "ref" => {
+                                        table_meta.ref_cells = val.to_string();
                                     }
-                                    b"headerRowCount" => {
-                                        table_meta.header_row_count =
-                                            xml.decoder().decode(val)?.parse()?;
+                                    "headerRowCount" => {
+                                        table_meta.header_row_count = val.parse()?;
                                     }
-                                    b"totalsRowCount" => {
-                                        table_meta.totals_row_count =
-                                            xml.decoder().decode(val)?.parse()?;
+                                    "totalsRowCount" => {
+                                        table_meta.totals_row_count = val.parse()?;
                                     }
                                     _ => {}
                                 }
                             }
                         }
-                        Ok(Event::Start(e)) if e.local_name().as_ref() == b"tableColumn" => {
-                            if let Some(val) = e.raw_attr(b"name")? {
-                                column_names.push(decode_attr(&xml.decoder(), val)?);
+                        Ok(Event::Start(e)) if e.local_name().as_ref() == "tableColumn" => {
+                            if let Some(val) = e.raw_attr("name")? {
+                                column_names.push(decode_attr(val)?);
                             }
                         }
-                        Ok(Event::End(e)) if e.local_name().as_ref() == b"table" => break,
+                        Ok(Event::End(e)) if e.local_name().as_ref() == "table" => break,
                         Ok(Event::Eof) => return Err(XlsxError::XmlEof("Table")),
                         Err(e) => return Err(XlsxError::Xml(e)),
                         _ => (),
@@ -758,20 +745,20 @@ impl<RS: Read + Seek> Xlsx<RS> {
                 loop {
                     buf.clear();
                     match xml.read_event_into(&mut buf) {
-                        Ok(Event::Start(e)) if e.local_name().as_ref() == b"Relationship" => {
+                        Ok(Event::Start(e)) if e.local_name().as_ref() == "Relationship" => {
                             let (rel_type, target) =
-                                get_attrs!(e, b"Type" => typ, b"Target" => target)?;
-                            let is_drawing = rel_type.is_some_and(|t| t.ends_with(b"/drawing"));
+                                get_attrs!(e, "Type" => typ, "Target" => target)?;
+                            let is_drawing = rel_type.is_some_and(|t| t.ends_with("/drawing"));
                             if is_drawing {
                                 if let Some(target) = target {
-                                    let target = decode_attr(&xml.decoder(), target)?;
+                                    let target = decode_attr(target)?;
                                     if !target.is_empty() {
                                         drawing_paths.push(resolve_path(base_folder, &target));
                                     }
                                 }
                             }
                         }
-                        Ok(Event::End(e)) if e.local_name().as_ref() == b"Relationships" => break,
+                        Ok(Event::End(e)) if e.local_name().as_ref() == "Relationships" => break,
                         Ok(Event::Eof) | Err(_) => break,
                         _ => (),
                     }
@@ -796,15 +783,16 @@ impl<RS: Read + Seek> Xlsx<RS> {
                     loop {
                         buf.clear();
                         match xml.read_event_into(&mut buf) {
-                            Ok(Event::Start(e)) if e.local_name().as_ref() == b"Relationship" => {
-                                let (id, target, rel_type) = get_attrs!(e, b"Id" => id, b"Target" => target, b"Type" => typ)?;
-                                let is_image = rel_type.is_some_and(|t| t.ends_with(b"/image"));
+                            Ok(Event::Start(e)) if e.local_name().as_ref() == "Relationship" => {
+                                let (id, target, rel_type) =
+                                    get_attrs!(e, "Id" => id, "Target" => target, "Type" => typ)?;
+                                let is_image = rel_type.is_some_and(|t| t.ends_with("/image"));
                                 if is_image {
                                     if let Some(id) = id {
-                                        let id = decode_attr(&xml.decoder(), id)?;
+                                        let id = decode_attr(id)?;
                                         if !id.is_empty() {
                                             let target = match target {
-                                                Some(t) => decode_attr(&xml.decoder(), t)?,
+                                                Some(t) => decode_attr(t)?,
                                                 None => String::new(),
                                             };
                                             let norm = resolve_path(draw_base, &target)
@@ -814,7 +802,7 @@ impl<RS: Read + Seek> Xlsx<RS> {
                                     }
                                 }
                             }
-                            Ok(Event::End(e)) if e.local_name().as_ref() == b"Relationships" => {
+                            Ok(Event::End(e)) if e.local_name().as_ref() == "Relationships" => {
                                 break
                             }
                             Ok(Event::Eof) | Err(_) => break,
@@ -845,7 +833,7 @@ impl<RS: Read + Seek> Xlsx<RS> {
                         match xml.read_event_into(&mut buf) {
                             Ok(Event::Start(e)) => {
                                 match e.local_name().as_ref() {
-                                    b"twoCellAnchor" | b"oneCellAnchor" | b"absoluteAnchor" => {
+                                    "twoCellAnchor" | "oneCellAnchor" | "absoluteAnchor" => {
                                         // absoluteAnchor uses <pos> in EMUs
                                         // rather than <from>, so its position
                                         // is reported as (0, 0).
@@ -855,25 +843,25 @@ impl<RS: Read + Seek> Xlsx<RS> {
                                         current_name.clear();
                                         current_rid.clear();
                                     }
-                                    b"from" if in_anchor => in_from = true,
-                                    b"col" if in_from => in_col = true,
-                                    b"row" if in_from => in_row = true,
-                                    b"blip" if in_anchor => {
+                                    "from" if in_anchor => in_from = true,
+                                    "col" if in_from => in_col = true,
+                                    "row" if in_from => in_row = true,
+                                    "blip" if in_anchor => {
                                         // The embed rId is namespaced (`r:embed`).
-                                        if let Some(val) = e.raw_attr_local(b"embed")? {
-                                            current_rid = decode_attr(&xml.decoder(), val)?;
+                                        if let Some(val) = e.raw_attr_local("embed")? {
+                                            current_rid = decode_attr(val)?;
                                         }
                                     }
-                                    b"cNvPr" if in_anchor => {
-                                        if let Some(val) = e.raw_attr(b"name")? {
-                                            current_name = decode_attr(&xml.decoder(), val)?;
+                                    "cNvPr" if in_anchor => {
+                                        if let Some(val) = e.raw_attr("name")? {
+                                            current_name = decode_attr(val)?;
                                         }
                                     }
                                     _ => (),
                                 }
                             }
                             Ok(Event::End(e)) => match e.local_name().as_ref() {
-                                b"twoCellAnchor" | b"oneCellAnchor" | b"absoluteAnchor" => {
+                                "twoCellAnchor" | "oneCellAnchor" | "absoluteAnchor" => {
                                     if !current_rid.is_empty() {
                                         if let Some(mp) = rid_to_media.get(&current_rid) {
                                             if let Some((ext, data)) = media.get(mp) {
@@ -891,17 +879,17 @@ impl<RS: Read + Seek> Xlsx<RS> {
                                     }
                                     in_anchor = false;
                                 }
-                                b"from" => in_from = false,
-                                b"col" => in_col = false,
-                                b"row" => in_row = false,
+                                "from" => in_from = false,
+                                "col" => in_col = false,
+                                "row" => in_row = false,
                                 _ => (),
                             },
                             Ok(Event::Text(e)) => {
                                 if in_col {
-                                    let s = e.xml10_content()?;
+                                    let s = e.xml10_content();
                                     anchor_col = s.trim().parse().unwrap_or(0);
                                 } else if in_row {
-                                    let s = e.xml10_content()?;
+                                    let s = e.xml10_content();
                                     anchor_row = s.trim().parse().unwrap_or(0);
                                 }
                             }
@@ -957,16 +945,16 @@ impl<RS: Read + Seek> Xlsx<RS> {
             loop {
                 buf.clear();
                 match xml.read_event_into(&mut buf) {
-                    Ok(Event::Start(e)) if e.local_name().as_ref() == b"Relationship" => {
+                    Ok(Event::Start(e)) if e.local_name().as_ref() == "Relationship" => {
                         let (id, target, rel_type) =
-                            get_attrs!(e, b"Id" => id, b"Target" => target, b"Type" => typ)?;
-                        let is_image = rel_type.is_some_and(|t| t.ends_with(b"/image"));
+                            get_attrs!(e, "Id" => id, "Target" => target, "Type" => typ)?;
+                        let is_image = rel_type.is_some_and(|t| t.ends_with("/image"));
                         if is_image {
                             if let Some(id) = id {
-                                let id = decode_attr(&xml.decoder(), id)?;
+                                let id = decode_attr(id)?;
                                 if !id.is_empty() {
                                     let target = match target {
-                                        Some(t) => decode_attr(&xml.decoder(), t)?,
+                                        Some(t) => decode_attr(t)?,
                                         None => String::new(),
                                     };
                                     let norm =
@@ -976,7 +964,7 @@ impl<RS: Read + Seek> Xlsx<RS> {
                             }
                         }
                     }
-                    Ok(Event::End(e)) if e.local_name().as_ref() == b"Relationships" => break,
+                    Ok(Event::End(e)) if e.local_name().as_ref() == "Relationships" => break,
                     Ok(Event::Eof) | Err(_) => break,
                     _ => (),
                 }
@@ -999,10 +987,10 @@ impl<RS: Read + Seek> Xlsx<RS> {
             loop {
                 buf.clear();
                 match xml.read_event_into(&mut buf) {
-                    Ok(Event::Start(e)) if e.local_name().as_ref() == b"rel" => {
+                    Ok(Event::Start(e)) if e.local_name().as_ref() == "rel" => {
                         // The rId is namespaced (`r:id`).
-                        let rid = match e.raw_attr_local(b"id")? {
-                            Some(val) => decode_attr(&xml.decoder(), val)?,
+                        let rid = match e.raw_attr_local("id")? {
+                            Some(val) => decode_attr(val)?,
                             None => String::new(),
                         };
                         let media_path = rid_to_media.get(&rid).cloned().unwrap_or_default();
@@ -1036,22 +1024,22 @@ impl<RS: Read + Seek> Xlsx<RS> {
             loop {
                 buf.clear();
                 match xml.read_event_into(&mut buf) {
-                    Ok(Event::Start(e)) if e.local_name().as_ref() == b"rv" => {
+                    Ok(Event::Start(e)) if e.local_name().as_ref() == "rv" => {
                         in_rv = true;
                         v_count = 0;
                         img_idx = 0;
                     }
-                    Ok(Event::Start(e)) if in_rv && e.local_name().as_ref() == b"v" => {
+                    Ok(Event::Start(e)) if in_rv && e.local_name().as_ref() == "v" => {
                         in_v = true;
                     }
                     Ok(Event::Text(e)) if in_v && v_count == 0 => {
-                        img_idx = e.xml10_content()?.trim().parse().unwrap_or(0);
+                        img_idx = e.xml10_content().trim().parse().unwrap_or(0);
                     }
-                    Ok(Event::End(e)) if e.local_name().as_ref() == b"v" => {
+                    Ok(Event::End(e)) if e.local_name().as_ref() == "v" => {
                         in_v = false;
                         v_count += 1;
                     }
-                    Ok(Event::End(e)) if e.local_name().as_ref() == b"rv" => {
+                    Ok(Event::End(e)) if e.local_name().as_ref() == "rv" => {
                         rv_to_img_idx.insert(rv_idx, img_idx);
                         rv_idx += 1;
                         in_rv = false;
@@ -1082,21 +1070,25 @@ impl<RS: Read + Seek> Xlsx<RS> {
             loop {
                 buf.clear();
                 match xml.read_event_into(&mut buf) {
-                    Ok(Event::Start(e)) if e.local_name().as_ref() == b"row" => {
-                        if let Some(r) = e.raw_attr(b"r")? {
-                            current_row = atoi_simd::parse::<u32, true, false>(r).unwrap_or(1) - 1;
+                    Ok(Event::Start(e)) if e.local_name().as_ref() == "row" => {
+                        if let Some(r) = e.raw_attr("r")? {
+                            current_row =
+                                atoi_simd::parse::<u32, true, false>(r.as_bytes()).unwrap_or(1) - 1;
                         }
                     }
-                    Ok(Event::Start(e)) if e.local_name().as_ref() == b"c" => {
-                        let (vm, r) = get_attrs!(e, b"vm" => vm, b"r" => r)?;
-                        let vm = vm.and_then(|v| atoi_simd::parse::<usize, true, false>(v).ok());
+                    Ok(Event::Start(e)) if e.local_name().as_ref() == "c" => {
+                        let (vm, r) = get_attrs!(e, "vm" => vm, "r" => r)?;
+                        let vm = vm.and_then(|v| {
+                            atoi_simd::parse::<usize, true, false>(v.as_bytes()).ok()
+                        });
                         if let Some(vm_val) = vm {
                             let rv_idx = vm_val.saturating_sub(1);
                             if let Some(&img_idx) = rv_to_img_idx.get(&rv_idx) {
                                 if let Some(media_path) = idx_to_media.get(img_idx) {
                                     if !media_path.is_empty() {
                                         if let Some((ext, data)) = media.get(media_path) {
-                                            let col = r.map_or(0, col_from_cell_ref);
+                                            let col =
+                                                r.map_or(0, |r| col_from_cell_ref(r.as_bytes()));
                                             seen.insert(media_path.clone());
                                             pics.push(Picture {
                                                 extension: ext.clone(),
@@ -1244,9 +1236,9 @@ impl<RS: Read + Seek> Xlsx<RS> {
                 loop {
                     buf.clear();
                     match xml.read_event_into(&mut buf) {
-                        Ok(Event::Start(e)) if e.local_name() == QName(b"mergeCell").into() => {
-                            if let Some(val) = e.raw_attr(b"ref")? {
-                                let dimension = get_dimension(val)?;
+                        Ok(Event::Start(e)) if e.local_name().as_ref() == "mergeCell" => {
+                            if let Some(val) = e.raw_attr("ref")? {
+                                let dimension = get_dimension(val.as_bytes())?;
                                 regions.push((
                                     sheet_name.to_string(),
                                     sheet_path.to_string(),
@@ -1869,7 +1861,7 @@ impl<RS: Read + Seek> Xlsx<RS> {
                 buffer.clear();
 
                 match xml.read_event_into(&mut buffer) {
-                    Ok(Event::Start(event)) if event.local_name().as_ref() == b"mergeCells" => {
+                    Ok(Event::Start(event)) if event.local_name().as_ref() == "mergeCells" => {
                         if let Ok(cells) = read_merge_cells(&mut xml) {
                             merge_cells = cells;
                         }
@@ -2057,7 +2049,7 @@ impl<RS: Read + Seek> Xlsx<RS> {
             buffer.clear();
 
             match xml.read_event_into(&mut buffer) {
-                Ok(Event::Start(event)) if event.local_name().as_ref() == b"mergeCells" => {
+                Ok(Event::Start(event)) if event.local_name().as_ref() == "mergeCells" => {
                     merge_cells = read_merge_cells(&mut xml)?;
                     break;
                 }
@@ -2210,7 +2202,7 @@ impl<RS: Read + Seek> Xlsx<RS> {
             buffer.clear();
 
             match xml.read_event_into(&mut buffer) {
-                Ok(Event::Start(event)) if event.local_name().as_ref() == b"hyperlinks" => {
+                Ok(Event::Start(event)) if event.local_name().as_ref() == "hyperlinks" => {
                     hyperlinks = read_hyperlinks(&mut xml, &rels)?;
                     break;
                 }
@@ -2387,27 +2379,22 @@ where
         buf.clear();
         match xml.read_event_into(&mut buf) {
             Ok(Event::Start(e)) | Ok(Event::Empty(e))
-                if e.local_name().as_ref() == b"Relationship" =>
+                if e.local_name().as_ref() == "Relationship" =>
             {
                 let (id, target, typ) =
-                    get_attrs!(e, b"Id" => id, b"Target" => target, b"Type" => typ)?;
-                let is_hyperlink = typ.is_some_and(|t| t.ends_with(b"/relationships/hyperlink"));
+                    get_attrs!(e, "Id" => id, "Target" => target, "Type" => typ)?;
+                let is_hyperlink = typ.is_some_and(|t| t.ends_with("/relationships/hyperlink"));
                 if is_hyperlink {
                     if let Some(id) = id.filter(|id| !id.is_empty()) {
-                        let id = xml.decoder().decode(id)?.into_owned();
+                        let id = id.to_string();
                         let target = target
-                            .map(|t| {
-                                xml.decoder()
-                                    .decode(t)
-                                    .map(|t| unescape_xml(&t).into_owned())
-                            })
-                            .transpose()?
+                            .map(|t| unescape_xml(t).into_owned())
                             .unwrap_or_default();
                         rels.insert(id, target);
                     }
                 }
             }
-            Ok(Event::End(e)) if e.local_name().as_ref() == b"Relationships" => break,
+            Ok(Event::End(e)) if e.local_name().as_ref() == "Relationships" => break,
             Ok(Event::Eof) => break,
             Err(e) => return Err(XlsxError::Xml(e)),
             _ => (),
@@ -2436,7 +2423,7 @@ where
 
         match xml.read_event_into(&mut buffer) {
             Ok(Event::Start(event)) | Ok(Event::Empty(event))
-                if event.local_name().as_ref() == b"hyperlink" =>
+                if event.local_name().as_ref() == "hyperlink" =>
             {
                 let mut range: Option<Dimensions> = None;
                 let mut rid: Option<String> = None;
@@ -2447,25 +2434,24 @@ where
                 for attr in event.iter_raw_attrs() {
                     let (key, val) = attr?;
                     match key {
-                        b"ref" => {
-                            range = Some(get_dimension(val)?);
+                        "ref" => {
+                            range = Some(get_dimension(val.as_bytes())?);
                         }
-                        b"location" => {
-                            location = Some(unescape_xml(&xml.decoder().decode(val)?).into_owned());
+                        "location" => {
+                            location = Some(unescape_xml(val).into_owned());
                         }
-                        b"display" => {
-                            displayed_text =
-                                Some(unescape_xml(&xml.decoder().decode(val)?).into_owned());
+                        "display" => {
+                            displayed_text = Some(unescape_xml(val).into_owned());
                         }
-                        b"tooltip" => {
-                            tooltip = Some(unescape_xml(&xml.decoder().decode(val)?).into_owned());
+                        "tooltip" => {
+                            tooltip = Some(unescape_xml(val).into_owned());
                         }
                         // Match on the local name; the namespace prefix
                         // for the relationships namespace is conventionally
                         // "r" but OOXML allows any prefix bound to the
                         // relationships namespace URI.
-                        key if local_name_matches(key, b"id") => {
-                            rid = Some(xml.decoder().decode(val)?.into_owned());
+                        key if local_name_matches(key, "id") => {
+                            rid = Some(val.to_string());
                         }
                         _ => (),
                     }
@@ -2482,7 +2468,7 @@ where
                     tooltip,
                 });
             }
-            Ok(Event::End(event)) if event.local_name().as_ref() == b"hyperlinks" => break,
+            Ok(Event::End(event)) if event.local_name().as_ref() == "hyperlinks" => break,
             Ok(Event::Eof) => return Err(XlsxError::XmlEof("hyperlinks")),
             Err(e) => return Err(XlsxError::Xml(e)),
             _ => (),
@@ -2881,11 +2867,11 @@ where
     loop {
         xml_buf.clear();
         match xml.read_event_into(xml_buf) {
-            Ok(Event::Start(e)) if e.local_name().as_ref() == b"r" && rich_buffer.is_none() => {
+            Ok(Event::Start(e)) if e.local_name().as_ref() == "r" && rich_buffer.is_none() => {
                 // use a buffer since richtext has multiples <r> and <t> for the same cell
                 rich_buffer = Some(String::new());
             }
-            Ok(Event::Start(e)) if e.local_name().as_ref() == b"rPh" => {
+            Ok(Event::Start(e)) if e.local_name().as_ref() == "rPh" => {
                 is_phonetic_text = true;
             }
             Ok(Event::End(e)) if e.name() == closing => {
@@ -2896,18 +2882,17 @@ where
                 }
                 return Ok(rich_buffer);
             }
-            Ok(Event::End(e)) if e.local_name().as_ref() == b"rPh" => {
+            Ok(Event::End(e)) if e.local_name().as_ref() == "rPh" => {
                 is_phonetic_text = false;
             }
-            Ok(Event::Start(e)) if e.local_name().as_ref() == b"t" && !is_phonetic_text => {
-                let preserve_space =
-                    matches!(e.raw_attr(b"xml:space")?, Some(v) if v == b"preserve");
+            Ok(Event::Start(e)) if e.local_name().as_ref() == "t" && !is_phonetic_text => {
+                let preserve_space = matches!(e.raw_attr("xml:space")?, Some(v) if v == "preserve");
                 text_buf.clear();
                 let mut value = String::new();
                 loop {
                     match xml.read_event_into(text_buf)? {
-                        Event::Text(t) => value.push_str(&t.xml10_content()?),
-                        Event::CData(t) => value.push_str(&t.xml10_content()?),
+                        Event::Text(t) => value.push_str(&t.xml10_content()),
+                        Event::CData(t) => value.push_str(&t.xml10_content()),
                         Event::GeneralRef(e) => unescape_entity_to_buffer(&e, &mut value)?,
                         Event::End(end) if end.name() == e.name() => break,
                         Event::Eof => return Err(XlsxError::XmlEof("t")),
@@ -2957,12 +2942,12 @@ where
         let mut buffer = Vec::new();
 
         match xml.read_event_into(&mut buffer) {
-            Ok(Event::Start(event)) if event.local_name().as_ref() == b"mergeCell" => {
-                if let Some(val) = event.raw_attr(b"ref")? {
-                    merge_cells.push(get_dimension(val)?);
+            Ok(Event::Start(event)) if event.local_name().as_ref() == "mergeCell" => {
+                if let Some(val) = event.raw_attr("ref")? {
+                    merge_cells.push(get_dimension(val.as_bytes())?);
                 }
             }
-            Ok(Event::End(event)) if event.local_name().as_ref() == b"mergeCells" => {
+            Ok(Event::End(event)) if event.local_name().as_ref() == "mergeCells" => {
                 break;
             }
             Ok(Event::Eof) => return Err(XlsxError::XmlEof("")),
@@ -3364,23 +3349,23 @@ enum Tag {
     D,
 }
 
-type Value = Option<Box<[u8]>>;
+type Value = Option<Box<str>>;
 
 /// Check if tag is an item within a PivotCache Record, which does not require a Definitions lookup.
 fn item_tag(e: &BytesStart) -> Option<Tag> {
     match e.local_name().as_ref() {
-        b"s" => Some(Tag::S),
-        b"n" => Some(Tag::N),
-        b"m" => Some(Tag::M),
-        b"e" => Some(Tag::E),
-        b"b" => Some(Tag::B),
-        b"d" => Some(Tag::D),
+        "s" => Some(Tag::S),
+        "n" => Some(Tag::N),
+        "m" => Some(Tag::M),
+        "e" => Some(Tag::E),
+        "b" => Some(Tag::B),
+        "d" => Some(Tag::D),
         _ => None,
     }
 }
 
 fn item_value(e: &BytesStart) -> Result<Value, quick_xml::events::attributes::AttrError> {
-    Ok(e.raw_attr(b"v")?.map(Box::from))
+    Ok(e.raw_attr("v")?.map(Box::from))
 }
 
 // Get the target location of the pivot table's pivot cache definitions.
@@ -3403,11 +3388,11 @@ where
     loop {
         buf.clear();
         match xml.read_event_into(&mut buf) {
-            Ok(Event::Start(e)) if e.local_name().as_ref() == b"Relationship" => {
-                let (target, typ) = get_attrs!(e, b"Target" => target, b"Type" => typ)?;
-                let is_pivot_cache_definitions_type = typ == Some(b"http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotCacheDefinition" as &[u8]);
+            Ok(Event::Start(e)) if e.local_name().as_ref() == "Relationship" => {
+                let (target, typ) = get_attrs!(e, "Target" => target, "Type" => typ)?;
+                let is_pivot_cache_definitions_type = typ == Some("http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotCacheDefinition");
                 let target = match target {
-                    Some(t) => decode_attr(&xml.decoder(), t)?,
+                    Some(t) => decode_attr(t)?,
                     None => String::new(),
                 };
                 match (is_pivot_cache_definitions_type, definitions_path.is_some()) {
@@ -3428,7 +3413,7 @@ where
                     _ => {}
                 }
             }
-            Ok(Event::End(e)) if e.local_name().as_ref() == b"Relationships" => break,
+            Ok(Event::End(e)) if e.local_name().as_ref() == "Relationships" => break,
             Ok(Event::Eof) => return Err(XlsxError::XmlEof("Relationships")),
             Err(e) => return Err(XlsxError::Xml(e)),
             _ => (),
@@ -3463,11 +3448,11 @@ where
     loop {
         buf.clear();
         match xml.read_event_into(&mut buf) {
-            Ok(Event::Start(e)) if e.local_name().as_ref() == b"Relationship" => {
-                let (target, typ) = get_attrs!(e, b"Target" => target, b"Type" => typ)?;
-                let is_pivot_cache_record_type = typ == Some(b"http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotCacheRecords" as &[u8]);
+            Ok(Event::Start(e)) if e.local_name().as_ref() == "Relationship" => {
+                let (target, typ) = get_attrs!(e, "Target" => target, "Type" => typ)?;
+                let is_pivot_cache_record_type = typ == Some("http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotCacheRecords");
                 let target = match target {
-                    Some(t) => decode_attr(&xml.decoder(), t)?,
+                    Some(t) => decode_attr(t)?,
                     None => String::new(),
                 };
                 match (is_pivot_cache_record_type, record_path.is_some()) {
@@ -3486,7 +3471,7 @@ where
                     _ => {}
                 }
             }
-            Ok(Event::End(e)) if e.local_name().as_ref() == b"Relationships" => break,
+            Ok(Event::End(e)) if e.local_name().as_ref() == "Relationships" => break,
             Ok(Event::Eof) => return Err(XlsxError::XmlEof("Relationships")),
             Err(e) => return Err(XlsxError::Xml(e)),
             _ => (),
@@ -3524,12 +3509,12 @@ where
     loop {
         buf.clear();
         match xml.read_event_into(&mut buf) {
-            Ok(Event::Start(e)) if e.local_name().as_ref() == b"Relationship" => {
-                let (target, typ) = get_attrs!(e, b"Target" => target, b"Type" => typ)?;
-                let is_pivot_table_type = typ == Some(b"http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotTable" as &[u8]);
+            Ok(Event::Start(e)) if e.local_name().as_ref() == "Relationship" => {
+                let (target, typ) = get_attrs!(e, "Target" => target, "Type" => typ)?;
+                let is_pivot_table_type = typ == Some("http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotTable");
                 if is_pivot_table_type {
                     let target = match target {
-                        Some(t) => decode_attr(&xml.decoder(), t)?,
+                        Some(t) => decode_attr(t)?,
                         None => String::new(),
                     };
                     if let Some(target) = target.strip_prefix("../") {
@@ -3543,7 +3528,7 @@ where
                     }
                 }
             }
-            Ok(Event::End(e)) if e.local_name().as_ref() == b"Relationships" => break,
+            Ok(Event::End(e)) if e.local_name().as_ref() == "Relationships" => break,
             Ok(Event::Eof) => return Err(XlsxError::XmlEof("Relationships")),
             Err(e) => return Err(XlsxError::Xml(e)),
             _ => (),
@@ -3571,17 +3556,17 @@ where
     loop {
         buf.clear();
         match xml.read_event_into(&mut buf) {
-            Ok(Event::Start(e)) if e.local_name().as_ref() == b"pivotTableDefinition" => {
-                if let Some(val) = e.raw_attr(b"name")? {
+            Ok(Event::Start(e)) if e.local_name().as_ref() == "pivotTableDefinition" => {
+                if let Some(val) = e.raw_attr("name")? {
                     if name.is_some() {
                         return Err(XlsxError::Unexpected(
                             "multiple name entries for one pivot table path",
                         ));
                     }
-                    name.replace(decode_attr(&xml.decoder(), val)?);
+                    name.replace(decode_attr(val)?);
                 }
             }
-            Ok(Event::End(e)) if e.local_name().as_ref() == b"pivotTableDefinition" => break,
+            Ok(Event::End(e)) if e.local_name().as_ref() == "pivotTableDefinition" => break,
             Ok(Event::Eof) => return Err(XlsxError::XmlEof("pivotTableDefinition")),
             Err(e) => return Err(XlsxError::Xml(e)),
             _ => (),
@@ -3594,45 +3579,33 @@ where
 }
 
 /// Parse an item within a PivotCache Record into its appropriate [`Data`] type.
-fn parse_item(item: &(Tag, Value), decoder: &Decoder) -> Data {
+fn parse_item(item: &(Tag, Value)) -> Data {
     let Some(val) = item.1.as_deref() else {
         return Data::Empty;
     };
     match item.0 {
         Tag::M => Data::Empty,
-        Tag::S => {
-            if let Ok(val) = decoder.decode(val.as_ref()) {
-                Data::String(val.to_string())
-            } else {
-                Data::Error(CellErrorType::GettingData)
-            }
-        }
+        Tag::S => Data::String(val.to_string()),
         Tag::N => {
-            if val.contains(&b'.') {
-                match bytes_to_f64(val, decoder) {
+            if val.contains('.') {
+                match str_to_f64(val) {
                     Some(val) => Data::Float(val),
                     None => Data::Error(CellErrorType::GettingData),
                 }
             } else {
-                match bytes_to_i64(val, decoder) {
+                match str_to_i64(val) {
                     Some(val) => Data::Int(val),
                     None => Data::Error(CellErrorType::GettingData),
                 }
             }
         }
-        Tag::D => {
-            if let Ok(val) = decoder.decode(val) {
-                Data::DateTimeIso(val.into())
-            } else {
-                Data::Error(CellErrorType::GettingData)
-            }
-        }
+        Tag::D => Data::DateTimeIso(val.into()),
         Tag::B => {
             {
                 // boolean tags only support W3C XML Schema
                 match val {
-                    b"0" | b"false" => Data::Bool(false),
-                    b"1" | b"true" => Data::Bool(true),
+                    "0" | "false" => Data::Bool(false),
+                    "1" | "true" => Data::Bool(true),
                     _ => Data::Error(CellErrorType::GettingData),
                 }
             }
@@ -3642,21 +3615,13 @@ fn parse_item(item: &(Tag, Value), decoder: &Decoder) -> Data {
 }
 
 // Parse failures are handled with None and left to `Self::parse_item` to address.
-fn bytes_to_i64(val: &[u8], decoder: &Decoder) -> Option<i64> {
-    if let Ok(val) = decoder.decode(val) {
-        atoi_simd::parse::<i64, true, false>(val.as_bytes()).ok()
-    } else {
-        None
-    }
+fn str_to_i64(val: &str) -> Option<i64> {
+    atoi_simd::parse::<i64, true, false>(val.as_bytes()).ok()
 }
 
 // Parse failures are handled with None and left to `parse_item` to address.
-fn bytes_to_f64(val: &[u8], decoder: &Decoder) -> Option<f64> {
-    if let Ok(val) = decoder.decode(val) {
-        fast_float2::parse(val.as_bytes()).ok()
-    } else {
-        None
-    }
+fn str_to_f64(val: &str) -> Option<f64> {
+    fast_float2::parse(val.as_bytes()).ok()
 }
 
 #[derive(Default)]
@@ -3836,10 +3801,10 @@ fn get_pivot_cache_iter<'a, RS: Read + Seek + 'a>(
             buf.clear();
 
             match xml.read_event_into(&mut buf) {
-                Ok(Event::Start(e)) if e.local_name().as_ref() == b"cacheField" => {
-                    let (name, formula) = get_attrs!(e, b"name" => name, b"formula" => formula)?;
+                Ok(Event::Start(e)) if e.local_name().as_ref() == "cacheField" => {
+                    let (name, formula) = get_attrs!(e, "name" => name, "formula" => formula)?;
                     if let Some(name) = name {
-                        field_names.push(decode_attr(&xml.decoder(), name)?);
+                        field_names.push(decode_attr(name)?);
                         fields.push(vec![]);
                     }
                     if formula.is_some() {
@@ -3849,7 +3814,7 @@ fn get_pivot_cache_iter<'a, RS: Read + Seek + 'a>(
                 }
                 // Exclude grouped fields from results.
                 // This does not represent the underlying data and should be removed.
-                Ok(Event::Start(e)) if e.local_name().as_ref() == b"groupItems" => {
+                Ok(Event::Start(e)) if e.local_name().as_ref() == "groupItems" => {
                     field_names.pop();
                     fields.pop();
                 }
@@ -3918,32 +3883,30 @@ impl<'a, RS: Read + Seek + 'a> Iterator for PivotCacheIter<'a, RS> {
         loop {
             buf.clear();
             match self.reader.read_event_into(&mut buf) {
-                Ok(Event::Start(e)) if e.local_name().as_ref() == b"x" => {
-                    let v = match e.raw_attr(b"v") {
+                Ok(Event::Start(e)) if e.local_name().as_ref() == "x" => {
+                    let v = match e.raw_attr("v") {
                         Ok(v) => v,
                         Err(e) => return Some(Err(e.into())),
                     };
                     if let Some(val) = v {
-                        let value_position = match atoi_simd::parse::<usize, true, false>(val) {
-                            Ok(val) => val,
-                            Err(_) => {
-                                return Some(Err(XlsxError::Unexpected(
-                                    "pivot cache x:v attribute must be a number",
-                                )));
-                            }
-                        };
+                        let value_position =
+                            match atoi_simd::parse::<usize, true, false>(val.as_bytes()) {
+                                Ok(val) => val,
+                                Err(_) => {
+                                    return Some(Err(XlsxError::Unexpected(
+                                        "pivot cache x:v attribute must be a number",
+                                    )));
+                                }
+                            };
 
                         let column_name = &self.field_names[col_number];
-                        row.push(parse_item(
-                            &self.definitions[column_name][value_position],
-                            &self.reader.decoder(),
-                        ));
+                        row.push(parse_item(&self.definitions[column_name][value_position]));
                     }
 
                     col_number += 1;
                 }
-                Ok(Event::End(e)) if e.local_name().as_ref() == b"r" => return Some(Ok(row)),
-                Ok(Event::Start(e)) if e.local_name().as_ref() == b"pivotCacheRecords" => {
+                Ok(Event::End(e)) if e.local_name().as_ref() == "r" => return Some(Ok(row)),
+                Ok(Event::Start(e)) if e.local_name().as_ref() == "pivotCacheRecords" => {
                     return Some(Ok(self
                         .field_names
                         .iter()
@@ -3958,7 +3921,7 @@ impl<'a, RS: Read + Seek + 'a> Iterator for PivotCacheIter<'a, RS> {
                             Ok(value) => value,
                             Err(e) => return Some(Err(e.into())),
                         };
-                        row.push(parse_item(&(tag, value), &self.reader.decoder()));
+                        row.push(parse_item(&(tag, value)));
                         col_number += 1;
                     }
                 }


### PR DESCRIPTION
Hi, while I'm looking to nushell pr to update quick-xml to 0.42.0, I found out some dependencies still uses 0.41.0. https://github.com/nushell/nushell/pull/18908

Since quick-xml 0.42.0 contains some breaking changes, this pr tried to update it and fixed the breaking change, which mainly reflects changes on https://github.com/tafia/quick-xml/pull/963, which changes from `&[u8]` to `&str`.