### PR TITLE
xlsb/xls: resolve shared and array formulas, fix transposed >= and >

### DIFF
--- a/src/xls.rs
+++ b/src/xls.rs
@@ -3,7 +3,7 @@
 // Copyright 2016-2026, Johann Tuffe.
 
 use std::cmp::min;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fmt::{self, Write};
 use std::io::{Read, Seek, SeekFrom};
 
@@ -613,6 +613,9 @@ impl<RS: Read + Seek> Xls<RS> {
             // The first BOF belongs to the worksheet itself.
             let mut seen_sheet_bof = false;
             let mut substream_depth = 0usize;
+            // Shared and array formula definitions, and the cells awaiting them.
+            let mut shared_defs: Vec<(Dimensions, Vec<u8>)> = Vec::new();
+            let mut shared_members: Vec<(usize, (u32, u32))> = Vec::new();
             for record in records {
                 let r = record?;
                 if substream_depth > 0 {
@@ -674,26 +677,107 @@ impl<RS: Read + Seek> Xls<RS> {
                             // it will appear in 0x0207 record coming next
                             cells.push(Cell::new(fmla_pos, val));
                         }
-                        let fmla = parse_formula(
-                            &r.data[20..],
-                            &fmla_sheet_names,
-                            &defined_names,
-                            &xtis,
-                            &encoding,
-                            biff,
-                        )
-                        .unwrap_or_else(|e| {
-                            debug!("{e}");
-                            format!(
-                                "Unrecognised formula \
-                                 for cell ({row}, {col}): {e:?}"
+                        if is_shared_formula_member(&r.data[20..]) {
+                            // The tokens live in a ShrFmla or Array record that
+                            // may not have been read yet; resolve after the pass.
+                            shared_members.push((formulas.len(), fmla_pos));
+                            formulas.push(Cell::new(fmla_pos, String::new()));
+                        } else {
+                            let fmla = parse_formula(
+                                &r.data[20..],
+                                &fmla_sheet_names,
+                                &defined_names,
+                                &xtis,
+                                &encoding,
+                                biff,
+                                fmla_pos,
                             )
-                        });
-                        formulas.push(Cell::new(fmla_pos, fmla));
+                            .unwrap_or_else(|e| {
+                                debug!("{e}");
+                                format!(
+                                    "Unrecognised formula \
+                                     for cell ({row}, {col}): {e:?}"
+                                )
+                            });
+                            formulas.push(Cell::new(fmla_pos, fmla));
+                        }
+                    }
+                    // 1212: ShrFmla — refU(6) unused(1) cUse(1) then the formula.
+                    0x04BC => {
+                        if let Some(range) = parse_ref_u(r.data).filter(|_| r.data.len() > 8) {
+                            shared_defs.push((range, r.data[8..].to_vec()));
+                        }
+                    }
+                    // 545: Array — refU(6) flags(2) chn(4) then the formula.
+                    0x0221 => {
+                        if let Some(range) = parse_ref_u(r.data).filter(|_| r.data.len() > 12) {
+                            shared_defs.push((range, r.data[12..].to_vec()));
+                        }
                     }
                     _ => (),
                 }
             }
+            // A shared or array formula is stored once, over a range, and each
+            // cell in that range carries only a PtgExp back-reference. Decode
+            // the definition separately for every member, anchored at that
+            // member's own position, so each row gets its own references.
+            // Index definitions by column, so a member is matched by binary
+            // search rather than a scan of every group on the sheet: Excel
+            // splits a filled-down column into groups of about 64 rows, so a
+            // linear scan per member is quadratic. Groups are nearly always one
+            // column wide; wider ones stay in a short list scanned directly.
+            const WIDE_GROUP_COLS: u32 = 64;
+            let mut by_column: HashMap<u32, Vec<(u32, u32, usize)>> = HashMap::new();
+            let mut wide: Vec<usize> = Vec::new();
+            for (i, (range, _)) in shared_defs.iter().enumerate() {
+                if range.end.1.saturating_sub(range.start.1) >= WIDE_GROUP_COLS {
+                    wide.push(i);
+                    continue;
+                }
+                for col in range.start.1..=range.end.1 {
+                    by_column
+                        .entry(col)
+                        .or_default()
+                        .push((range.start.0, range.end.0, i));
+                }
+            }
+            for spans in by_column.values_mut() {
+                spans.sort_unstable();
+            }
+
+            for (index, pos) in shared_members {
+                let found = by_column.get(&pos.1).and_then(|spans| {
+                    // Groups in a column do not overlap, so the only candidate
+                    // is the last one starting at or before this row.
+                    let i = spans.partition_point(|&(start, _, _)| start <= pos.0);
+                    let &(_, end, def) = spans.get(i.checked_sub(1)?)?;
+                    (pos.0 <= end).then_some(def)
+                });
+                let Some(def_index) = found.or_else(|| {
+                    wide.iter().rev().copied().find(|&i| {
+                        let range = &shared_defs[i].0;
+                        pos.0 >= range.start.0
+                            && pos.0 <= range.end.0
+                            && pos.1 >= range.start.1
+                            && pos.1 <= range.end.1
+                    })
+                }) else {
+                    continue;
+                };
+                match parse_formula(
+                    &shared_defs[def_index].1,
+                    &fmla_sheet_names,
+                    &defined_names,
+                    &xtis,
+                    &encoding,
+                    biff,
+                    pos,
+                ) {
+                    Ok(f) => formulas[index] = Cell::new(pos, f),
+                    Err(e) => debug!("{e}"),
+                }
+            }
+
             let range = Range::from_sparse(cells);
             let formula = Range::from_sparse(formulas);
             sheets.insert(
@@ -1374,6 +1458,146 @@ fn write_absolute_cell_ref(f: &mut String, col: u32, row: u32) {
     write!(f, "${}", row + 1).unwrap();
 }
 
+/// Read a `RefU`: `rwFirst(2) rwLast(2) colFirst(1) colLast(1)`.
+///
+/// This is the range header on `ShrFmla` and `Array` records. Its columns are a
+/// single byte each, unlike the wider `Ref8U` used elsewhere, and it is not the
+/// shape of the `Dimensions` record either.
+fn parse_ref_u(r: &[u8]) -> Option<Dimensions> {
+    (r.len() >= 6).then(|| Dimensions {
+        start: (read_u16(&r[0..2]) as u32, r[4] as u32),
+        end: (read_u16(&r[2..4]) as u32, r[5] as u32),
+    })
+}
+
+/// Sign-extend the low `bits` of `v`.
+fn sign_extend(v: u32, bits: u32) -> i32 {
+    let shift = 32 - bits;
+    ((v << shift) as i32) >> shift
+}
+
+/// Decode an `N`-class reference operand.
+///
+/// Returns `(row, col, row_is_relative, col_is_relative, bytes_consumed)` with
+/// absolute zero-based indices. Relative components are stored as signed offsets
+/// from the cell that owns the formula: 16-bit row and 14-bit column in BIFF8,
+/// 14-bit row and 8-bit column before it.
+fn read_ref_n(
+    rgce: &[u8],
+    anchor: (u32, u32),
+    is_pre_biff8: bool,
+) -> Result<(u32, u32, bool, bool, usize), XlsError> {
+    let need = if is_pre_biff8 { 3 } else { 4 };
+    if rgce.len() < need {
+        return Err(XlsError::Len {
+            expected: need,
+            found: rgce.len(),
+            typ: "PtgRefN",
+        });
+    }
+
+    let (row_field, col_field, row_rel, col_rel, row_bits, col_bits) = if is_pre_biff8 {
+        // BIFF2-5: rw(2) carries the row in 14 bits with fRwRel = 0x8000 and
+        // fColRel = 0x4000; the column is a single byte.
+        let rw = read_u16(rgce) as u32;
+        (
+            rw & 0x3FFF,
+            rgce[2] as u32,
+            rw & 0x8000 != 0,
+            rw & 0x4000 != 0,
+            14,
+            8,
+        )
+    } else {
+        // BIFF8: rw(2) is the full row. grbitCol(2) is an RgceLocRel, whose
+        // column occupies only the low **8** bits -- this format has 256
+        // columns, not 16384 -- followed by six unused bits, then
+        // fColRel = 0x8000 and fRwRel = 0x4000. Masking 14 bits here instead
+        // would read a negative column offset such as 0xFF as +255.
+        let col = read_u16(&rgce[2..4]) as u32;
+        (
+            read_u16(rgce) as u32,
+            col & 0x00FF,
+            col & 0x4000 != 0,
+            col & 0x8000 != 0,
+            16,
+            8,
+        )
+    };
+
+    let row = if row_rel {
+        (anchor.0 as i32).wrapping_add(sign_extend(row_field, row_bits)) as u32
+    } else {
+        row_field
+    };
+    let col = if col_rel {
+        (anchor.1 as i32).wrapping_add(sign_extend(col_field, col_bits)) as u32
+    } else {
+        col_field
+    };
+
+    Ok((row, col, row_rel, col_rel, need))
+}
+
+/// Decode a `PtgAreaN` operand as its two corners.
+#[allow(clippy::type_complexity)]
+fn read_area_n(
+    rgce: &[u8],
+    anchor: (u32, u32),
+    is_pre_biff8: bool,
+) -> Result<(u32, u32, bool, bool, u32, u32, bool, bool, usize), XlsError> {
+    let need = if is_pre_biff8 { 6 } else { 8 };
+    if rgce.len() < need {
+        return Err(XlsError::Len {
+            expected: need,
+            found: rgce.len(),
+            typ: "PtgAreaN",
+        });
+    }
+    // Corners are stored grouped: both rows, then both columns. Re-pack each
+    // corner into the layout `read_ref_n` expects.
+    let (first, second, ref_len) = if is_pre_biff8 {
+        (
+            [rgce[0], rgce[1], rgce[4], 0],
+            [rgce[2], rgce[3], rgce[5], 0],
+            3,
+        )
+    } else {
+        (
+            [rgce[0], rgce[1], rgce[4], rgce[5]],
+            [rgce[2], rgce[3], rgce[6], rgce[7]],
+            4,
+        )
+    };
+    let (r1, c1, r1r, c1r, _) = read_ref_n(&first[..ref_len], anchor, is_pre_biff8)?;
+    let (r2, c2, r2r, c2r, _) = read_ref_n(&second[..ref_len], anchor, is_pre_biff8)?;
+    Ok((r1, c1, r1r, c1r, r2, c2, r2r, c2r, need))
+}
+
+/// Append an A1 reference, marking absolute components with `$`.
+fn push_a1(out: &mut String, row: u32, col: u32, row_rel: bool, col_rel: bool) {
+    if !col_rel {
+        out.push('$');
+    }
+    push_column(col, out);
+    if !row_rel {
+        out.push('$');
+    }
+    let _ = write!(out, "{}", row + 1);
+}
+
+/// Whether a cell-parsed formula is just a `PtgExp` pointing at a group.
+///
+/// Such a cell belongs to a shared or array formula whose tokens live in a
+/// separate `ShrFmla` or `Array` record, so it carries no formula of its own.
+fn is_shared_formula_member(rgce: &[u8]) -> bool {
+    if rgce.len() < 3 {
+        return false;
+    }
+    let cce = read_u16(rgce) as usize;
+    cce > 0 && rgce.len() >= 2 + cce && rgce[2] == 0x01
+}
+
 /// Formula parsing
 ///
 /// Does not implement ALL possibilities, only Area are parsed
@@ -1454,10 +1678,14 @@ fn parse_defined_names(rgce: &[u8], biff: Biff) -> Result<(Option<usize>, String
     };
     Ok(res)
 }
-
 /// Formula parsing
 ///
 /// `CellParsedFormula` [MS-XLS 2.5.198.3]
+///
+/// `anchor` is the cell owning the formula, as a zero-based `(row, col)`. The
+/// `N`-class tokens `PtgRefN` and `PtgAreaN`, which shared and array formulas
+/// are built from, store offsets from the evaluating cell rather than absolute
+/// positions, so they cannot be decoded without it.
 fn parse_formula(
     mut rgce: &[u8],
     sheets: &[String],
@@ -1465,6 +1693,7 @@ fn parse_formula(
     xtis: &[Xti],
     encoding: &XlsEncoding,
     biff: Biff,
+    anchor: (u32, u32),
 ) -> Result<String, XlsError> {
     let is_pre_biff8 = matches!(biff, Biff::Biff2 | Biff::Biff3 | Biff::Biff4 | Biff::Biff5);
     let mut stack = Vec::new();
@@ -1559,8 +1788,8 @@ fn parse_formula(
                     0x09 => "<",
                     0x0A => "<=",
                     0x0B => "=",
-                    0x0C => ">",
-                    0x0D => ">=",
+                    0x0C => ">=",
+                    0x0D => ">",
                     0x0E => "<>",
                     0x0F => " ",
                     0x10 => ",",
@@ -1738,6 +1967,23 @@ fn parse_formula(
                 stack.push(formula.len());
                 formula.push_str(names.get(iname).map_or("#REF!", |n| &*n.0));
                 rgce = &rgce[4..];
+            }
+            0x2C | 0x4C | 0x6C => {
+                // PtgRefN: PtgRef whose relative parts are offsets from `anchor`.
+                let (row, col, row_rel, col_rel, len) = read_ref_n(rgce, anchor, is_pre_biff8)?;
+                stack.push(formula.len());
+                push_a1(&mut formula, row, col, row_rel, col_rel);
+                rgce = &rgce[len..];
+            }
+            0x2D | 0x4D | 0x6D => {
+                // PtgAreaN: the two-corner form of PtgRefN.
+                let (r1, c1, r1_rel, c1_rel, r2, c2, r2_rel, c2_rel, len) =
+                    read_area_n(rgce, anchor, is_pre_biff8)?;
+                stack.push(formula.len());
+                push_a1(&mut formula, r1, c1, r1_rel, c1_rel);
+                formula.push(':');
+                push_a1(&mut formula, r2, c2, r2_rel, c2_rel);
+                rgce = &rgce[len..];
             }
             0x24 | 0x44 | 0x64 => {
                 stack.push(formula.len());
@@ -2009,5 +2255,161 @@ mod tests {
     fn test_parse_string() {
         let enc = XlsEncoding::from_codepage(1252).unwrap();
         parse_string(&[0, 1], &enc, Biff::Biff8).unwrap_err();
+    }
+}
+
+#[cfg(test)]
+mod formula_tests {
+    use super::{is_shared_formula_member, parse_formula, read_ref_n, Biff};
+    use crate::cfb::XlsEncoding;
+
+    fn encoding() -> XlsEncoding {
+        XlsEncoding::from_codepage(1200).expect("utf-16 codepage")
+    }
+
+    /// Wrap token bytes in the `cce`-prefixed form `parse_formula` expects.
+    fn cell_formula(tokens: &[u8]) -> Vec<u8> {
+        let mut v = (tokens.len() as u16).to_le_bytes().to_vec();
+        v.extend_from_slice(tokens);
+        v
+    }
+
+    /// Build a BIFF8 `PtgRefN` token: `ptg + rw(2) + grbitCol(2)`.
+    ///
+    /// The column occupies only the low 8 bits: BIFF8 sheets are 256 columns
+    /// wide, so a negative offset such as -1 is written as `0xFF`.
+    fn ref_n_biff8(ptg: u8, row: i16, col: i8, row_rel: bool, col_rel: bool) -> Vec<u8> {
+        let mut v = vec![ptg];
+        v.extend_from_slice(&(row as u16).to_le_bytes());
+        let mut c = (col as u8) as u16;
+        if row_rel {
+            c |= 0x4000;
+        }
+        if col_rel {
+            c |= 0x8000;
+        }
+        v.extend_from_slice(&c.to_le_bytes());
+        v
+    }
+
+    fn parse(tokens: &[u8], anchor: (u32, u32), biff: Biff) -> String {
+        parse_formula(
+            &cell_formula(tokens),
+            &[],
+            &[],
+            &[],
+            &encoding(),
+            biff,
+            anchor,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn ptg_ref_n_resolves_relative_offsets_against_the_anchor() {
+        // One row up, same column, evaluated at C6 (row 5, col 2) -> C5.
+        let t = ref_n_biff8(0x4C, -1, 0, true, true);
+        assert_eq!(parse(&t, (5, 2), Biff::Biff8), "C5");
+
+        // One column left, same row -> B6.
+        let t = ref_n_biff8(0x4C, 0, -1, true, true);
+        assert_eq!(parse(&t, (5, 2), Biff::Biff8), "B6");
+    }
+
+    #[test]
+    fn ptg_ref_n_absolute_components_ignore_the_anchor() {
+        let t = ref_n_biff8(0x4C, 0, 0, false, false);
+        assert_eq!(parse(&t, (5, 2), Biff::Biff8), "$A$1");
+        assert_eq!(parse(&t, (99, 7), Biff::Biff8), "$A$1");
+    }
+
+    #[test]
+    fn ptg_ref_n_shifts_with_the_anchor() {
+        // One definition must serve a whole filled-down column.
+        let t = ref_n_biff8(0x4C, -1, 0, true, true);
+        let got: Vec<String> = (5..9).map(|r| parse(&t, (r, 2), Biff::Biff8)).collect();
+        assert_eq!(got, ["C5", "C6", "C7", "C8"]);
+    }
+
+    #[test]
+    fn ptg_ref_n_biff8_column_offset_is_eight_bits() {
+        // BIFF8 has 256 columns, so the column offset in an RgceLocRel is 8
+        // bits wide, not the 14 bits XLSB uses. Reading it as 14 bits turns the
+        // -1 written as 0xFF into +255, silently moving A to IW.
+        let t = ref_n_biff8(0x4C, 0, -1, true, true);
+        assert_eq!(parse(&t, (0, 1), Biff::Biff8), "A1");
+
+        // The same mistake widens a SUM range: J38 summing B38:I38 became
+        // IX38:JE38 before this was pinned down.
+        // PtgAreaN: rwFirst(2) rwLast(2) colFirst(2) colLast(2), both columns
+        // relative. Both flags set marks row and column relative.
+        const REL: u16 = 0xC000;
+        let mut area = vec![0x4Du8];
+        area.extend_from_slice(&0u16.to_le_bytes()); // rwFirst: same row
+        area.extend_from_slice(&0u16.to_le_bytes()); // rwLast:  same row
+        area.extend_from_slice(&(REL | 0x00F8).to_le_bytes()); // colFirst: -8
+        area.extend_from_slice(&(REL | 0x00FF).to_le_bytes()); // colLast:  -1
+        assert_eq!(parse(&area, (37, 9), Biff::Biff8), "B38:I38");
+    }
+
+    #[test]
+    fn ptg_ref_n_pre_biff8_layout() {
+        // BIFF2-5 packs the row in 14 bits with fRwRel = 0x8000, fColRel =
+        // 0x4000, and uses a single byte for the column.
+        let rw: u16 = ((-1i16 as u16) & 0x3FFF) | 0x8000 | 0x4000;
+        let mut t = vec![0x4Cu8];
+        t.extend_from_slice(&rw.to_le_bytes());
+        t.push(0); // column delta 0
+        assert_eq!(parse(&t, (5, 2), Biff::Biff5), "C5");
+    }
+
+    #[test]
+    fn read_ref_n_rejects_a_truncated_token() {
+        assert!(read_ref_n(&[0, 0], (0, 0), false).is_err());
+        assert!(read_ref_n(&[0, 0], (0, 0), true).is_err());
+    }
+
+    #[test]
+    fn comparison_operators_match_the_ptg_assignments() {
+        // MS-XLS assigns PtgGe = 0x0C and PtgGt = 0x0D.
+        let lhs = ref_n_biff8(0x4C, 0, 0, true, true);
+        let rhs = ref_n_biff8(0x4C, -1, 0, true, true);
+        let build = |op: u8| {
+            let mut t = lhs.clone();
+            t.extend_from_slice(&rhs);
+            t.push(op);
+            parse(&t, (5, 2), Biff::Biff8)
+        };
+        assert_eq!(build(0x0C), "C6>=C5");
+        assert_eq!(build(0x0D), "C6>C5");
+        assert_eq!(build(0x09), "C6<C5");
+        assert_eq!(build(0x0A), "C6<=C5");
+        assert_eq!(build(0x0B), "C6=C5");
+        assert_eq!(build(0x0E), "C6<>C5");
+    }
+
+    #[test]
+    fn ref_u_reads_single_byte_columns() {
+        // The range header on ShrFmla and Array records is a RefU, whose
+        // columns are one byte each. Reading it as the wider Ref8U yields
+        // plausible rows and nonsense columns, so no member ever matches.
+        let r = [0x00, 0x00, 0x03, 0x00, 0x01, 0x01];
+        let d = super::parse_ref_u(&r).expect("6 bytes is enough");
+        assert_eq!((d.start, d.end), ((0, 1), (3, 1)));
+        assert!(super::parse_ref_u(&r[..5]).is_none());
+    }
+
+    #[test]
+    fn ptg_exp_marks_a_shared_formula_member() {
+        // A lone PtgExp with its row/col operand.
+        assert!(is_shared_formula_member(&cell_formula(&[
+            0x01, 0x09, 0x00, 0x0C, 0x00
+        ])));
+        // An ordinary reference is not a member.
+        assert!(!is_shared_formula_member(&cell_formula(&ref_n_biff8(
+            0x4C, 0, 0, true, true
+        ))));
+        assert!(!is_shared_formula_member(&[]));
+        assert!(!is_shared_formula_member(&[0x00, 0x00]));
     }
 }

--- a/src/xlsb/cells_reader.rs
+++ b/src/xlsb/cells_reader.rs
@@ -2,6 +2,7 @@
 //
 // Copyright 2016-2026, Johann Tuffe.
 
+use std::collections::HashMap;
 use std::io::{Read, Seek};
 
 use crate::{
@@ -11,7 +12,7 @@ use crate::{
     Cell, CellErrorType, Dimensions, XlsbError,
 };
 
-use super::{cell_format, parse_formula, wide_str, RecordIter};
+use super::{cell_format, parse_formula, shared_formula_anchor_row, wide_str, RecordIter};
 
 /// A cells reader for xlsb files
 pub struct XlsbCellsReader<'a, RS>
@@ -160,34 +161,138 @@ where
         Ok(Some(Cell::new((self.row, col), value)))
     }
 
+    /// Read the next formula cell, skipping shared and array formula members.
+    ///
+    /// Members of a shared or array formula group decode to an empty string,
+    /// because their token stream is a single `PtgExp` pointing at a definition
+    /// stored elsewhere in the sheet. Resolving them needs a second pass over
+    /// the sheet, so use [`XlsbCellsReader::formulas`] to get them.
     pub fn next_formula(&mut self) -> Result<Option<Cell<String>>, XlsbError> {
-        let value = loop {
+        loop {
+            match self.next_formula_record()? {
+                None => return Ok(None),
+                Some(FormulaRecord::Cell(cell)) => return Ok(Some(cell)),
+                // Preserve the historical shape of this API: a member yields an
+                // empty formula rather than disappearing from the iteration.
+                Some(FormulaRecord::Member { pos }) => {
+                    return Ok(Some(Cell::new(pos, String::new())))
+                }
+                Some(FormulaRecord::Definition { .. }) => continue,
+            }
+        }
+    }
+
+    /// Read every formula on the sheet, resolving shared and array formulas.
+    ///
+    /// Excel stores a run of repeated formulas once, as a `BrtShrFmla` or
+    /// `BrtArrFmla` definition covering a range, and gives each cell in that
+    /// range a lone `PtgExp` token pointing back at it. A single pass cannot
+    /// resolve those, because the definition may appear after the members that
+    /// refer to it, so members are collected and resolved at the end.
+    ///
+    /// A definition's token stream uses the relative `PtgRefN` and `PtgAreaN`
+    /// forms, so it is decoded once per member, anchored at that member's own
+    /// position. That is what makes each row of a filled-down column come out
+    /// with its own correct references.
+    pub fn formulas(&mut self) -> Result<Vec<Cell<String>>, XlsbError> {
+        let mut cells = Vec::new();
+        let mut members: Vec<(u32, u32)> = Vec::new();
+        let mut definitions: Vec<(Dimensions, Vec<u8>)> = Vec::new();
+
+        while let Some(record) = self.next_formula_record()? {
+            match record {
+                FormulaRecord::Cell(cell) => {
+                    if !cell.get_value().is_empty() {
+                        cells.push(cell);
+                    }
+                }
+                FormulaRecord::Member { pos } => members.push(pos),
+                FormulaRecord::Definition { range, rgce } => definitions.push((range, rgce)),
+            }
+        }
+
+        // Index definitions by column. A sheet can hold thousands of them —
+        // Excel splits a filled-down column into groups of about 64 rows — and
+        // scanning them all for each of millions of members is quadratic enough
+        // to dominate the read. Groups are nearly always one column wide;
+        // anything wider stays in a small list scanned linearly, which keeps the
+        // index compact without losing matches.
+        const WIDE_GROUP_COLS: u32 = 64;
+        let mut by_column: HashMap<u32, Vec<(u32, u32, usize)>> = HashMap::new();
+        let mut wide: Vec<usize> = Vec::new();
+        for (i, (range, _)) in definitions.iter().enumerate() {
+            if range.end.1.saturating_sub(range.start.1) >= WIDE_GROUP_COLS {
+                wide.push(i);
+                continue;
+            }
+            for col in range.start.1..=range.end.1 {
+                by_column
+                    .entry(col)
+                    .or_default()
+                    .push((range.start.0, range.end.0, i));
+            }
+        }
+        for spans in by_column.values_mut() {
+            spans.sort_unstable();
+        }
+
+        for pos in members {
+            let found = by_column.get(&pos.1).and_then(|spans| {
+                // Groups in a column do not overlap, so the only candidate is
+                // the last one starting at or before this row.
+                let i = spans.partition_point(|&(start, _, _)| start <= pos.0);
+                let &(_, end, index) = spans.get(i.checked_sub(1)?)?;
+                (pos.0 <= end).then_some(index)
+            });
+            let Some(index) = found.or_else(|| {
+                wide.iter().rev().copied().find(|&i| {
+                    let range = &definitions[i].0;
+                    pos.0 >= range.start.0
+                        && pos.0 <= range.end.0
+                        && pos.1 >= range.start.1
+                        && pos.1 <= range.end.1
+                })
+            }) else {
+                continue;
+            };
+            let rgce = &definitions[index].1;
+            let formula = parse_formula(rgce, self.extern_sheets, self.metadata_names, pos)?;
+            if !formula.is_empty() {
+                cells.push(Cell::new(pos, formula));
+            }
+        }
+
+        // `Range::from_sparse` expects row-major order, which the second pass
+        // breaks by appending resolved members after the cells read inline.
+        cells.sort_unstable_by_key(|c| c.get_position());
+        Ok(cells)
+    }
+
+    /// Read the next formula-related record from the sheet stream.
+    fn next_formula_record(&mut self) -> Result<Option<FormulaRecord>, XlsbError> {
+        loop {
             self.typ = self.iter.read_type()?;
             let _ = self.iter.fill_buffer(&mut self.buf)?;
 
-            let value = match self.typ {
-                // 0x0001 => continue, // Data::Empty, // BrtCellBlank
+            let rgce = match self.typ {
                 0x0008 => {
                     // BrtFmlaString
                     let cch = read_u32(&self.buf[8..]) as usize;
                     let formula = &self.buf[14 + cch * 2..];
                     let cce = read_u32(formula) as usize;
-                    let rgce = &formula[4..4 + cce];
-                    parse_formula(rgce, self.extern_sheets, self.metadata_names)?
+                    &formula[4..4 + cce]
                 }
                 0x0009 => {
                     // BrtFmlaNum
                     let formula = &self.buf[18..];
                     let cce = read_u32(formula) as usize;
-                    let rgce = &formula[4..4 + cce];
-                    parse_formula(rgce, self.extern_sheets, self.metadata_names)?
+                    &formula[4..4 + cce]
                 }
                 0x000A | 0x000B => {
                     // BrtFmlaBool | BrtFmlaError
                     let formula = &self.buf[11..];
                     let cce = read_u32(formula) as usize;
-                    let rgce = &formula[4..4 + cce];
-                    parse_formula(rgce, self.extern_sheets, self.metadata_names)?
+                    &formula[4..4 + cce]
                 }
                 0x0000 => {
                     // BrtRowHdr
@@ -197,19 +302,127 @@ where
                     }
                     continue;
                 }
+                // BrtArrFmla carries a one-byte flags field between the range
+                // and the token stream; BrtShrFmla does not.
+                0x01AA | 0x01AB => {
+                    let offset = if self.typ == 0x01AA { 17 } else { 16 };
+                    match parse_formula_definition(&self.buf, offset) {
+                        Some(def) => return Ok(Some(def)),
+                        None => continue,
+                    }
+                }
                 0x0092 => return Ok(None), // BrtEndSheetData
                 _ => continue, // anything else, ignore and try next, without changing idx
             };
-            break value;
-        };
-        let col = read_u32(&self.buf);
-        Ok(Some(Cell::new((self.row, col), value)))
+
+            let pos = (self.row, read_u32(&self.buf));
+            if shared_formula_anchor_row(rgce).is_some() {
+                return Ok(Some(FormulaRecord::Member { pos }));
+            }
+            let formula = parse_formula(rgce, self.extern_sheets, self.metadata_names, pos)?;
+            return Ok(Some(FormulaRecord::Cell(Cell::new(pos, formula))));
+        }
     }
+}
+
+/// A record encountered while scanning a sheet for formulas.
+enum FormulaRecord {
+    /// A cell whose formula stands on its own.
+    Cell(Cell<String>),
+    /// A cell belonging to a shared or array formula group.
+    Member { pos: (u32, u32) },
+    /// The definition a group's members point at.
+    Definition { range: Dimensions, rgce: Vec<u8> },
+}
+
+/// Decode a `BrtShrFmla` or `BrtArrFmla` payload into a range and token stream.
+///
+/// Returns `None` rather than a malformed definition if the declared token
+/// length does not fit the record, so a misread never turns into a wrong
+/// formula on every cell of a range.
+fn parse_formula_definition(buf: &[u8], offset: usize) -> Option<FormulaRecord> {
+    if buf.len() < offset + 4 {
+        return None;
+    }
+    let range = parse_dimensions(buf.get(..16)?);
+    let cce = read_u32(&buf[offset..]) as usize;
+    if cce == 0 || buf.len() < offset + 4 + cce {
+        return None;
+    }
+    Some(FormulaRecord::Definition {
+        range,
+        rgce: buf[offset + 4..offset + 4 + cce].to_vec(),
+    })
 }
 
 fn parse_dimensions(buf: &[u8]) -> Dimensions {
     Dimensions {
         start: (read_u32(&buf[0..4]), read_u32(&buf[8..12])),
         end: (read_u32(&buf[4..8]), read_u32(&buf[12..16])),
+    }
+}
+
+#[cfg(test)]
+mod definition_tests {
+    use super::{parse_formula_definition, FormulaRecord};
+
+    /// Build a `BrtShrFmla`-shaped payload: `rfx(16) cce(4) rgce`.
+    fn shr_fmla(
+        rw_first: u32,
+        rw_last: u32,
+        col_first: u32,
+        col_last: u32,
+        rgce: &[u8],
+    ) -> Vec<u8> {
+        let mut v = Vec::new();
+        for f in [rw_first, rw_last, col_first, col_last] {
+            v.extend_from_slice(&f.to_le_bytes());
+        }
+        v.extend_from_slice(&(rgce.len() as u32).to_le_bytes());
+        v.extend_from_slice(rgce);
+        v
+    }
+
+    #[test]
+    fn shared_definition_layout() {
+        // Excel chunks a filled-down column into groups of about 64 rows, so a
+        // single-column range like this is the common shape.
+        let payload = shr_fmla(2, 65, 3, 3, &[0x4C, 0, 0, 0, 0, 0xFF, 0xC0]);
+        let Some(FormulaRecord::Definition { range, rgce }) =
+            parse_formula_definition(&payload, 16)
+        else {
+            panic!("expected a definition");
+        };
+        assert_eq!((range.start, range.end), ((2, 3), (65, 3)));
+        assert_eq!(rgce.len(), 7);
+    }
+
+    #[test]
+    fn array_definition_skips_its_flags_byte() {
+        // BrtArrFmla carries one flags byte between the range and the tokens.
+        let mut payload = shr_fmla(0, 2, 2, 2, &[0x1C, 0x2A]);
+        payload.insert(16, 0x02);
+        let Some(FormulaRecord::Definition { range, rgce }) =
+            parse_formula_definition(&payload, 17)
+        else {
+            panic!("expected a definition");
+        };
+        assert_eq!((range.start, range.end), ((0, 2), (2, 2)));
+        assert_eq!(rgce, vec![0x1C, 0x2A]);
+    }
+
+    #[test]
+    fn malformed_definitions_are_rejected_rather_than_guessed() {
+        // A wrong offset would otherwise turn into a plausible but wrong
+        // formula on every cell of a range, which is worse than none at all.
+        assert!(parse_formula_definition(&[0u8; 8], 16).is_none());
+        assert!(parse_formula_definition(&shr_fmla(0, 1, 0, 0, &[]), 16).is_none());
+
+        // Token length overruns the record.
+        let mut truncated = shr_fmla(0, 1, 0, 0, &[0x4C, 0, 0]);
+        let len = truncated.len();
+        truncated[16..20].copy_from_slice(&99u32.to_le_bytes());
+        assert_eq!(truncated.len(), len);
+        assert!(parse_formula_definition(&truncated, 16).is_none());
     }
 }

--- a/src/xlsb/mod.rs
+++ b/src/xlsb/mod.rs
@@ -76,6 +76,15 @@ pub enum XlsbError {
         /// buffer length
         buf_len: usize,
     },
+    /// A formula token was shorter than its layout requires
+    Len {
+        /// token name
+        typ: &'static str,
+        /// bytes the token needs
+        expected: usize,
+        /// bytes available
+        found: usize,
+    },
     /// Unrecognized data
     Unrecognized {
         /// data type
@@ -117,6 +126,14 @@ impl std::fmt::Display for XlsbError {
             XlsbError::BErr(t) => write!(f, "Unsupported BErr {t:X}"),
             XlsbError::Ptg(t) => write!(f, "Unsupported Ptf {t:X}"),
             XlsbError::CellError(t) => write!(f, "Unsupported Cell Error code {t:X}"),
+            XlsbError::Len {
+                typ,
+                expected,
+                found,
+            } => write!(
+                f,
+                "{typ} token needs {expected} bytes but only {found} are available"
+            ),
             XlsbError::WideStr { ws_len, buf_len } => write!(
                 f,
                 "Wide str length exceeds buffer length ({ws_len} > {buf_len})",
@@ -384,7 +401,7 @@ impl<RS: Read + Seek> Xlsb<RS> {
                     let name = wide_str(&buf[9..len], &mut str_len)?.into_owned();
                     let rgce_len = read_u32(&buf[9 + str_len..]) as usize;
                     let rgce = &buf[13 + str_len..13 + str_len + rgce_len];
-                    let formula = parse_formula(rgce, &self.extern_sheets, &defined_names)?;
+                    let formula = parse_formula(rgce, &self.extern_sheets, &defined_names, (0, 0))?;
                     defined_names.push((name, formula));
                 }
                 0x009D | 0x0225 | 0x018D | 0x0180 | 0x009A | 0x0252 | 0x0229 | 0x009B | 0x0084 => {
@@ -530,12 +547,10 @@ impl<RS: Read + Seek> Reader<RS> for Xlsb<RS> {
     /// MS-XLSB 2.1.7.62
     fn worksheet_formula(&mut self, name: &str) -> Result<Range<String>, XlsbError> {
         let mut cells_reader = self.worksheet_cells_reader(name)?;
-        let mut cells = Vec::with_capacity(cells_reader.dimensions().len().min(1_000_000) as _);
-        while let Some(cell) = cells_reader.next_formula()? {
-            if !cell.val.is_empty() {
-                cells.push(cell);
-            }
-        }
+        // `formulas` rather than a `next_formula` loop: shared and array formula
+        // members carry only a back-reference to a definition that may appear
+        // later in the sheet, so resolving them needs the two-pass read.
+        let cells = cells_reader.formulas()?;
         Ok(Range::from_sparse(cells))
     }
 
@@ -726,14 +741,112 @@ fn wide_str<'a>(buf: &'a [u8], str_len: &mut usize) -> Result<Cow<'a, str>, Xlsb
 
 /// Formula parsing
 ///
+/// Decode a 6-byte `Loc` reference whose relative components are offsets.
+///
+/// Returns `(row, col, row_is_relative, col_is_relative)` with absolute
+/// zero-based indices. In the `N`-class tokens the stored row is a signed 32-bit
+/// delta and the stored column a signed 14-bit delta, both measured from the
+/// cell that owns the formula.
+fn read_ref_n(rgce: &[u8], anchor: (u32, u32)) -> Result<(u32, u32, bool, bool), XlsbError> {
+    if rgce.len() < 6 {
+        return Err(XlsbError::Len {
+            typ: "PtgRefN",
+            expected: 6,
+            found: rgce.len(),
+        });
+    }
+    let raw_row = read_u32(rgce);
+    let raw_col = read_u16(&[rgce[4], rgce[5]]);
+    let col_rel = rgce[5] & 0x80 == 0x80;
+    let row_rel = rgce[5] & 0x40 == 0x40;
+
+    let row = if row_rel {
+        anchor.0.wrapping_add(raw_row)
+    } else {
+        raw_row
+    };
+
+    let col_field = raw_col & 0x3FFF;
+    let col = if col_rel {
+        // Sign-extend the 14-bit delta before applying it.
+        let delta = ((col_field << 2) as i16 >> 2) as i32;
+        (anchor.1 as i32).wrapping_add(delta) as u32
+    } else {
+        col_field as u32
+    };
+
+    Ok((row & 0xF_FFFF, col & 0x3FFF, row_rel, col_rel))
+}
+
+/// Decode the first corner of a `PtgAreaN` token.
+///
+/// The token's layout is `rwFirst(4) rwLast(4) colFirst(2) colLast(2)`, so the
+/// first corner is `rwFirst` paired with `colFirst`.
+fn read_area_n_first(rgce: &[u8], anchor: (u32, u32)) -> Result<(u32, u32, bool, bool), XlsbError> {
+    if rgce.len() < 12 {
+        return Err(XlsbError::Len {
+            typ: "PtgAreaN",
+            expected: 12,
+            found: rgce.len(),
+        });
+    }
+    let first = [rgce[0], rgce[1], rgce[2], rgce[3], rgce[8], rgce[9]];
+    read_ref_n(&first, anchor)
+}
+
+/// Decode the second corner of a `PtgAreaN` token.
+fn read_area_n_second(
+    rgce: &[u8],
+    anchor: (u32, u32),
+) -> Result<(u32, u32, bool, bool), XlsbError> {
+    if rgce.len() < 12 {
+        return Err(XlsbError::Len {
+            typ: "PtgAreaN",
+            expected: 12,
+            found: rgce.len(),
+        });
+    }
+    // Layout is rwFirst(4) rwLast(4) colFirst(2) colLast(2); the second corner
+    // is therefore rwLast plus colLast.
+    let second = [rgce[4], rgce[5], rgce[6], rgce[7], rgce[10], rgce[11]];
+    read_ref_n(&second, anchor)
+}
+
+/// Append an A1 reference, marking absolute components with `$`.
+fn push_a1(out: &mut String, row: u32, col: u32, row_rel: bool, col_rel: bool) {
+    if !col_rel {
+        out.push('$');
+    }
+    push_column(col, out);
+    if !row_rel {
+        out.push('$');
+    }
+    out.push_str(&format!("{}", row + 1));
+}
+
+/// The row a `PtgExp` token points at, if `rgce` is a shared/array member.
+///
+/// A member of a shared or array formula group carries a single `PtgExp` token
+/// naming the group's first row; the group's actual token stream lives in a
+/// separate `BrtShrFmla` or `BrtArrFmla` record.
+pub(crate) fn shared_formula_anchor_row(rgce: &[u8]) -> Option<u32> {
+    (rgce.len() >= 5 && rgce[0] == 0x01).then(|| read_u32(&rgce[1..5]))
+}
+
 /// [MS-XLSB 2.2.2]
 /// [MS-XLSB 2.5.97]
 ///
 /// See Ptg [2.5.97.16]
+///
+/// `anchor` is the cell the formula belongs to, as a zero-based `(row, col)`.
+/// It is required because the `N`-class reference tokens `PtgRefN` and
+/// `PtgAreaN` — the ones shared and array formulas are built from — store
+/// *offsets from the cell being evaluated* rather than absolute positions.
 fn parse_formula(
     mut rgce: &[u8],
     sheets: &[String],
     names: &[(String, String)],
+    anchor: (u32, u32),
 ) -> Result<String, XlsbError> {
     if rgce.is_empty() {
         return Ok(String::new());
@@ -815,8 +928,8 @@ fn parse_formula(
                     0x09 => "<",
                     0x0A => "<=",
                     0x0B => "=",
-                    0x0C => ">",
-                    0x0D => ">=",
+                    0x0C => ">=",
+                    0x0D => ">",
                     0x0E => "<>",
                     0x0F => " ",
                     0x10 => ",",
@@ -997,6 +1110,31 @@ fn parse_formula(
                 formula.push_str(&format!("{}", read_u32(&rgce[4..8]) + 1));
                 rgce = &rgce[12..];
             }
+            0x2C | 0x4C | 0x6C => {
+                // PtgRefN: like PtgRef, but relative components are signed
+                // offsets from `anchor` rather than absolute indices.
+                let (row, col, row_rel, col_rel) = read_ref_n(rgce, anchor)?;
+                stack.push(formula.len());
+                if !col_rel {
+                    formula.push('$');
+                }
+                push_column(col, &mut formula);
+                if !row_rel {
+                    formula.push('$');
+                }
+                formula.push_str(&format!("{}", row + 1));
+                rgce = &rgce[6..];
+            }
+            0x2D | 0x4D | 0x6D => {
+                // PtgAreaN: the two-corner form of PtgRefN.
+                let (r1, c1, r1_rel, c1_rel) = read_area_n_first(rgce, anchor)?;
+                let (r2, c2, r2_rel, c2_rel) = read_area_n_second(rgce, anchor)?;
+                stack.push(formula.len());
+                push_a1(&mut formula, r1, c1, r1_rel, c1_rel);
+                formula.push(':');
+                push_a1(&mut formula, r2, c2, r2_rel, c2_rel);
+                rgce = &rgce[12..];
+            }
             0x2A | 0x4A | 0x6A => {
                 stack.push(formula.len());
                 formula.push_str("#REF!");
@@ -1010,7 +1148,7 @@ fn parse_formula(
             0x29 | 0x49 | 0x69 => {
                 let cce = read_u16(rgce) as usize;
                 rgce = &rgce[2..];
-                let f = parse_formula(&rgce[..cce], sheets, names)?;
+                let f = parse_formula(&rgce[..cce], sheets, names, anchor)?;
                 stack.push(formula.len());
                 formula.push_str(&f);
                 rgce = &rgce[cce..];
@@ -1052,4 +1190,105 @@ fn check_for_password_protected<RS: Read + Seek>(reader: &mut RS) -> Result<(), 
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod formula_tests {
+    use super::{parse_formula, read_ref_n, shared_formula_anchor_row};
+
+    /// Build a `PtgRefN`-class reference token.
+    ///
+    /// `row` is a signed row delta when `row_rel`, otherwise an absolute index;
+    /// likewise `col`. This is the encoding shared and array formulas use.
+    fn ref_n(ptg: u8, row: i32, col: i16, row_rel: bool, col_rel: bool) -> Vec<u8> {
+        let mut v = vec![ptg];
+        v.extend_from_slice(&(row as u32).to_le_bytes());
+        let mut c = (col as u16) & 0x3FFF;
+        if row_rel {
+            c |= 0x4000;
+        }
+        if col_rel {
+            c |= 0x8000;
+        }
+        v.extend_from_slice(&c.to_le_bytes());
+        v
+    }
+
+    #[test]
+    fn ptg_ref_n_resolves_relative_offsets_against_the_anchor() {
+        // One row up, same column, evaluated at C6 (row 5, col 2) -> C5.
+        let rgce = ref_n(0x4C, -1, 0, true, true);
+        let f = parse_formula(&rgce, &[], &[], (5, 2)).unwrap();
+        assert_eq!(f, "C5");
+
+        // One column left, same row -> B6.
+        let rgce = ref_n(0x4C, 0, -1, true, true);
+        assert_eq!(parse_formula(&rgce, &[], &[], (5, 2)).unwrap(), "B6");
+    }
+
+    #[test]
+    fn ptg_ref_n_absolute_components_ignore_the_anchor() {
+        let rgce = ref_n(0x4C, 0, 0, false, false);
+        // Absolute row 0, column 0, regardless of where the formula lives.
+        assert_eq!(parse_formula(&rgce, &[], &[], (5, 2)).unwrap(), "$A$1");
+        assert_eq!(parse_formula(&rgce, &[], &[], (99, 7)).unwrap(), "$A$1");
+    }
+
+    #[test]
+    fn ptg_ref_n_mixed_absoluteness() {
+        // Absolute column A, row relative one up.
+        let rgce = ref_n(0x4C, -1, 0, true, false);
+        assert_eq!(parse_formula(&rgce, &[], &[], (5, 2)).unwrap(), "$A5");
+    }
+
+    #[test]
+    fn ptg_ref_n_shifts_with_the_anchor() {
+        // The same token decoded at successive rows must walk down the sheet,
+        // which is what makes one shared definition serve a whole column.
+        let rgce = ref_n(0x4C, -1, 0, true, true);
+        let got: Vec<String> = (5..9)
+            .map(|row| parse_formula(&rgce, &[], &[], (row, 2)).unwrap())
+            .collect();
+        assert_eq!(got, ["C5", "C6", "C7", "C8"]);
+    }
+
+    #[test]
+    fn read_ref_n_rejects_a_truncated_token() {
+        assert!(read_ref_n(&[0, 0, 0], (0, 0)).is_err());
+    }
+
+    #[test]
+    fn comparison_operators_match_the_ptg_assignments() {
+        // MS-XLSB assigns PtgGe = 0x0C and PtgGt = 0x0D.
+        let lhs = ref_n(0x4C, 0, 0, true, true);
+        let rhs = ref_n(0x4C, -1, 0, true, true);
+        let build = |op: u8| {
+            let mut v = lhs.clone();
+            v.extend_from_slice(&rhs);
+            v.push(op);
+            parse_formula(&v, &[], &[], (5, 2)).unwrap()
+        };
+        assert_eq!(build(0x0C), "C6>=C5");
+        assert_eq!(build(0x0D), "C6>C5");
+        assert_eq!(build(0x09), "C6<C5");
+        assert_eq!(build(0x0A), "C6<=C5");
+        assert_eq!(build(0x0B), "C6=C5");
+        assert_eq!(build(0x0E), "C6<>C5");
+    }
+
+    #[test]
+    fn ptg_exp_is_recognised_as_a_group_member() {
+        // PtgExp carries the first row of the group it belongs to.
+        let rgce = [0x01u8, 0x02, 0x00, 0x00, 0x00];
+        assert_eq!(shared_formula_anchor_row(&rgce), Some(2));
+
+        // An ordinary reference is not a member.
+        assert_eq!(
+            shared_formula_anchor_row(&ref_n(0x4C, 0, 0, true, true)),
+            None
+        );
+        assert_eq!(shared_formula_anchor_row(&[]), None);
+        // Too short to carry a row.
+        assert_eq!(shared_formula_anchor_row(&[0x01, 0x00]), None);
+    }
 }


### PR DESCRIPTION
> **Disclosure: this pull request was written by an AI agent** (Claude, via Claude
> Code), including the code, the tests and this description. I directed and
> reviewed the work, and I have run the tests and checks reported below, but I
> did not hand-write the patch. I am raising it because the underlying bugs are
> real and reproducible, and the evidence is checkable independently of who or
> what wrote it. **If you do not accept AI-generated contributions, please close
> this** — no hard feelings, and I would be glad to file it as an issue with the
> findings instead so someone else can pick it up.

## Summary

Two silent defects in the binary-format formula readers, fixed for both `.xlsb`
and `.xls` (one commit each).

### 1. `PtgExp` is discarded, losing shared and array formulas

`PtgExp` marks a cell as a member of a shared or array formula group. The tokens
live in a separate record covering a range (`BrtShrFmla`/`BrtArrFmla` in XLSB,
`ShrFmla`/`Array` in XLS) and the member carries only a back-reference. It was
treated as a no-op, so members decoded to an empty string and `worksheet_formula`
dropped them.

This is the normal encoding for a filled-down column, so the loss is large. On a
170 MB XLSB workbook with 43.5M populated cells:

| | Formula cells |
|---|---|
| Present in the file | 6,793,166 |
| Decoded before | 2,012,750 |
| **Silently dropped** | **4,780,416 (70.4%)** |

Several sheets returned no formulas at all. On one sheet of 390,730 formula
cells, 390,728 were `PtgExp` members and `worksheet_formula` returned 2.

Resolving them needs two passes, because a definition can appear *after* the
members that refer to it. `XlsbCellsReader::formulas` collects members and
definitions and resolves at the end; `worksheet_formula` uses it. `next_formula`
keeps its previous behaviour, so the public API is unchanged.

Definitions are built from the relative `PtgRefN` and `PtgAreaN` tokens, which
were not handled at all. They store signed offsets from the cell being
evaluated, so `parse_formula` now takes an anchor cell and decodes the
definition once per member — that is what gives each row its own references.

Definitions are indexed by column and found by binary search, which is sound
because groups within a column cannot overlap. Excel splits a column into groups
of about 64 rows, so a large sheet holds thousands of definitions against
millions of members; a linear scan per member took 43.7s on the workbook above
against 10.1s indexed.

### 2. `>` and `>=` are transposed

The comparison operator tables in both readers had `PtgGe` and `PtgGt` the wrong
way round. The specs assign `PtgGe = 0x0C` and `PtgGt = 0x0D`, but `0x0C`
rendered as `>` and `0x0D` as `>=`, inverting every comparison read from a binary
workbook with no error raised.

Found by comparing `tests/issues.xls`/`.xlsb` against their `.xlsx` twin, where
`datatypes!A4` stores the authoritative text `A1>A2` as XML while both binary
reads gave `A1>=A2`.

## Verification

**`.xls`, against this repository's own fixtures:** formulas recovered go from
**496 to 869**, with **none of the previously decoded formulas lost** and exactly
two changed — both the operator fix, both now agreeing with the `issues.xlsx`
twin.

**`.xlsb`, against the 170 MB workbook:** all 6,793,166 formulas recovered,
matching an independent count of `BrtFmla*` records taken by walking the raw
BIFF12 stream.

Counting alone does not show correctness — a mis-applied anchor gives the same
count with every row pointing at the wrong cells. So the check is the invariant a
shared formula must satisfy: two vertically adjacent members of a group differ by
exactly one row.

```
shared/array formula members found:      4,780,416
  left unresolved by the two-pass read:          0
adjacent member pairs compared:          4,779,791
  advance by exactly one row:            4,779,791
  WRONG:                                         0
```

That invariant is not sufficient on its own, which is worth stating plainly: it
validates rows and is blind to columns, because every member of a group gets the
*same* column. A review before opening this PR used that gap to find a third bug,
now fixed here — the column offset in a BIFF8 `RgceLocRel` is **8 bits** wide,
not the 14 bits XLSB uses, since that format has 256 columns rather than 16384.
Masking 14 bits read the `-1` written as `0xFF` as `+255`, turning
`SUM(B38:I38)` into `SUM(IX38:JE38)`. It affected 90 formulas in this
repository's fixtures. It was caught by generating an `.xls` through LibreOffice
and diffing against its `.xlsx` twin, and by checking for references past column
`IV`, which cannot exist in that format.

All existing tests pass, plus `cargo fmt --check`, `clippy --all-targets` and
`typos`.

## Tests added

Fixture-free unit tests for the `N`-class reference decoding in both BIFF
layouts (including the 8-bit column offset), the anchor shifting, the operator
assignments, `PtgExp` recognition, and the `RefU` / `BrtShrFmla` / `BrtArrFmla`
record layouts.

## Known gap

**No fixture in this repository exercises XLSB shared or array formulas**, so
that path is verified against a private workbook rather than in-tree. I could not
add one: nothing open-source can write XLSB — LibreOffice imports it but has no
export filter — so a fixture needs someone with Excel. I would be happy to add
one if you can supply or generate a file.

The `.xls` side does have in-tree coverage: `OOM_alloc.xls` and
`optional_records.xls` both contain `ShrFmla` records and exercise the fix
end to end.

One observation, left alone as out of scope: on the same workbook, the unpatched
reader already emits sheet-local references outside the sheet's used columns at a
higher rate than the patched one (14.5% against 2.8%), including a column `USO`
on a sheet using `A..I`. That looks like a separate pre-existing issue in other
token types rather than anything these commits touch.
