### PR TITLE
xlsb: mask the relativity flags out of a reference's column, and read them the right way round

### DIFF
--- a/src/xlsb/mod.rs
+++ b/src/xlsb/mod.rs
@@ -724,6 +724,33 @@ fn wide_str<'a>(buf: &'a [u8], str_len: &mut usize) -> Result<Cow<'a, str>, Xlsb
     Ok(UTF_16LE.decode(s).0)
 }
 
+/// Split an `RgceLoc` column field into its parts.
+///
+/// The low 14 bits are the column — XLSB sheets have 16,384 of them — and the
+/// top two are relativity flags: `0x8000` for the column, `0x4000` for the row.
+/// Reading the field whole is not a display bug but a wrong reference: a
+/// relative column 2 is stored as `0x4002`, which taken as a column index is
+/// 16,386, two past Excel's last and printed as `XFF`.
+fn read_loc_col(field: u16) -> (u32, bool, bool) {
+    (
+        u32::from(field & 0x3FFF),
+        field & 0x8000 == 0x8000,
+        field & 0x4000 == 0x4000,
+    )
+}
+
+/// Append an A1 reference, marking absolute components with `$`.
+fn push_a1(out: &mut String, row: u32, col: u32, row_rel: bool, col_rel: bool) {
+    if !col_rel {
+        out.push('$');
+    }
+    push_column(col, out);
+    if !row_rel {
+        out.push('$');
+    }
+    out.push_str(&format!("{}", row + 1));
+}
+
 /// Formula parsing
 ///
 /// [MS-XLSB 2.2.2]
