### PR TITLE
xlsb: don't name a sheet of this workbook for a reference into another

### DIFF
--- a/src/xlsb/mod.rs
+++ b/src/xlsb/mod.rs
@@ -150,10 +150,24 @@ struct XlsbOptions {
     pub header_row: HeaderRow,
 }
 
+/// One entry of a workbook's supporting-book table.
+///
+/// Only the distinction matters here: an `Xti` gives a sheet index, and that
+/// index means a sheet of *this* workbook or of another one depending on which
+/// supporting book it names.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SupBook {
+    SelfBook,
+    Other,
+}
+
 /// A Xlsb reader
 pub struct Xlsb<RS> {
     zip: ZipArchive<RS>,
     extern_sheets: Vec<String>,
+    /// Supporting books in the order they are declared, so that an `Xti` naming
+    /// one by position can be told from this workbook.
+    supbooks: Vec<SupBook>,
     sheets: Vec<(String, String)>,
     strings: Vec<String>,
     /// Cell (number) formats
@@ -354,6 +368,19 @@ impl<RS: Read + Seek> Xlsb<RS> {
         loop {
             let typ = iter.read_type()?;
             match typ {
+                // A supporting book. They appear in order before BrtExternSheet
+                // and an `Xti` names one by position, so all that is needed
+                // here is which position is this workbook itself.
+                0x0163 => {
+                    // BrtSupBookSrc: another workbook, named by a relationship.
+                    let _ = iter.fill_buffer(&mut buf)?;
+                    self.supbooks.push(SupBook::Other);
+                }
+                0x0165 => {
+                    // BrtSupSelf: this workbook.
+                    let _ = iter.fill_buffer(&mut buf)?;
+                    self.supbooks.push(SupBook::SelfBook);
+                }
                 0x016A => {
                     // BrtExternSheet
                     let _len = iter.fill_buffer(&mut buf)?;
@@ -362,16 +389,19 @@ impl<RS: Read + Seek> Xlsb<RS> {
                         self.extern_sheets.reserve(cxti);
                     }
                     let sheets = &self.sheets;
+                    let this_book = self
+                        .supbooks
+                        .iter()
+                        .position(|b| matches!(b, SupBook::SelfBook));
                     let extern_sheets = buf[4..]
                         .chunks(12)
                         .map(|xti| {
-                            match read_i32(&xti[4..8]) {
-                                -2 => "#ThisWorkbook",
-                                -1 => "#InvalidWorkSheet",
-                                p if p >= 0 && (p as usize) < sheets.len() => &sheets[p as usize].0,
-                                _ => "#Unknown",
-                            }
-                            .to_string()
+                            xti_sheet(
+                                read_i32(&xti[0..4]),
+                                read_i32(&xti[4..8]),
+                                this_book,
+                                sheets,
+                            )
                         })
                         .take(cxti)
                         .collect();
@@ -480,6 +510,7 @@ impl<RS: Read + Seek> Reader<RS> for Xlsb<RS> {
             sheets: Vec::new(),
             strings: Vec::new(),
             extern_sheets: Vec::new(),
+            supbooks: Vec::new(),
             formats: Vec::new(),
             is_1904: false,
             metadata: Metadata::default(),
@@ -722,6 +753,32 @@ fn wide_str<'a>(buf: &'a [u8], str_len: &mut usize) -> Result<Cow<'a, str>, Xlsb
     *str_len = 4 + len * 2;
     let s = &buf[4..*str_len];
     Ok(UTF_16LE.decode(s).0)
+}
+
+/// Name the sheet an `Xti` points at.
+///
+/// `book` indexes the workbook's supporting books and `tab` indexes the sheets
+/// *of that book*, so a tab index means one of `sheets` only when the reference
+/// is into this workbook. Resolving one that is not would name a real sheet of
+/// ours and record a real dependency, on the wrong sheet — a workbook linking
+/// to last year's copy of itself has every sheet index land somewhere
+/// plausible.
+///
+/// `this_book` is the position of the `BrtSupSelf` record, or `None` for a
+/// workbook that declares no supporting books at all, where every reference is
+/// necessarily local.
+fn xti_sheet(book: i32, tab: i32, this_book: Option<usize>, sheets: &[(String, String)]) -> String {
+    let is_this_book = this_book.is_none_or(|i| book == i as i32);
+    match tab {
+        -2 => "#ThisWorkbook".to_string(),
+        -1 => "#InvalidWorkSheet".to_string(),
+        p if is_this_book && p >= 0 && (p as usize) < sheets.len() => sheets[p as usize].0.clone(),
+        // Written the way an external reference is written, so a reader can
+        // tell that it is one. The sheet's own name lives in the other
+        // workbook, which is not open.
+        p if !is_this_book && p >= 0 => format!("[{book}]#Sheet{}", p + 1),
+        _ => "#Unknown".to_string(),
+    }
 }
 
 /// Formula parsing
@@ -1052,4 +1109,50 @@ fn check_for_password_protected<RS: Read + Seek>(reader: &mut RS) -> Result<(), 
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod xti_tests {
+    use super::xti_sheet;
+
+    fn sheets() -> Vec<(String, String)> {
+        ["Summary", "Data", "Rates"]
+            .iter()
+            .map(|n| (n.to_string(), String::new()))
+            .collect()
+    }
+
+    #[test]
+    fn a_tab_of_this_workbook_is_named() {
+        assert_eq!(xti_sheet(0, 1, Some(0), &sheets()), "Data");
+        // The self record need not come first.
+        assert_eq!(xti_sheet(2, 2, Some(2), &sheets()), "Rates");
+    }
+
+    #[test]
+    fn a_tab_of_another_workbook_is_never_named_from_ours() {
+        // The defect in one assertion: supporting book 1, sheet 2 of *that*
+        // book. Resolved against our sheets it is `Rates`, which exists, is
+        // wrong, and looks like every other dependency in the graph.
+        assert_eq!(xti_sheet(1, 2, Some(0), &sheets()), "[1]#Sheet3");
+        assert_eq!(xti_sheet(3, 25, Some(0), &sheets()), "[3]#Sheet26");
+    }
+
+    #[test]
+    fn the_sentinels_outrank_the_book() {
+        assert_eq!(xti_sheet(0, -2, Some(0), &sheets()), "#ThisWorkbook");
+        assert_eq!(xti_sheet(1, -1, Some(0), &sheets()), "#InvalidWorkSheet");
+    }
+
+    #[test]
+    fn a_tab_past_our_last_sheet_is_still_unknown() {
+        assert_eq!(xti_sheet(0, 9, Some(0), &sheets()), "#Unknown");
+    }
+
+    #[test]
+    fn a_workbook_with_no_supporting_books_resolves_everything_locally() {
+        // Nothing declares a self record, so there is nothing to be external
+        // to, and the old behaviour is the right one.
+        assert_eq!(xti_sheet(0, 1, None, &sheets()), "Data");
+    }
 }


### PR DESCRIPTION
> **Disclosure: this pull request was written by an AI agent** (Claude, via Claude
> Code), including the code, the tests and this description. I directed and
> reviewed the work, and I have run the tests and checks reported below, but I
> did not hand-write the patch. I am raising it because the underlying bug is
> real and reproducible, and the evidence is checkable independently of who or
> what wrote it. **If you do not accept AI-generated contributions, please close
> this** — no hard feelings, and I would be glad to file it as an issue with the
> findings instead so someone else can pick it up.

## Summary

An `Xti` carries two indices: a supporting book, and a tab within *that* book.
`BrtExternSheet` used only the second, resolving it against the sheets of the
workbook being read:

```rust
match read_i32(&xti[4..8]) {
    -2 => "#ThisWorkbook",
    -1 => "#InvalidWorkSheet",
    p if p >= 0 && (p as usize) < sheets.len() => &sheets[p as usize].0,
    _ => "#Unknown",
}
```

## Why it matters

For a workbook that links to another one — last year's copy of itself, most
commonly — this names a real sheet of *ours*, records a real dependency, and
points it at the wrong place. **Nothing about the result looks wrong.** The
reference reads `SHEET_A!$D$21`, `SHEET_A` exists in this workbook, and `$D$21`
is a cell on it. A caller has no way to tell that the formula was never talking
about this workbook at all.

On the workbook I found it on, the externals block declares four supporting
books — `BrtSupSelf` (`0x0165`) first, then three `BrtSupBookSrc` (`0x0163`) —
and its 18 `Xti` entries name them:

| ixti | supbook | tab | resolved to | actually |
|---|---|---|---|---|
| 2 | 1 | 5 | `SHEET_A` | sheet 6 of another workbook |
| 6 | 2 | 12 | `SHEET_B` | sheet 13 of another workbook |
| 16 | 3 | 26 | `#Unknown` | sheet 27 of another workbook |

Twelve formulas used them. Ten disagreed with the value Excel had stored; two
agreed by coincidence, the local cell happening to hold the same number as the
foreign one — which is the case that would never have been found by looking.

## The evidence is arithmetic, not documentary

One of those formulas reads

```
=IF($B2="ACTIVE",SHEET_A!$D$21,SHEET_A!$D$22)
```

and Excel stored `2`. `SHEET_A` is 13 rows long, so `$D$21` is empty and the
formula could not have produced `2` from it. `SHEET_C!D21:D24` — the sheet the
*self*-book `Xti` at index 3 names — holds `2, 0, 2, 1`, which is exactly what
all six formulas of that family stored. The supporting books are copies of this
workbook, and the sheet in question sits at a different tab index in them.

(Sheet names are pseudonymised; the workbook is confidential. The arithmetic is
unaffected.)

## The fix

Supporting books are tracked in declaration order, and a tab index resolves
against our sheets only when the `Xti` actually names ours. A reference into
another book is written `[1]#Sheet3` — the shape an external reference already
has in this codebase — because the sheet's own name lives in that workbook and
it is not open. A workbook that declares no supporting books keeps the old
behaviour, every reference being local. The two sentinels still outrank the
book index.

`xti_sheet` is a free function with unit tests for each case.

## On test coverage, honestly

**No fixture has an external link and I could not author one**, for the usual
reason: no open-source tool writes XLSB. The end-to-end evidence is the
workbook above, which I cannot share — hence the arithmetic, which stands on
its own.

After this change, recomputing every formula in that workbook left **zero**
disagreements out of 6,677,397 evaluable formulas, down from 11. What remains
unevaluated there is two unimplemented functions and the 12 references into
workbooks that are not open — honest gaps, no decoding failures.

If you can supply or generate a `.xlsb` with an external link, I will add it.

Independent of #712, #713 and my other branches; branched from `master`.

All 274 tests pass; `cargo fmt --check` and `cargo clippy --all-targets` are
clean.
