### PR TITLE
xlsx: subtract the totals row count, not the header row count, from a table's range — and expose both

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,10 @@ env_logger = "0.11"
 serde_derive = "1.0"
 rstest = { version = "0.26", default-features = false }
 criterion = { version = "0.7", features = ["html_reports"] }
+# For authoring a headerless/totals-row table fixture on the fly: no
+# open-source tool writes XLSB, but XLSX table XML is plain OOXML, and this
+# writer supports `set_header_row(false)`/`set_total_row(true)` directly.
+rust_xlsxwriter = "0.91"
 
 [[bench]]
 name = "basic"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1908,6 +1908,12 @@ pub struct Table<T> {
     pub(crate) sheet_name: String,
     pub(crate) columns: Vec<String>,
     pub(crate) data: Range<T>,
+    /// The table's own `headerRowCount`, as declared in its XML (0 or 1 in
+    /// every workbook Excel's UI can produce — "My table has headers"
+    /// unchecked is 0).
+    pub(crate) header_row_count: u32,
+    /// The table's own `totalsRowCount`, as declared in its XML.
+    pub(crate) totals_row_count: u32,
 }
 impl<T> Table<T> {
     /// Get the name of the table.
@@ -2062,6 +2068,51 @@ impl<T> Table<T> {
     ///
     pub fn data(&self) -> &Range<T> {
         &self.data
+    }
+
+    /// Whether the table declares a header row.
+    ///
+    /// Excel always writes `tableColumn` names, even for a table created with
+    /// "My table has headers" unchecked (it auto-names them `Column1`,
+    /// `Column2`, …), so a non-empty [`Table::columns`] is not the same
+    /// question — this is `headerRowCount != 0`, the table's own declaration.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use calamine::{open_workbook, Error, Xlsx};
+    ///
+    /// fn main() -> Result<(), Error> {
+    ///     let path = format!("{}/tests/inventory-table.xlsx", env!("CARGO_MANIFEST_DIR"));
+    ///     let mut workbook: Xlsx<_> = open_workbook(path)?;
+    ///     workbook.load_tables()?;
+    ///     let table = workbook.table_by_name("Table1")?;
+    ///     assert!(table.has_header_row());
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn has_header_row(&self) -> bool {
+        self.header_row_count != 0
+    }
+
+    /// Whether the table declares a totals row.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use calamine::{open_workbook, Error, Xlsx};
+    ///
+    /// fn main() -> Result<(), Error> {
+    ///     let path = format!("{}/tests/inventory-table.xlsx", env!("CARGO_MANIFEST_DIR"));
+    ///     let mut workbook: Xlsx<_> = open_workbook(path)?;
+    ///     workbook.load_tables()?;
+    ///     let table = workbook.table_by_name("Table1")?;
+    ///     assert!(!table.has_totals_row());
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn has_totals_row(&self) -> bool {
+        self.totals_row_count != 0
     }
 }
 

--- a/src/xlsx/mod.rs
+++ b/src/xlsx/mod.rs
@@ -245,7 +245,8 @@ impl FromStr for CellErrorType {
     }
 }
 
-type Tables = Option<Vec<(String, String, Vec<String>, Dimensions)>>;
+/// Name, sheet name, column names, dimensions, `headerRowCount`, `totalsRowCount`.
+type Tables = Option<Vec<(String, String, Vec<String>, Dimensions, u32, u32)>>;
 
 /// A struct representing xml zipped excel file
 /// Xlsx, Xlsm, Xlam
@@ -687,7 +688,7 @@ impl<RS: Read + Seek> Xlsx<RS> {
                     dims.start.0 += table_meta.header_row_count;
                 }
                 if table_meta.totals_row_count != 0 {
-                    dims.end.0 -= table_meta.header_row_count;
+                    dims.end.0 -= table_meta.totals_row_count;
                 }
 
                 new_tables.push((
@@ -695,6 +696,8 @@ impl<RS: Read + Seek> Xlsx<RS> {
                     sheet_name.clone(),
                     column_names,
                     dims,
+                    table_meta.header_row_count,
+                    table_meta.totals_row_count,
                 ));
             }
         }
