### PR TITLE
Quote sheet names that need quoting in decoded formulas

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -76,6 +76,60 @@ pub fn push_column(col: u32, buf: &mut String) {
     }
 }
 
+/// Write a sheet name into a formula, quoting it if Excel requires quotes.
+///
+/// `'My Sheet'!A1` is one reference; `My Sheet!A1` is not valid formula syntax
+/// and reads as a reference to a sheet called `Sheet`. Excel needs the quotes
+/// whenever the name is not a plain identifier, and an apostrophe inside a
+/// quoted name is doubled.
+pub fn push_sheet_name(name: &str, buf: &mut String) {
+    if !sheet_name_needs_quotes(name) {
+        buf.push_str(name);
+        return;
+    }
+    buf.push('\'');
+    for c in name.chars() {
+        if c == '\'' {
+            buf.push('\'');
+        }
+        buf.push(c);
+    }
+    buf.push('\'');
+}
+
+/// Whether a sheet name must be quoted to appear in a formula.
+fn sheet_name_needs_quotes(name: &str) -> bool {
+    let mut chars = name.chars();
+    let Some(first) = chars.next() else {
+        // An empty name cannot be written bare at all.
+        return true;
+    };
+    // A leading digit would read as a number, and a leading `.` is not a legal
+    // start for an identifier.
+    if !(first.is_alphabetic() || first == '_') {
+        return true;
+    }
+    if chars.any(|c| !(c.is_alphanumeric() || c == '_' || c == '.')) {
+        return true;
+    }
+    // A name shaped like a cell reference must be quoted, or `Q1!A1` would
+    // read as the cell `Q1` of the current sheet. `R` and `C` alone collide
+    // with R1C1 notation the same way.
+    looks_like_reference(name)
+}
+
+/// Whether a name would parse as a cell reference, e.g. `Q1` or `XFD9`.
+fn looks_like_reference(name: &str) -> bool {
+    if name.eq_ignore_ascii_case("r") || name.eq_ignore_ascii_case("c") {
+        return true;
+    }
+    let letters = name.bytes().take_while(|b| b.is_ascii_alphabetic()).count();
+    if letters == 0 || letters > 3 || letters == name.len() {
+        return false;
+    }
+    name[letters..].bytes().all(|b| b.is_ascii_digit())
+}
+
 /// Write the Excel letters for a 0-based column index into `out` (most
 /// significant first) and return how many were written.
 pub(crate) fn column_name_digits(col: u32, out: &mut [u8]) -> usize {
@@ -1173,6 +1227,41 @@ pub const FTAB_ARGC: [u8; FTAB_LEN] = [
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_push_sheet_name() {
+        let check = |name: &str, expected: &str| {
+            let mut got = String::new();
+            push_sheet_name(name, &mut got);
+            assert_eq!(got, expected, "push_sheet_name({name:?})");
+        };
+
+        // A plain identifier is written as it stands.
+        check("Sheet1", "Sheet1");
+        check("_hidden", "_hidden");
+        check("Sales.2024", "Sales.2024");
+        check("Ünicode", "Ünicode");
+
+        // Anything else needs quotes, or the name runs into the `!`.
+        check("My Sheet", "'My Sheet'");
+        check("BP136-6-WORK DOC", "'BP136-6-WORK DOC'");
+        check("2024", "'2024'");
+        check("", "''");
+
+        // An apostrophe inside a quoted name is doubled.
+        check("Bob's Sheet", "'Bob''s Sheet'");
+
+        // A name shaped like a cell reference would otherwise read as one.
+        check("Q1", "'Q1'");
+        check("XFD9", "'XFD9'");
+        check("R", "'R'");
+        check("C", "'C'");
+
+        // But a name that only looks similar does not.
+        check("Q", "Q");
+        check("Quarter1", "Quarter1");
+        check("ABCD1", "ABCD1");
+    }
 
     #[test]
     fn test_push_column() {

--- a/src/xls.rs
+++ b/src/xls.rs
@@ -16,7 +16,9 @@ use crate::formats::{
 };
 #[cfg(feature = "picture")]
 use crate::utils::read_usize;
-use crate::utils::{push_column, read_f64, read_i16, read_i32, read_u16, read_u32};
+use crate::utils::{
+    push_column, push_sheet_name, read_f64, read_i16, read_i32, read_u16, read_u32,
+};
 use crate::vba::VbaProject;
 use crate::{
     Cell, CellErrorType, Data, Dimensions, HeaderRow, Metadata, Range, Reader, Sheet, SheetType,
@@ -1482,10 +1484,13 @@ fn parse_formula(
                 let colu = read_u16(&rgce[4..]);
                 let sh = xtis
                     .get(ixti as usize)
-                    .and_then(|xti| sheets.get(xti.itab_first as usize))
-                    .map_or("#REF", |sh| sh);
+                    .and_then(|xti| sheets.get(xti.itab_first as usize));
                 stack.push(formula.len());
-                formula.push_str(sh);
+                match sh {
+                    Some(sh) => push_sheet_name(sh, &mut formula),
+                    // Not a sheet name but an error marker, so it is not quoted.
+                    None => formula.push_str("#REF"),
+                }
                 formula.push('!');
                 let col = colu << 2; // first 14 bits only
                 if colu & 2 != 0 {
@@ -1502,7 +1507,11 @@ fn parse_formula(
                 // PtgArea3d
                 let ixti = read_u16(&rgce[0..2]);
                 stack.push(formula.len());
-                formula.push_str(sheets.get(ixti as usize).map_or("#REF", |s| &**s));
+                match sheets.get(ixti as usize) {
+                    Some(sh) => push_sheet_name(sh, &mut formula),
+                    // Not a sheet name but an error marker, so it is not quoted.
+                    None => formula.push_str("#REF"),
+                }
                 formula.push('!');
                 // TODO: check with relative columns
                 formula.push('$');
@@ -1516,7 +1525,11 @@ fn parse_formula(
                 // PtfRefErr3d
                 let ixti = read_u16(&rgce[0..2]);
                 stack.push(formula.len());
-                formula.push_str(sheets.get(ixti as usize).map_or("#REF", |s| &**s));
+                match sheets.get(ixti as usize) {
+                    Some(sh) => push_sheet_name(sh, &mut formula),
+                    // Not a sheet name but an error marker, so it is not quoted.
+                    None => formula.push_str("#REF"),
+                }
                 formula.push('!');
                 formula.push_str("#REF!");
                 rgce = &rgce[6..];
@@ -1525,7 +1538,11 @@ fn parse_formula(
                 // PtgAreaErr3d
                 let ixti = read_u16(&rgce[0..2]);
                 stack.push(formula.len());
-                formula.push_str(sheets.get(ixti as usize).map_or("#REF", |s| &**s));
+                match sheets.get(ixti as usize) {
+                    Some(sh) => push_sheet_name(sh, &mut formula),
+                    // Not a sheet name but an error marker, so it is not quoted.
+                    None => formula.push_str("#REF"),
+                }
                 formula.push('!');
                 formula.push_str("#REF!");
                 rgce = &rgce[10..];

--- a/src/xlsb/mod.rs
+++ b/src/xlsb/mod.rs
@@ -23,8 +23,8 @@ use crate::attrs::{decode_attr, RawAttributes};
 use crate::datatype::DataRef;
 use crate::formats::{builtin_format_by_code, detect_custom_number_format, CellFormat};
 use crate::utils::{
-    build_zip_path_cache, cached_zip_path, push_column, read_f64, read_i32, read_u16, read_u32,
-    read_usize,
+    build_zip_path_cache, cached_zip_path, push_column, push_sheet_name, read_f64, read_i32,
+    read_u16, read_u32, read_usize,
 };
 use crate::vba::VbaProject;
 use crate::{
@@ -749,7 +749,7 @@ fn parse_formula(
                 // PtgRef3d
                 let ixti = read_u16(&rgce[0..2]);
                 stack.push(formula.len());
-                formula.push_str(&sheets[ixti as usize]);
+                push_sheet_name(&sheets[ixti as usize], &mut formula);
                 formula.push('!');
                 // TODO: check with relative columns
                 formula.push('$');
@@ -762,7 +762,7 @@ fn parse_formula(
                 // PtgArea3d
                 let ixti = read_u16(&rgce[0..2]);
                 stack.push(formula.len());
-                formula.push_str(&sheets[ixti as usize]);
+                push_sheet_name(&sheets[ixti as usize], &mut formula);
                 formula.push('!');
                 // TODO: check with relative columns
                 formula.push('$');
@@ -780,7 +780,7 @@ fn parse_formula(
                 // PtfRefErr3d
                 let ixti = read_u16(&rgce[0..2]);
                 stack.push(formula.len());
-                formula.push_str(&sheets[ixti as usize]);
+                push_sheet_name(&sheets[ixti as usize], &mut formula);
                 formula.push('!');
                 formula.push_str("#REF!");
                 rgce = &rgce[8..];
@@ -789,7 +789,7 @@ fn parse_formula(
                 // PtgAreaErr3d
                 let ixti = read_u16(&rgce[0..2]);
                 stack.push(formula.len());
-                formula.push_str(&sheets[ixti as usize]);
+                push_sheet_name(&sheets[ixti as usize], &mut formula);
                 formula.push('!');
                 formula.push_str("#REF!");
                 rgce = &rgce[14..];

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -3671,3 +3671,33 @@ fn xls_embedded_cross_sheet_chart_does_not_leak_cells() {
         Some(&Data::String("VALUE C6".to_string()))
     );
 }
+
+#[test]
+fn sheet_name_with_a_space_is_quoted_in_a_formula() {
+    // A sheet name that is not a plain identifier must be quoted, or the `!`
+    // runs straight into the last word: `EIM New Deals!AK$12` parses as a
+    // reference to a sheet called `Deals`, and a workbook that also has a
+    // sheet by that name has its dependency attributed to the wrong one with
+    // nothing to see.
+    let mut excel: Xls<_> = wb("OOM_alloc.xls");
+    let formula = excel.worksheet_formula("Data").unwrap();
+    let referencing: Vec<&str> = formula
+        .used_cells()
+        .filter(|(_, _, f)| f.contains("New Deals"))
+        .map(|(_, _, f)| f.as_str())
+        .collect();
+    assert!(
+        !referencing.is_empty(),
+        "fixture should reference the sheet with a space in its name"
+    );
+    assert_eq!(
+        referencing[0],
+        "+'EIM New Deals'!AK$12+'EIM New Deals'!$AO12+'EIM New Deals'!AK$28+'EIM New Deals'!$AO28"
+    );
+    for f in &referencing {
+        assert!(
+            !f.contains("EIM New Deals!"),
+            "unquoted sheet name in {f:?}"
+        );
+    }
+}


### PR DESCRIPTION
A sheet name that is not a plain identifier must be quoted inside a formula: `'EIM New Deals'!AK12`. Both binary readers concatenate the name bare, so the decoded formula text is `EIM New Deals!AK12` — text Excel would reject, and which parses as a reference to a sheet called `Deals`.

Four sites in `src/xlsb/mod.rs` (`PtgRef3d`, `PtgArea3d`, `PtgRefErr3d`, `PtgAreaErr3d`) and the same four in `src/xls.rs`:

```rust
formula.push_str(&sheets[ixti as usize]);
formula.push('!');
```

### Why it can be worse than a broken reference

Usually the trailing fragment names no sheet, so the reference is simply broken — bad, but visible. The case that worries me is a workbook with sheets `Q3 SALES` **and** `SALES`, which is an entirely ordinary pair. Every reference to the first is then silently attributed to the second: no error, no empty value, no count out of place. Just a dependency pointing at the wrong sheet.

### The change

`push_sheet_name` in `utils.rs`, beside the existing `push_column`, quotes when the name is not a plain identifier and doubles any interior apostrophe. It also quotes:

- a name shaped like a cell reference, since `Q1!A1` would otherwise read as cell `Q1` of the current sheet;
- `R` and `C` alone, which collide with R1C1 notation.

The `#REF` marker the readers substitute for a missing sheet is an error marker rather than a name, so it stays unquoted and existing behaviour there is unchanged.

### Testing

`tests/OOM_alloc.xls` already has a sheet called `EIM New Deals` and formulas referring to it, so the `.xls` path is covered end to end. Without the change the test fails with:

```
left:  "+EIM New Deals!AK$12+EIM New Deals!$AO12+..."
right: "+'EIM New Deals'!AK$12+'EIM New Deals'!$AO12+..."
```

**No `.xlsb` fixture exercises this, and I could not author one** — no open-source tool writes XLSB. That path rests on the unit tests for the helper plus the call sites being identical in shape to the `.xls` ones. I would rather say so than imply coverage I do not have.

I found it on a real 170 MB `.xlsb` workbook I cannot share, where 10 of 25 sheet names need quoting and 1,665 references use one.

All 271 tests pass; `cargo fmt --check` and `cargo clippy --all-targets` are clean.

### Disclosure

**This change was written by AI** (Claude, driven by me), as was this description. I have reviewed it and run the tests, but you should weigh it accordingly, and I will not be offended if you would rather not take AI-authored changes.

This is independent of #712 and branches from `master`, so the two can be reviewed or merged in either order.
