### PR TITLE
xlsb: read a formula cell whose cached value is an error

### DIFF
--- a/src/xlsb/cells_reader.rs
+++ b/src/xlsb/cells_reader.rs
@@ -117,7 +117,10 @@ where
                         format_excel_f64_ref(v, cell_format(self.formats, &self.buf), self.is_1904)
                     }
                 }
-                0x0003 => {
+                0x0003 | 0x000B => {
+                    // BrtCellError, and BrtFmlaError — a formula whose cached
+                    // value is an error. The two records differ in what follows
+                    // the error byte, and nothing here reads past it.
                     let error = match self.buf[8] {
                         0x00 => CellErrorType::Null,
                         0x07 => CellErrorType::Div0,
@@ -129,7 +132,6 @@ where
                         0x2B => CellErrorType::GettingData,
                         c => return Err(XlsbError::CellError(c)),
                     };
-                    // BrtCellError
                     DataRef::Error(error)
                 }
                 0x0004 | 0x000A => DataRef::Bool(self.buf[8] != 0), // BrtCellBool or BrtFmlaBool


### PR DESCRIPTION
> **Disclosure: this pull request was written by an AI agent** (Claude, via Claude
> Code), including the code, the tests and this description. I directed and
> reviewed the work, and I have run the tests and checks reported below, but I
> did not hand-write the patch. I am raising it because the underlying bug is
> real and reproducible, and the evidence is checkable independently of who or
> what wrote it. **If you do not accept AI-generated contributions, please close
> this** — no hard feelings, and I would be glad to file it as an issue with the
> findings instead so someone else can pick it up.

## Summary

`next_cell` pairs each literal cell record with its formula counterpart:
`BrtCellBool` with `BrtFmlaBool`, `BrtCellReal` with `BrtFmlaNum`, `BrtCellSt`
with `BrtFmlaString`. `BrtCellError` (`0x0003`) has no such pair, so
`BrtFmlaError` (`0x000B`) falls through the match's catch-all and the record is
skipped:

```rust
0x0004 | 0x000A => DataRef::Bool(self.buf[8] != 0), // BrtCellBool or BrtFmlaBool
0x0005 | 0x0009 => { .. }                           // BrtCellReal or BrtFmlaNum
0x0006 | 0x0008 => { .. }                           // BrtCellSt or BrtFmlaString
0x0003 => { .. }                                    // BrtCellError, alone
```

## Why it matters

The cell is not merely valueless, it is **absent**. `worksheet_range` has no
entry for it and `used_cells` never yields it, so nothing distinguishes it from
a blank cell. Meanwhile `worksheet_formula` still returns its formula — so the
same coordinate exists in one range and not the other, which is a surprising
thing for a caller to have to defend against.

And this is an ordinary cell, not an exotic one. Any `VLOOKUP` that misses
stores `#N/A`, so a workbook that looks things up has thousands: **48,006** on
the workbook I found it on, every one of them reading back as blank.

## The fix

`0x000B` joins the `0x0003` arm. The error byte sits at the same offset in both
records — `next_formula_record` already reads the two together for that reason
— and nothing in that arm reads past it. One line, plus the comment.

## On test coverage, honestly

**No fixture exercises this and I could not author one**, for the usual reason:
no open-source tool writes XLSB. Verified against a 170 MB `.xlsb` workbook I
cannot share, where a `VLOOKUP` column returning `#N/A` came back blank before
this change and comes back `#N/A` after it. Recomputing every formula in that
workbook and comparing against the cached values, agreement went from 97.6% to
**98.3%**.

I would rather state that plainly than imply coverage I do not have. If you can
supply or generate a `.xlsb` containing a formula cell with a cached error, I
will add it as a fixture test.

Independent of #712, #713 and my other branches; branched from `master`.

All 269 tests pass; `cargo fmt --check` and `cargo clippy --all-targets` are
clean.