@@ -1282,12 +1285,16 @@ impl<RS: Read + Seek> Xlsx<RS> {
             start: match_table_meta.3.start,
             end: match_table_meta.3.end,
         };
+        let header_row_count = match_table_meta.4;
+        let totals_row_count = match_table_meta.5;
 
         Ok(TableMetadata {
             name,
             sheet_name,
             columns,
             dimensions,
+            header_row_count,
+            totals_row_count,
         })
     }
 
@@ -1686,6 +1693,8 @@ impl<RS: Read + Seek> Xlsx<RS> {
             sheet_name,
             columns,
             dimensions,
+            header_row_count,
+            totals_row_count,
         } = self.get_table_meta(table_name)?;
         let Dimensions { start, end } = dimensions;
         let range = self.worksheet_range(&sheet_name)?;
@@ -1696,6 +1705,8 @@ impl<RS: Read + Seek> Xlsx<RS> {
             sheet_name,
             columns,
             data: tbl_rng,
+            header_row_count,
+            totals_row_count,
         })
     }
 
@@ -1760,6 +1771,8 @@ impl<RS: Read + Seek> Xlsx<RS> {
             sheet_name,
             columns,
             dimensions,
+            header_row_count,
+            totals_row_count,
         } = self.get_table_meta(table_name)?;
         let Dimensions { start, end } = dimensions;
         let range = self.worksheet_range_ref(&sheet_name)?;
@@ -1770,6 +1783,8 @@ impl<RS: Read + Seek> Xlsx<RS> {
             sheet_name,
             columns,
             data: tbl_rng,
+            header_row_count,
+            totals_row_count,
         })
     }
 