@@ -751,11 +778,8 @@ fn parse_formula(
                 stack.push(formula.len());
                 formula.push_str(&sheets[ixti as usize]);
                 formula.push('!');
-                // TODO: check with relative columns
-                formula.push('$');
-                push_column(read_u16(&rgce[6..8]) as u32, &mut formula);
-                formula.push('$');
-                formula.push_str(&format!("{}", read_u32(&rgce[2..6]) + 1));
+                let (col, col_rel, row_rel) = read_loc_col(read_u16(&rgce[6..8]));
+                push_a1(&mut formula, read_u32(&rgce[2..6]), col, row_rel, col_rel);
                 rgce = &rgce[8..];
             }
             0x3b | 0x5b | 0x7b => {
@@ -764,16 +788,12 @@ fn parse_formula(
                 stack.push(formula.len());
                 formula.push_str(&sheets[ixti as usize]);
                 formula.push('!');
-                // TODO: check with relative columns
-                formula.push('$');
-                push_column(read_u16(&rgce[10..12]) as u32, &mut formula);
-                formula.push('$');
-                formula.push_str(&format!("{}", read_u32(&rgce[2..6]) + 1));
+                // ixti(2) rwFirst(4) rwLast(4) colFirst(2) colLast(2).
+                let (c1, c1_rel, r1_rel) = read_loc_col(read_u16(&rgce[10..12]));
+                let (c2, c2_rel, r2_rel) = read_loc_col(read_u16(&rgce[12..14]));
+                push_a1(&mut formula, read_u32(&rgce[2..6]), c1, r1_rel, c1_rel);
                 formula.push(':');
-                formula.push('$');
-                push_column(read_u16(&rgce[12..14]) as u32, &mut formula);
-                formula.push('$');
-                formula.push_str(&format!("{}", read_u32(&rgce[6..10]) + 1));
+                push_a1(&mut formula, read_u32(&rgce[6..10]), c2, r2_rel, c2_rel);
                 rgce = &rgce[14..];
             }
             0x3c | 0x5c | 0x7c => {
@@ -970,31 +990,20 @@ fn parse_formula(
                 rgce = &rgce[4..];
             }
             0x24 | 0x44 | 0x64 => {
-                let row = read_u32(rgce) + 1;
-                let col = [rgce[4], rgce[5] & 0x3F];
-                let col = read_u16(&col);
+                // PtgRef
+                let (col, col_rel, row_rel) = read_loc_col(read_u16(&rgce[4..6]));
                 stack.push(formula.len());
-                if rgce[5] & 0x80 != 0x80 {
-                    formula.push('$');
-                }
-                push_column(col as u32, &mut formula);
-                if rgce[5] & 0x40 != 0x40 {
-                    formula.push('$');
-                }
-                formula.push_str(&format!("{row}"));
+                push_a1(&mut formula, read_u32(rgce), col, row_rel, col_rel);
                 rgce = &rgce[6..];
             }
             0x25 | 0x45 | 0x65 => {
+                // PtgArea: rwFirst(4) rwLast(4) colFirst(2) colLast(2).
+                let (c1, c1_rel, r1_rel) = read_loc_col(read_u16(&rgce[8..10]));
+                let (c2, c2_rel, r2_rel) = read_loc_col(read_u16(&rgce[10..12]));
                 stack.push(formula.len());
-                formula.push('$');
-                push_column(read_u16(&rgce[8..10]) as u32, &mut formula);
-                formula.push('$');
-                formula.push_str(&format!("{}", read_u32(&rgce[0..4]) + 1));
+                push_a1(&mut formula, read_u32(&rgce[0..4]), c1, r1_rel, c1_rel);
                 formula.push(':');
-                formula.push('$');
-                push_column(read_u16(&rgce[10..12]) as u32, &mut formula);
-                formula.push('$');
-                formula.push_str(&format!("{}", read_u32(&rgce[4..8]) + 1));
+                push_a1(&mut formula, read_u32(&rgce[4..8]), c2, r2_rel, c2_rel);
                 rgce = &rgce[12..];
             }
             0x2A | 0x4A | 0x6A => {
@@ -1052,4 +1061,100 @@ fn check_for_password_protected<RS: Read + Seek>(reader: &mut RS) -> Result<(), 
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod formula_tests {
+    use super::{parse_formula, read_loc_col};
+
+    /// Build an `RgceLoc` column field: 14 bits of column, two of relativity.
+    fn loc_col(col: u16, row_rel: bool, col_rel: bool) -> u16 {
+        let mut field = col & 0x3FFF;
+        if row_rel {
+            field |= 0x4000;
+        }
+        if col_rel {
+            field |= 0x8000;
+        }
+        field
+    }
+
+    /// Build a `PtgRef` token: `row(4) col(2)`.
+    fn ptg_ref(ptg: u8, row: u32, col: u16, row_rel: bool, col_rel: bool) -> Vec<u8> {
+        let mut v = vec![ptg];
+        v.extend_from_slice(&row.to_le_bytes());
+        v.extend_from_slice(&loc_col(col, row_rel, col_rel).to_le_bytes());
+        v
+    }
+
+    /// Build a `PtgArea` token: `rwFirst(4) rwLast(4) colFirst(2) colLast(2)`.
+    fn ptg_area(ptg: u8, first: (u32, u16), last: (u32, u16), rel: bool) -> Vec<u8> {
+        let mut v = vec![ptg];
+        v.extend_from_slice(&first.0.to_le_bytes());
+        v.extend_from_slice(&last.0.to_le_bytes());
+        v.extend_from_slice(&loc_col(first.1, rel, rel).to_le_bytes());
+        v.extend_from_slice(&loc_col(last.1, rel, rel).to_le_bytes());
+        v
+    }
+
+    #[test]
+    fn a_relative_flag_is_never_read_as_part_of_the_column() {
+        // The whole defect in one assertion: column 2 marked relative is
+        // stored as 0x4002, and taken whole that is 16,386 — two past Excel's
+        // last column, printed as `XFF`.
+        assert_eq!(read_loc_col(0x4002), (2, false, true));
+        assert_eq!(read_loc_col(0xC003), (3, true, true));
+        assert_eq!(read_loc_col(0x3FFF), (16383, false, false));
+    }
+
+    #[test]
+    fn ptg_ref_marks_each_component_by_its_own_flag() {
+        let cases = [
+            (true, true, "C2"),
+            (false, false, "$C$2"),
+            (true, false, "$C2"),
+            (false, true, "C$2"),
+        ];
+        for (row_rel, col_rel, want) in cases {
+            let rgce = ptg_ref(0x44, 1, 2, row_rel, col_rel);
+            assert_eq!(parse_formula(&rgce, &[], &[]).unwrap(), want);
+        }
+    }
+
+    #[test]
+    fn ptg_area_reads_both_corners_within_the_sheet() {
+        // `D4:H4`, which before the fix decoded as `$BTRO$4:$BTRT$4` — columns
+        // three times the width of a worksheet.
+        let rgce = ptg_area(0x45, (3, 3), (3, 7), true);
+        assert_eq!(parse_formula(&rgce, &[], &[]).unwrap(), "D4:H4");
+
+        let rgce = ptg_area(0x45, (0, 0), (1048575, 16383), false);
+        assert_eq!(
+            parse_formula(&rgce, &[], &[]).unwrap(),
+            "$A$1:$XFD$1048576",
+            "the last cell of a worksheet is still inside it"
+        );
+    }
+
+    #[test]
+    fn a_three_d_reference_keeps_its_sheet_and_its_column() {
+        let sheets = ["Summary".to_string(), "Data".to_string()];
+
+        // PtgRef3d: ixti(2) rw(4) col(2).
+        let mut rgce = vec![0x5A, 0x00, 0x00];
+        rgce.extend_from_slice(&24u32.to_le_bytes());
+        rgce.extend_from_slice(&loc_col(3, true, true).to_le_bytes());
+        assert_eq!(parse_formula(&rgce, &sheets, &[]).unwrap(), "Summary!D25");
+
+        // PtgArea3d: ixti(2) rwFirst(4) rwLast(4) colFirst(2) colLast(2).
+        let mut rgce = vec![0x5B, 0x01, 0x00];
+        rgce.extend_from_slice(&0u32.to_le_bytes());
+        rgce.extend_from_slice(&1048575u32.to_le_bytes());
+        rgce.extend_from_slice(&loc_col(2, false, false).to_le_bytes());
+        rgce.extend_from_slice(&loc_col(9, false, false).to_le_bytes());
+        assert_eq!(
+            parse_formula(&rgce, &sheets, &[]).unwrap(),
+            "Data!$C$1:$J$1048576"
+        );
+    }
 }

--- a/src/xlsb/mod.rs
+++ b/src/xlsb/mod.rs
@@ -727,15 +727,18 @@ fn wide_str<'a>(buf: &'a [u8], str_len: &mut usize) -> Result<Cow<'a, str>, Xlsb
 /// Split an `RgceLoc` column field into its parts.
 ///
 /// The low 14 bits are the column — XLSB sheets have 16,384 of them — and the
-/// top two are relativity flags: `0x8000` for the column, `0x4000` for the row.
+/// top two are relativity flags. MS-XLSB orders them column-first: `0x4000`
+/// marks the column relative and `0x8000` the row, which is the reverse of the
+/// BIFF8 layout the `.xls` reader uses. Same two bits, different format.
+///
 /// Reading the field whole is not a display bug but a wrong reference: a
 /// relative column 2 is stored as `0x4002`, which taken as a column index is
 /// 16,386, two past Excel's last and printed as `XFF`.
 fn read_loc_col(field: u16) -> (u32, bool, bool) {
     (
         u32::from(field & 0x3FFF),
-        field & 0x8000 == 0x8000,
         field & 0x4000 == 0x4000,
+        field & 0x8000 == 0x8000,
     )
 }
 
@@ -1070,10 +1073,10 @@ mod formula_tests {
     /// Build an `RgceLoc` column field: 14 bits of column, two of relativity.
     fn loc_col(col: u16, row_rel: bool, col_rel: bool) -> u16 {
         let mut field = col & 0x3FFF;
-        if row_rel {
+        if col_rel {
             field |= 0x4000;
         }
-        if col_rel {
+        if row_rel {
             field |= 0x8000;
         }
         field
@@ -1102,7 +1105,8 @@ mod formula_tests {
         // The whole defect in one assertion: column 2 marked relative is
         // stored as 0x4002, and taken whole that is 16,386 — two past Excel's
         // last column, printed as `XFF`.
-        assert_eq!(read_loc_col(0x4002), (2, false, true));
+        assert_eq!(read_loc_col(0x4002), (2, true, false));
+        assert_eq!(read_loc_col(0x8002), (2, false, true));
         assert_eq!(read_loc_col(0xC003), (3, true, true));
         assert_eq!(read_loc_col(0x3FFF), (16383, false, false));
     }


### PR DESCRIPTION
> **Disclosure: this pull request was written by an AI agent** (Claude, via Claude
> Code), including the code, the tests and this description. I directed and
> reviewed the work, and I have run the tests and checks reported below, but I
> did not hand-write the patch. I am raising it because the underlying bug is
> real and reproducible, and the evidence is checkable independently of who or
> what wrote it. **If you do not accept AI-generated contributions, please close
> this** — no hard feelings, and I would be glad to file it as an issue with the
> findings instead so someone else can pick it up.

## Summary

An `RgceLoc` column field is 14 bits of column and two bits of relativity. Both
halves of that sentence were being read wrongly, and this branch fixes them in
that order, one commit each:

1. **The flags are read as part of the column.** `PtgArea`, `PtgRef3d` and
   `PtgArea3d` read the field whole, so a relative column comes back as a
   column index far past `XFD`.
2. **Once masked off, the two flags turn out to be swapped.** MS-XLSB orders
   the field column-first, so `0x4000` marks the *column* relative and `0x8000`
   the *row* — the reverse of the BIFF8 layout the `.xls` reader documents.
   Same two bits, different format.

Independent of #712 and #713; branched from `master`, and touches code neither
of those goes near.

## 1. The flags are read as part of the column

`PtgRef` masks them off. The other three read the field whole and print both
components as absolute, under a `// TODO: check with relative columns`:

```rust
formula.push('$');
push_column(read_u16(&rgce[10..12]) as u32, &mut formula);
```

A relative column 2 is stored as `0x4002`, which taken as a column index is
16,386 — two past `XFD`, the last column a worksheet has — and `push_column`
renders it as a four-letter column no formula can name:

| Decoded | Actually |
|---|---|
| `=SUM($BTRO$4:$BTRT$4)` | `=SUM(C4:H4)` |
| `=SHEET_A!$BTRO$25` | `=SHEET_A!C25` |
| `=VLOOKUP(B2,SHEET_B!$XFF$1:$XFM$1048576,5,0)` | `=VLOOKUP(B2,SHEET_B!$B1:$I1048576,5,0)` |

The first is a row total in column `I` over the six columns to its left, which
is how you know the mask is right and not merely in range.

Nothing fails when this happens. A formula that is displayed still looks like a
formula; only something that *reads* the reference finds it points nowhere. On
the workbook I found it on, **855,637 of 6,793,166 formulas — 12.6% — named a
column that cannot exist**, and it had survived every layer that parses
formulas without evaluating them.

## 2. The two flags are the wrong way round

Masking them off leaves the question of what they mean. For `PtgRef`, `PtgArea`
and the 3-D forms, getting it wrong only misplaces the `$` signs — an absolute
and a relative reference still name the same cell. For `PtgRefN` and `PtgAreaN`
it decides whether the stored number is an index or an offset from the cell
being evaluated, so it changes **which cell is read**, and those are the tokens
every filled-down formula is built from.

A concrete token, from the second operand of a cell at (row 4, col 35):

```
field = 0x8021, raw_row = 0, anchor = (row 4, col 35)
```

Read as the reader had it — column relative, row absolute — that is column
35 + 33 = `BQ`, row 1, giving `=V5*BQ$1`. `BQ1` holds 159.49, so the product is
93,958. Excel stored 295.87.

Read the other way — column absolute, row relative — it is column 33, row
4 + 0, giving `=V5*$AH5`. `AH5` holds 0.502222 and the product is
295.86915555555555: the stored value to the last digit. Four sibling cells
decode the same way and match their stored values exactly, and the row below
stores 0, which only the relative row explains.

## The fix

One `read_loc_col` splits the field, so a single place knows the layout, and
each component is marked `$` by its own flag through `push_a1`. `PtgRef` is
routed through both — a refactor, not a change: its masking and its flag
reading already agreed, and `formula_xlsb` covers it, `issues.xlsb` decoding to
`B1+OneRange` before and after.

## On test coverage, honestly

**No fixture in either repository discriminates the two flag readings**, and I
could not author one — no open-source tool writes XLSB. A fixture would need a
reference that is absolute in one axis and relative in the other, and none has
one. That is also *why* this survived: `B1+OneRange` is relative in both axes,
and both readings agree on it.

The branch adds unit tests for the field split, for each of the four `$`
combinations, for both corners of an area and for the two 3-D forms. The
end-to-end evidence is a 170 MB `.xlsb` workbook I cannot share, so I have
given the arithmetic above instead — it is checkable on its own terms.

I would much rather say this than imply coverage I do not have. If you can
supply or generate a `.xlsb` with a mixed-relativity reference, I will add it.

## What it changed

Recomputing every formula in that workbook and comparing with the value Excel
had cached:

| | Before | After part 1 | After part 2 |
|---|---|---|---|
| Agreed with the stored value | 71.9% | 83.8% | **97.6%** |
| Disagreed | 13.8% | 14.5% | **0.7%** |
| Not recomputable | 14.3% | 1.7% | **1.7%** |
| Failed to parse | 855,637 | 0 | **0** |

The middle column is worth reading twice: masking the flags off *raised* the
disagreement count, because 855,637 formulas that had been unreadable became
readable and then, being read with the flags reversed, wrong. A fix that makes
a number worse is not always the wrong fix — it can be one that stops hiding
the next defect.

All 273 tests pass; `cargo fmt --check` and `cargo clippy --all-targets` are
clean.