@@ -2497,6 +2512,8 @@ struct TableMetadata {
     sheet_name: String,
     columns: Vec<String>,
     dimensions: Dimensions,
+    header_row_count: u32,
+    totals_row_count: u32,
 }
 
 struct InnerTableMetadata {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -2981,6 +2981,57 @@ fn test_xlsx_table_insertrow_attribute() {
     assert!(result.is_ok(), "Expected table_by_name to succeed");
 }
 
+// A table with `headerRowCount="0"` still declares `tableColumn` elements
+// (Excel auto-names them Column1, Column2, …), so their mere presence cannot
+// tell a caller whether the table actually has a header row — that is what
+// `Table::has_header_row()`/`has_totals_row()` exist to answer honestly.
+//
+// This also exercises the range-shifting fix at the end of `read_tables()`:
+// with a totals row and no header row, the old code subtracted
+// `header_row_count` (0, so nothing happened) instead of `totals_row_count`
+// (1), leaving the fabricated totals row inside `table.data()`.
+#[test]
+fn test_headerless_table_with_totals_row() {
+    use calamine::open_workbook_from_rs;
+    use rust_xlsxwriter::{Table, TableColumn, TableFunction, Workbook};
+
+    let mut workbook = Workbook::new();
+    let worksheet = workbook.add_worksheet();
+    worksheet.write_column(0, 0, [1.0, 2.0, 3.0]).unwrap();
+    worksheet.write_column(0, 1, [10.0, 20.0, 30.0]).unwrap();
+
+    let columns = vec![
+        TableColumn::new(),
+        TableColumn::new().set_total_function(TableFunction::Sum),
+    ];
+    let table = Table::new()
+        .set_name("Headerless")
+        .set_header_row(false)
+        .set_total_row(true)
+        .set_columns(&columns);
+    // Rows 0..=2 are data, row 3 is the totals row Excel adds; no header row.
+    worksheet.add_table(0, 0, 3, 1, &table).unwrap();
+
+    let bytes = workbook.save_to_buffer().unwrap();
+    let mut xlsx: Xlsx<_> = open_workbook_from_rs(Cursor::new(bytes)).unwrap();
+    xlsx.load_tables().unwrap();
+    let table = xlsx
+        .table_by_name("Headerless")
+        .expect("parsing the table should not error");
+
+    assert!(!table.has_header_row(), "headerRowCount was set to 0");
+    assert!(table.has_totals_row(), "totalsRowCount was set to 1");
+
+    let data = table.data();
+    assert_eq!(
+        data.height(),
+        3,
+        "the totals row must not be counted as data"
+    );
+    assert_eq!(data.get((0, 0)), Some(&Float(1.0)));
+    assert_eq!(data.get((2, 0)), Some(&Float(3.0)));
+}
+
 // Test for issue #594: ODS DoS protection via repeat limits.
 // This test verifies that the ODS parser correctly caps malicious repeat values
 // that would otherwise cause memory exhaustion.


### PR DESCRIPTION
> **Disclosure: this pull request was written by an AI agent** (Claude, via Claude
> Code), including the code, the tests and this description. I directed and
> reviewed the work, and I have run the tests and checks reported below, but I
> did not hand-write the patch. I am raising it because the underlying bug is
> real and reproducible, and the evidence is checkable independently of who or
> what wrote it. **If you do not accept AI-generated contributions, please close
> this** — no hard feelings, and I would be glad to file it as an issue with the
> findings instead so someone else can pick it up.

## Summary

Two related problems in `Xlsx::read_tables()` (`src/xlsx/mod.rs`).

**The range bug.** A declared table's `ref` range is shifted to exclude its
header and totals rows before becoming `Table::data()`:

```rust
let mut dims = get_dimension(table_meta.ref_cells.as_bytes())?;
if table_meta.header_row_count != 0 {
    dims.start.0 += table_meta.header_row_count;
}
if table_meta.totals_row_count != 0 {
    dims.end.0 -= table_meta.header_row_count;   // should be totals_row_count
}
```

The `dims.end` line subtracts `header_row_count` instead of
`totals_row_count`.

For the overwhelmingly common shape — one header row, and either no totals row
or one — both counts are small integers that happen to agree, so this passes
every existing test. It surfaces exactly when the two differ: a table with
**no** header row (`headerRowCount="0"`, "My table has headers" unchecked in
Excel) and a totals row (`totalsRowCount="1"`) subtracts 0 instead of 1,
leaving the fabricated totals row inside `data()`. The totals formula then
reads back as if it were one more row of data.

**The missing accessors.** Even computed correctly, neither count reached a
caller. `Table<T>` carried `name`, `sheet_name`, `columns` and `data`, so there
was no way to ask a table whether it actually declares a header row — only
whether `columns()` is non-empty, which is **always** true, because Excel
auto-names an unheaded table's columns (`Column1`, `Column2`, …) rather than
leaving them empty. Downstream, a headerless table's auto-generated column
names get treated as if they were the row above the table.

## The fix

`InnerTableMetadata`'s already-parsed `header_row_count`/`totals_row_count` are
threaded through `Tables`, `TableMetadata`, `table_by_name` and
`table_by_name_ref` into two new fields on `Table<T>`, with public accessors
`Table::has_header_row()` and `Table::has_totals_row()` (`src/lib.rs`)
alongside the existing `name()`/`sheet_name()`/`columns()`/`data()`. The
`dims.end` line now subtracts `totals_row_count`.

## Tests

Unlike my other branches, this one **has** a real regression test, because XLSX
table XML is plain OOXML and can be authored.

No existing fixture has `headerRowCount="0"` or a nonzero `totalsRowCount` — I
checked every `.xlsx` fixture's `xl/tables/*.xml` directly. So
`test_headerless_table_with_totals_row` (`tests/test.rs`) writes one on the fly
with `rust_xlsxwriter` (added as a dev-dependency) rather than needing a
checked-in binary: a headerless three-row table with a totals row, asserting
`!has_header_row()`, `has_totals_row()`, and that `data()` is exactly the three
data rows.

Reverting the `dims.end` line to `header_row_count` fails it — `data.height()`
comes back `4`, with the totals row counted as data.

If you would rather not take a new dev-dependency, say so and I will author the
fixture bytes inline instead.

Independent of #712, #713 and my other branches; branched from `master`.

All 272 tests pass; `cargo fmt --check` and `cargo clippy --all-targets` are
clean.
